### PR TITLE
Add setting for redis password

### DIFF
--- a/ownphotos/settings.py
+++ b/ownphotos/settings.py
@@ -163,6 +163,11 @@ else:
     redis_path = "redis://" + os.environ['REDIS_HOST']
     redis_path += ":" + os.environ["REDIS_PORT"] + "/1"
 
+if 'REDIS_PASS' in os.environ:
+    redis_password = os.environ['REDIS_PASS']
+else:
+    redis_password = ""
+
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
@@ -170,8 +175,7 @@ CACHES = {
         "TIMEOUT": 60 * 60 * 24,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            if 'REDIS_PASS' in os.environ:
-                "PASSWORD": os.environ['REDIS_PASS'],
+            "PASSWORD": redis_password,
         }
     }
 }

--- a/ownphotos/settings.py
+++ b/ownphotos/settings.py
@@ -170,6 +170,8 @@ CACHES = {
         "TIMEOUT": 60 * 60 * 24,
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            if 'REDIS_PASS' in os.environ:
+                "PASSWORD": os.environ['REDIS_PASS'],
         }
     }
 }


### PR DESCRIPTION
This change is for the people who have a separate redis server which needs a password.
I'm only using the front- and backend with docker because I have got dedicated lxd containers for postgres, redis and reverse proxy (caddy).
At the moment I'm mounting a backend-settings.py as ownphotos/settings.py from the host into the backend container.