### PR TITLE
Allow using a Unix socket file to connect to Redis

### DIFF
--- a/ownphotos/settings.py
+++ b/ownphotos/settings.py
@@ -175,7 +175,7 @@ RQ_QUEUES = {
     'default': {
         'USE_REDIS_CACHE': 'default',
         'DEFAULT_TIMEOUT': 360,
-        'DB':0
+        'DB': 0
     }
 }
 

--- a/ownphotos/settings.py
+++ b/ownphotos/settings.py
@@ -156,15 +156,18 @@ DATABASES = {
     },
 }
 
+if 'REDIS_PATH' in os.environ:
+    redis_path = 'unix://' + os.environ['REDIS_PATH']
+    redis_path += '?db=' + os.environ.get('REDIS_DB', '0')
+else:
+    redis_path = "redis://" + os.environ['REDIS_HOST']
+    redis_path += ":" + os.environ["REDIS_PORT"] + "/1"
+
 CACHES = {
     "default": {
-        "BACKEND":
-        "django_redis.cache.RedisCache",
-        "LOCATION":
-        "redis://" + os.environ['REDIS_HOST'] + ":" + os.environ["REDIS_PORT"]
-        + "/1",
-        "TIMEOUT":
-        60 * 60 * 24,
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": redis_path,
+        "TIMEOUT": 60 * 60 * 24,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }


### PR DESCRIPTION
tl;dr: previous behavior is preserved unless `REDIS_PATH` is set in the environment. In that case it's assumed that that's a Unix socket file, and the host and port configuration are ignored.

I guess actually looking at this diff we should probably allow configuring the DB for TCP connections too? I just put that in since it wasn't clear to me whether that was a mandatory part of the connection string or not.

Also includes an unrelated whitespace fix that didn't seem worth opening a separate PR for.