### PR TITLE
fix: check for orientation key in rotate_image

### DIFF
--- a/api/exifreader.py
+++ b/api/exifreader.py
@@ -3,14 +3,15 @@ import PIL
 from PIL import ImageOps
 from PIL.ExifTags import TAGS as EXIFTAGS
 import api.util as util
- 
+
 def rotate_image(image):
     # If no ExifTags, no rotating needed.
     try:
         # Grab orientation value.
+        ORIENTATION_KEY = 274
         image_exif = image._getexif()
-        if(image_exif):
-            image_orientation = image_exif[274]
+        if(image_exif and ORIENTATION_KEY in image_exif):
+            image_orientation = image_exif[ORIENTATION_KEY]
 
             # Rotate depending on orientation.
             if image_orientation == 2:


### PR DESCRIPTION
Receiving several of these in the logs:
```
2021-02-16 16:14:32,346 : exifreader.py : rotate_image : 33 : ERROR : Error when grabbing exif data
Traceback (most recent call last):
  File "/code/api/exifreader.py", line 13, in rotate_image
    image_orientation = image_exif[274]
KeyError: 274
```

If the behavior is to not rotate when exif data is missing, we should also be checking that the orientation key exists before trying to rotate.