### PR TITLE
Do not run `manage.py makemigrations` in Docker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,6 @@ service nginx restart
 
 /miniconda/bin/python image_similarity/main.py 2>&1 | tee logs/gunicorn_image_similarity.log &
 /miniconda/bin/python manage.py showmigrations | tee logs/show_migrate.log
-/miniconda/bin/python manage.py makemigrations | tee logs/command_makemigrations.log
 /miniconda/bin/python manage.py migrate | tee logs/command_migrate.log
 /miniconda/bin/python manage.py showmigrations | tee logs/show_migrate.log
 /miniconda/bin/python manage.py build_similarity_index 2>&1 | tee logs/command_build_similarity_index.log


### PR DESCRIPTION
`makemigrations` is a Django command which automatically generates migrations based on changes to the app's models. This command should really be run on developers' machines, and the migrations that it generates checked into source control. It has no business being run in production - if a developer forgot to generate migrations, and code review at PR time (or whatever) didn't catch that mistake, it's better to let the app crash because the database schema wasn't right rather than make permanent changes to the database based on what Django thought should be done, with absolutely no manual human review.

Therefore, stop running this command when launching Docker containers.