### PR TITLE
Change Redis container to use alpine based image

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -88,6 +88,6 @@ services:
         condition: service_healthy
 
   librephotos-redis:
-    image: redis
+    image: redis:alpine
     container_name: librephotos-redis
     restart: always


### PR DESCRIPTION
Changing the Redis Container to use the alpine based version saves ~70mb in image size and has no side effects.

(Also see bottom of page https://hub.docker.com/_/redis)