### PR TITLE
Updated directory_watcher.py for NextCloud 

### DIFF
--- a/nextcloud/directory_watcher.py
+++ b/nextcloud/directory_watcher.py
@@ -7,7 +7,7 @@ from ownphotos import settings
 import datetime
 import pytz
 import api.util as util
-from api.directory_watcher import handle_new_image, isValidMedia
+from api.directory_watcher import handle_new_image
 from api.image_similarity import build_image_similarity_index
 
 def isValidNCMedia(file_obj):

--- a/nextcloud/directory_watcher.py
+++ b/nextcloud/directory_watcher.py
@@ -10,10 +10,18 @@ import api.util as util
 from api.directory_watcher import handle_new_image, isValidMedia
 from api.image_similarity import build_image_similarity_index
 
+def isValidNCMedia(file_obj):
+    file_attr = file_obj[1].attributes
+    filetype = file_attr.get("{DAV:}getcontenttype","")
+    try:
+        return 'jpeg' in filetype or 'png' in filetype or 'bmp' in filetype or 'gif' in filetype
+    except:
+        util.logger.exception("An image throwed an exception")
+        return False
 
 def collect_photos(nc, path, photos):
     for x in nc.list(path):
-        if not x.is_dir() and isValidMedia(nc.get_file_contents(x.path)):
+        if not x.is_dir() and isValidNCMedia(x):
             photos.append(x.path)
         elif x.is_dir():
             collect_photos(nc, x.path, photos)

--- a/nextcloud/directory_watcher.py
+++ b/nextcloud/directory_watcher.py
@@ -11,7 +11,7 @@ from api.directory_watcher import handle_new_image, isValidMedia
 from api.image_similarity import build_image_similarity_index
 
 def isValidNCMedia(file_obj):
-    file_attr = file_obj[1].attributes
+    file_attr = file_obj.attributes
     filetype = file_attr.get("{DAV:}getcontenttype","")
     try:
         return 'jpeg' in filetype or 'png' in filetype or 'bmp' in filetype or 'gif' in filetype

--- a/nextcloud/directory_watcher.py
+++ b/nextcloud/directory_watcher.py
@@ -14,7 +14,7 @@ def isValidNCMedia(file_obj):
     file_attr = file_obj.attributes
     filetype = file_attr.get("{DAV:}getcontenttype","")
     try:
-        return 'jpeg' in filetype or 'png' in filetype or 'bmp' in filetype or 'gif' in filetype
+        return 'jpeg' in filetype or 'png' in filetype or 'bmp' in filetype or 'gif' in filetype or 'heic' in filetype or 'heif' in filetype
     except:
         util.logger.exception("An image throwed an exception")
         return False


### PR DESCRIPTION
in case of larger directory scans from the NextCloud, downloading whole file just to determine the file type is not optimal for importing lot of data, which is most of the time a case when user starts a new instance of the server.

hence instead of downloading a file and then checking the type of the file, we rely on the file type provided by NextCloud Dav attributes, since NextCloud already identified the file as image, it should not be a problem.