### PR TITLE
Find local time for videos using geolocation

### DIFF
--- a/api/background_tasks.py
+++ b/api/background_tasks.py
@@ -26,6 +26,7 @@ def geolocate(overwrite=False):
         try:
             logger.info("geolocating %s" % photo.image_path)
             photo._geolocate_mapbox()
+            photo._add_location_to_album_dates()
         except Exception:
             logger.exception("could not geolocate photo: " + photo)
 

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -151,6 +151,13 @@ def handle_new_image(user, image_path, job_id):
                         job_id, img_abs_path, elapsed
                     )
                 )
+                photo._add_location_to_album_dates()
+                elapsed = (datetime.datetime.now() - start).total_seconds()
+                util.logger.info(
+                    "job {}: add location to album dates: {}, elapsed: {}".format(
+                        job_id, img_abs_path, elapsed
+                    )
+                )
                 photo._extract_rating(True)
                 elapsed = (datetime.datetime.now() - start).total_seconds()
                 util.logger.info(
@@ -208,6 +215,7 @@ def rescan_image(user, image_path, job_id):
             photo._calculate_aspect_ratio(False)
             photo._geolocate_mapbox(True)
             photo._extract_date_time_from_exif(True)
+            photo._add_location_to_album_dates()
             photo._extract_rating(True)
             photo._get_dominant_color()
 

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -137,17 +137,17 @@ def handle_new_image(user, image_path, job_id):
                         job_id, img_abs_path, elapsed
                     )
                 )
-                photo._extract_date_time_from_exif(True)
-                elapsed = (datetime.datetime.now() - start).total_seconds()
-                util.logger.info(
-                    "job {}: extract date time: {}, elapsed: {}".format(
-                        job_id, img_abs_path, elapsed
-                    )
-                )
                 photo._geolocate_mapbox(True)
                 elapsed = (datetime.datetime.now() - start).total_seconds()
                 util.logger.info(
                     "job {}: geolocate: {}, elapsed: {}".format(
+                        job_id, img_abs_path, elapsed
+                    )
+                )
+                photo._extract_date_time_from_exif(True)
+                elapsed = (datetime.datetime.now() - start).total_seconds()
+                util.logger.info(
+                    "job {}: extract date time: {}, elapsed: {}".format(
                         job_id, img_abs_path, elapsed
                     )
                 )
@@ -206,8 +206,8 @@ def rescan_image(user, image_path, job_id):
             photo = Photo.objects.filter(Q(image_paths__contains=image_path)).get()
             photo._generate_thumbnail(True)
             photo._calculate_aspect_ratio(False)
-            photo._extract_date_time_from_exif(True)
             photo._geolocate_mapbox(True)
+            photo._extract_date_time_from_exif(True)
             photo._extract_rating(True)
             photo._get_dominant_color()
 

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -7,6 +7,7 @@ import face_recognition
 import numpy as np
 import PIL
 import pytz
+from timezonefinder import TimezoneFinder
 from django.contrib.postgres.fields import ArrayField
 from django.core.cache import cache
 from django.core.files.base import ContentFile
@@ -353,6 +354,15 @@ class Photo(models.Model):
         if commit:
             self.save()
 
+    def _try_getting_timezone_from_geolocation(self, timestamp):
+        if self.exif_gps_lon and self.exif_gps_lat:
+            tzfinder = TimezoneFinder()
+            tz_name = tzfinder.timezone_at(lng=self.exif_gps_lon, lat=self.exif_gps_lat)
+            util.logger.info(f"{self.image_paths[0]} marked as timezone {tz_name} based on lat/lon {self.exif_gps_lat}/{self.exif_gps_lon}")
+            if tz_name:
+                return timestamp.astimezone(pytz.timezone(tz_name))
+        return timestamp
+
     def _extract_date_time_from_exif(self, commit=True):
         date_format = "%Y:%m:%d %H:%M:%S"
         timestamp_from_exif = None
@@ -371,6 +381,11 @@ class Photo(models.Model):
         if exifvideo:
             try:
                 timestamp_from_exif = datetime.strptime(exifvideo, date_format).replace(
+                    tzinfo=pytz.utc
+                )
+                # Try to get actual timezone using geolocation before stripping it off to get correct local time for video
+                # Video timestamp expected to be in UTC (as per standard)
+                timestamp_from_exif = self._try_getting_timezone_from_geolocation(timestamp_from_exif).replace(
                     tzinfo=pytz.utc
                 )
             except Exception:

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -478,7 +478,14 @@ class Photo(models.Model):
                 )
             album_place.photos.add(self)
             album_place.save()
-        # Add location to album dates
+
+        if commit:
+            self.save()
+
+
+    def _add_location_to_album_dates(self):
+        if not self.geolocation_json:
+            return
         album_date = self._find_album_date()
         city_name = [
             f["text"]
@@ -495,8 +502,6 @@ class Photo(models.Model):
         else:
             album_date.location = {"places": [city_name]}
         # Safe geolocation_json
-        if commit:
-            self.save()
         album_date.save()
         cache.clear()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ seaborn==0.11.0
 sentence_transformers==1.2.0
 serpy==0.3.1
 sklearn==0.0
+timezonefinder==5.2.0
 tqdm==4.51.0
 gevent==20.12.1
 python-magic==0.4.18


### PR DESCRIPTION
Currently video timestamp taken from metadata is expected to contain UTC time (unlike exif timestamp from images which usually contains time with timezone). Right now this leads to the situation when videos being shown by LibrePhotos as if the UTC time was local time for them and appear to be shifted in time compared to photos taken at similar times.

For the case when video has geolocation this can be fixed by converting UTC timestamp to local using timezone inferred from the location.

This change is:
1. Adding dependency of timezonefinder (https://pypi.org/project/timezonefinder/)
2. Change order of photo._geolocate_mapbox and photo._extract_date_time_from_exif in scanning and rescanning (so that coordinates are available when we extract datetime)
3. When timestamp is taken from video metadata source it is attempted to be localized using timezone inferred by timezonefinder.