### PR TITLE
Add boolean field favorited to list image data

### DIFF
--- a/api/views/serializers_serpy.py
+++ b/api/views/serializers_serpy.py
@@ -62,6 +62,7 @@ class PigPhotoSerilizer(serpy.Serializer):
     birthTime = serpy.StrField(attr='exif_timestamp')
     aspectRatio = serpy.FloatField(attr='aspect_ratio')
     type = serpy.MethodField("get_type")
+    favorited = serpy.BoolField('favorited')
 
     def get_type(self, obj):
         if(obj.video):


### PR DESCRIPTION
Add boolean field `favorited` to `PigPhotoSerializer`, so that it is available in image data entries in lists fetched from backend.

Together with https://github.com/derneuere/react-pig/pull/6, this will show a star icon in the top left corner of a photo, next to the selection box.