### PR TITLE
fix: lookup photo based on md5 hash only for key-constraint requirements

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -40,12 +40,12 @@ def calculate_hash(user, image_path):
 def should_skip(filepath):
     if not os.getenv('SKIP_PATTERNS'):
         return False
-        
+
     skip_patterns = os.getenv('SKIP_PATTERNS')
     skip_list = skip_patterns.split(',')
     skip_list = map(str.strip, skipList)
 
-    res = [ele for ele in skip_list if(ele in filepath)] 
+    res = [ele for ele in skip_list if(ele in filepath)]
     return bool(res)
 
 if os.name == "Windows":
@@ -91,7 +91,7 @@ def handle_new_image(user, image_path, job_id):
             elapsed_times["md5"] = elapsed
 
             photo_exists = Photo.objects.filter(
-                Q(image_hash=image_hash) & Q(image_path=image_path)
+                Q(image_hash=image_hash)
             ).exists()
 
             if not photo_exists:
@@ -170,7 +170,7 @@ def rescan_image(user, image_path, job_id):
 def walk_directory(directory, callback):
     for file in os.scandir(directory):
         fpath = os.path.join(directory, file)
-        if not is_hidden(fpath) and not should_skip(fpath):            
+        if not is_hidden(fpath) and not should_skip(fpath):
             if os.path.isdir(fpath):
                 walk_directory(fpath, callback)
             else:


### PR DESCRIPTION
I do not have the cleanest image directory structure, and I expect most users do not.
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "api_photo_pkey"
DETAIL:  Key (image_hash)=(9964563822bd175171fe2412dac212431) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/code/api/directory_watcher.py", line 98, in handle_new_image
    photo = Photo.objects.create(
  File "/miniconda/lib/python3.8/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/miniconda/lib/python3.8/site-packages/django/db/models/query.py", line 433, in create
    obj.save(force_insert=True, using=self.db)
  File "/miniconda/lib/python3.8/site-packages/django/db/models/base.py", line 748, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/miniconda/lib/python3.8/site-packages/django/db/models/base.py", line 785, in save_base
    updated = self._save_table(
  File "/miniconda/lib/python3.8/site-packages/django/db/models/base.py", line 890, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/miniconda/lib/python3.8/site-packages/django/db/models/base.py", line 927, in _do_insert
    return manager._insert(
  File "/miniconda/lib/python3.8/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/miniconda/lib/python3.8/site-packages/django/db/models/query.py", line 1204, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/miniconda/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1394, in execute_sql
    cursor.execute(sql, params)
  File "/miniconda/lib/python3.8/site-packages/django/db/backends/utils.py", line 100, in execute
    return super().execute(sql, params)
  File "/miniconda/lib/python3.8/site-packages/django/db/backends/utils.py", line 68, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/miniconda/lib/python3.8/site-packages/django/db/backends/utils.py", line 77, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/miniconda/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/miniconda/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/miniconda/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: duplicate key value violates unique constraint "api_photo_pkey"
DETAIL:  Key (image_hash)=(9964563822bd175171fe2412dac212431) already exists.
```
I have duplicated images in different directorys. This violation of the key constraint is due to the lookup comparing the md5 hash and the file path. There is no uniqueness constraint in the database index for the path, thus this error will pop up and halt processing. The md5 uniqueness should be the truth for a unique image, this may have downstream effects. If those are undesirable, the database index should be updated to enforce uniqueness on md5 and the path if this is the desired approach.

My linter is also stripping whitespace.