### PR TITLE
Prevents face scanner to crash on non-8bit gray/RGB images while getting face_locations

### DIFF
--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -503,12 +503,16 @@ class Photo(models.Model):
             unknown_person = qs_unknown_person[0]
         image = np.array(PIL.Image.open(self.thumbnail_big.path))
 
-        face_locations = face_recognition.face_locations(image)
-        face_encodings = face_recognition.face_encodings(
-            image, known_face_locations=face_locations
-        )
+        face_locations = []
+        try:
+            face_locations = face_recognition.face_locations(image)
+        except:
+            logger.debug(f"Can't extract face information on photo: {self.image_paths[0]}")
 
         if len(face_locations) > 0:
+            face_encodings = face_recognition.face_encodings(
+                image, known_face_locations=face_locations
+            )
             for idx_face, face in enumerate(zip(face_encodings, face_locations)):
                 face_encoding = face[0]
                 face_location = face[1]


### PR DESCRIPTION
If scanning a non-8bit gray/RGB photo, face_recognition fails fetching face_locations getting the following exception:

```
directory_watcher.py : scan_faces : 363 : ERROR : An error occured: 
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.9/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File "/code/api/directory_watcher.py", line 324, in face_scanner
    photo._extract_faces()
  File "/code/api/models/photo.py", line 506, in _extract_faces
    face_locations = face_recognition.face_locations(image)
  File "/usr/local/lib/python3.9/dist-packages/face_recognition/api.py", line 118, in face_locations
    return [_trim_css_to_bounds(_rect_to_css(face), img.shape) for face in _raw_face_locations(img, number_of_times_to_upsample, model)]
  File "/usr/local/lib/python3.9/dist-packages/face_recognition/api.py", line 102, in _raw_face_locations
    return face_detector(img, number_of_times_to_upsample)
RuntimeError: Unsupported image type, must be 8bit gray or RGB image.
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/code/api/directory_watcher.py", line 360, in scan_faces
    pool.starmap(face_scanner, all)
  File "/usr/lib/python3.9/multiprocessing/pool.py", line 372, in starmap
    return self._map_async(func, iterable, starmapstar, chunksize).get()
  File "/usr/lib/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
RuntimeError: Unsupported image type, must be 8bit gray or RGB image.
```

**Fixed** capturing `face_locations = face_recognition.face_locations(image)` possible exceptions