### PR TITLE
Improve .gitignore for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,149 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# LibrePhotos
 densecap/data/models/densecap/densecap-pretrained-vgg16.t7
 */*.pkl
 */*/*.pkl
 thumbnails
 media
 samplephotos
-db.sqlite3
-*/__pycache__
-*/*/__pycache__
-__pycache__
-.DS_Store
 tags
 api/places365/model/
 Conv2d.patch
@@ -18,22 +153,14 @@ BatchNorm2d.patch
 AvgPool2d.patch
 ReLU.patch
 run_docker.sh
-logs/*
+logs/
 playground
 api/im2txt/data/
 api/im2txt/models/
 api/im2txt/png/
 *.ipynb
-.ipynb_checkpoints/
 api/im2txt/*.tar.gz
 api/places365/*.tar.gz
 *.db
 media*
-*.log
 protected_media
-.vscode
-.coverage
-htmlcov
-samplephotos
-nextcloud_media
-docker-compose.yml


### PR DESCRIPTION
This was imported from github/gitignore on GitHub, then merged with the existing entries.

I dropped `.DS_Store` and `.vscode` because those should be configured in developers' global .gitignore files, not individual projects.