### PR TITLE
WIP: Remove issue where should_skip returns always False on Python3

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -43,7 +43,6 @@ def should_skip(filepath):
         
     skipPatterns = os.getenv('SKIP_PATTERNS')
     skipList = skipPatterns.split(',')
-    skipList = map(str.strip, skipList)
 
     res = [ele for ele in skipList if(ele in filepath)] 
     return bool(res)


### PR DESCRIPTION
With the map it fails to evaluate on Python3 (works for Python2)