### PR TITLE
Create a manage.py command for creating superusers

### DIFF
--- a/api/management/commands/createadmin.py
+++ b/api/management/commands/createadmin.py
@@ -1,0 +1,51 @@
+import sys
+import os
+from getpass import getpass
+from django.core.management.base import BaseCommand, CommandError
+from django.core.validators import validate_email, ValidationError
+from api.models import User
+
+class Command(BaseCommand):
+    help = 'Create a LibrePhotos user with administrative permissions'
+
+    def add_arguments(self, parser):
+        parser.add_argument('admin_username', help='Username to create')
+        parser.add_argument('admin_email', help='Email address of the new user')
+        parser.add_argument('-u', '--update',
+            help=('Update an existing superuser\'s password (ignoring the'
+                  'provided email) instead of reporting an error'),
+            action='store_true'
+        )
+        # Done this way because command lines are visible to the whole system by
+        #  default on Linux, so a password in the arguments would leak
+        parser.epilog = ('The password is read from the ADMIN_PASSWORD'
+                         'environment variable or interactively if'
+                         'ADMIN_PASSWORD is not set')
+
+    def handle(self, *args, **options):
+        try:
+            validate_email(options['admin_email'])
+        except ValidationError as err:
+            raise CommandError(err.message)
+
+        if 'ADMIN_PASSWORD' in os.environ:
+            options['admin_password'] = os.environ['ADMIN_PASSWORD']
+        else:
+            options['admin_password'] = getpass()
+
+        if not options['admin_password']:
+            raise CommandError('Admin password cannot be empty')
+
+        if not User.objects.filter(username=options['admin_username']).exists():
+            User.objects.create_superuser(
+                options['admin_username'],
+                options['admin_email'],
+                options['admin_password']
+            )
+        elif options['update']:
+            print('Warning: ignoring provided email ' + options['admin_email'], file=sys.stderr)
+            admin_user = User.objects.get(username=options['admin_username'])
+            admin_user.set_password(options['admin_password'])
+            admin_user.save()
+        else:
+            raise CommandError('Specified user already exists')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,16 +17,7 @@ service nginx restart
 /miniconda/bin/python manage.py showmigrations | tee logs/show_migrate.log
 /miniconda/bin/python manage.py build_similarity_index 2>&1 | tee logs/command_build_similarity_index.log
 
-/miniconda/bin/python manage.py shell <<EOF
-from api.models import User
-
-if User.objects.filter(username="$ADMIN_USERNAME").exists():
-    admin_user = User.objects.get(username="$ADMIN_USERNAME")
-    admin_user.set_password("$ADMIN_PASSWORD")
-    admin_user.save()
-else:
-    User.objects.create_superuser('$ADMIN_USERNAME', '$ADMIN_EMAIL', '$ADMIN_PASSWORD')
-EOF
+/miniconda/bin/python manage.py createadmin -u $ADMIN_USERNAME $ADMIN_EMAIL 2>&1 | tee logs/command_createadmin.log
 
 echo "Running backend server..."
 


### PR DESCRIPTION
This basically moves the manual `manage.py shell` code in `entrypoint.sh` into a command usable from the CLI.

Marking as WIP because I still need to test:

* The change to `entrypoint.sh`
* The `epilog` bit of the argument parsing