### PR TITLE
fix LibrePhotos/librephotos#330

### DIFF
--- a/api/models/face.py
+++ b/api/models/face.py
@@ -1,10 +1,10 @@
 import os
 
 from django.db import models
+from django.dispatch import receiver
 
 from api.models.person import Person, get_unknown_person
 from api.models.photo import Photo
-from django.dispatch import receiver
 
 
 class Face(models.Model):

--- a/api/models/face.py
+++ b/api/models/face.py
@@ -1,7 +1,10 @@
+import os
+
 from django.db import models
 
 from api.models.person import Person, get_unknown_person
 from api.models.photo import Photo
+from django.dispatch import receiver
 
 
 class Face(models.Model):
@@ -26,3 +29,11 @@ class Face(models.Model):
 
     def __str__(self):
         return "%d" % self.id
+
+
+# From: https://stackoverflow.com/questions/16041232/django-delete-filefield
+@receiver(models.signals.post_delete, sender=Face)
+def auto_delete_file_on_delete(sender, instance, **kwargs):
+    if instance.image:
+        if os.path.isfile(instance.image.path):
+            os.remove(instance.image.path)

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -445,19 +445,19 @@ class Photo(models.Model):
                 image_path = self.image_hash + "_" + str(idx_face) + ".jpg"
 
                 margin = 2
-                existingFaces = api.models.face.Face.objects.filter(
-                        photo=self,
-                        location_top__lte    = face_location[0]+margin,
-                        location_top__gte    = face_location[0]-margin,
-                        location_right__lte  = face_location[1]+margin,
-                        location_right__gte  = face_location[1]-margin,
-                        location_bottom__lte = face_location[2]+margin,
-                        location_bottom__gte = face_location[2]-margin,
-                        location_left__lte   = face_location[3]+margin,
-                        location_left__gte   = face_location[3]-margin,
-                        )
+                existing_faces = api.models.face.Face.objects.filter(
+                    photo=self,
+                    location_top__lte    = face_location[0]+margin,
+                    location_top__gte    = face_location[0]-margin,
+                    location_right__lte  = face_location[1]+margin,
+                    location_right__gte  = face_location[1]-margin,
+                    location_bottom__lte = face_location[2]+margin,
+                    location_bottom__gte = face_location[2]-margin,
+                    location_left__lte   = face_location[3]+margin,
+                    location_left__gte   = face_location[3]-margin,
+                )
 
-                if existingFaces.count() != 0:
+                if existing_faces.count() != 0:
                     continue
 
                 face = api.models.face.Face(

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -444,7 +444,23 @@ class Photo(models.Model):
 
                 image_path = self.image_hash + "_" + str(idx_face) + ".jpg"
 
-                face, created = api.models.face.Face.objects.get_or_create(
+                margin = 2
+                existingFaces = api.models.face.Face.objects.filter(
+                        photo=self,
+                        location_top__lte    = face_location[0]+margin,
+                        location_top__gte    = face_location[0]-margin,
+                        location_right__lte  = face_location[1]+margin,
+                        location_right__gte  = face_location[1]-margin,
+                        location_bottom__lte = face_location[2]+margin,
+                        location_bottom__gte = face_location[2]-margin,
+                        location_left__lte   = face_location[3]+margin,
+                        location_left__gte   = face_location[3]-margin,
+                        )
+
+                if existingFaces.count() != 0:
+                    continue
+
+                face = api.models.face.Face(
                     image_path=image_path,
                     photo=self,
                     location_top=face_location[0],
@@ -452,7 +468,7 @@ class Photo(models.Model):
                     location_bottom=face_location[2],
                     location_left=face_location[3],
                     encoding=face_encoding.tobytes().hex(),
-                    defaults={"person": unknown_person},
+                    person=unknown_person,
                 )
 
                 face_io = BytesIO()


### PR DESCRIPTION
Add a 2 pixel margin for face location coordinates
Add post delete hook to Face model to delete face image on disk

The 2 pixel margin is currently hard coded in photo model. I have decided against using percentage error since that will require full dimension of the photo which is an additional step. 

The post delete hook is added to prevent face images from piling up in disk. Since this django version does not delete files on model delete. 