### PR TITLE
-#335 #310: Read metadata from XMP sidecar file if present

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -121,6 +121,7 @@ def handle_new_image(user, image_path, job_id):
                 photo._generate_clip_embeddings(True)
                 photo._extract_date_time_from_exif(True)
                 photo._geolocate_mapbox(True)
+                photo._extract_rating(True)
                 photo._extract_faces()
 
                 elapsed = (datetime.datetime.now() - start).total_seconds()
@@ -166,6 +167,7 @@ def rescan_image(user, image_path, job_id):
             photo._generate_clip_embeddings(True)
             photo._extract_date_time_from_exif(True)
             photo._geolocate_mapbox(True)
+            photo._extract_rating(True)
 
     except Exception as e:
         try:
@@ -190,14 +192,22 @@ def walk_directory(directory, callback):
                 callback.append(fpath)
 
 
+def _file_was_modified_after(filepath, time):
+    modified = os.path.getmtime(filepath)
+    return datetime.datetime.fromtimestamp(modified).replace(tzinfo=pytz.utc) > time
+
+
 def photo_scanner(user, lastScan, full_scan, path, job_id):
     if Photo.objects.filter(image_paths__contains=path).exists():
-        time = os.path.getmtime(path)
+        sidecar_file = util.get_existing_sidecar_file(path)
         if (
             full_scan
             or not lastScan
-            or datetime.datetime.fromtimestamp(time).replace(tzinfo=pytz.utc)
-            > lastScan.finished_at
+            or _file_was_modified_after(path, lastScan.finished_at)
+            or (
+                sidecar_file
+                and _file_was_modified_after(sidecar_file, lastScan.finished_at)
+            )
         ):
             rescan_image(user, path, job_id)
     else:
@@ -211,6 +221,23 @@ def photo_scanner(user, lastScan, full_scan, path, job_id):
                 ) where job_id = %(job_id)s""",
             {"job_id": str(job_id)},
         )
+
+
+def initialize_scan_process(*args, **kwargs):
+    """
+    Each process will have its own exiftool instance
+    so we need to start _and_ stop it for each process.
+    multiprocessing.util.Finalize is _undocumented_ and
+    should perhaps not be relied on but I found no other
+    way. (See https://stackoverflow.com/a/24724452)
+
+    """
+    from multiprocessing.util import Finalize
+
+    from api.util import exiftool_instance
+
+    et = exiftool_instance.__enter__()
+    Finalize(et, et.__exit__, exitpriority=16)
 
 
 @job
@@ -253,7 +280,11 @@ def scan_photos(user, full_scan, job_id):
         lrj.result = {"progress": {"current": 0, "target": files_found}}
         lrj.save()
         db.connections.close_all()
-        with Pool(processes=ownphotos.settings.HEAVYWEIGHT_PROCESS) as pool:
+
+        with Pool(
+            processes=ownphotos.settings.HEAVYWEIGHT_PROCESS,
+            initializer=initialize_scan_process,
+        ) as pool:
             pool.starmap(photo_scanner, all)
 
         place365_instance.unload()


### PR DESCRIPTION
#310 (part): read metadata from XMP sidecar file if one is present + extract Rating.

NOTE:
If a user chooses to Rescan all photos (filesystem), any rating set manually by the user in librephotos (stored in the postgres db) will be reset to the value in the image (or sidecar) metadata on the hard drive.

I have code ready for writing Rating to sidecar file when a photo is updated (and as a CLI command for all photos). When this is enabled, and as long as the pictures folder is writeable by librephotos, this shouldn't be a problem, since the Rating setting will then be kept up-to-date between hard drive and database.

How to test:

1. Choose a photo in your collection that is not favorited. Copy the path on the file system.
2. Create an XMP sidecar file with a Rating=5:
```
exiftool path/to/the-chosen-photo.xmp -Rating=5
```
3. Scan your photos (filesystem)
4. Check that the chosen photo now shows as favorited (refresh page if needed)

Also, #335 use only one exiftool instance per process.
How to test: unknown...