### PR TITLE
Limit number of threads used by heavyweight processes for photo scanning

### DIFF
--- a/api/directory_watcher_initializer.py
+++ b/api/directory_watcher_initializer.py
@@ -1,0 +1,39 @@
+"""
+This module peovides initializer function
+without importing anything at the module level.
+This allows to set env vars suxh as OMP_NUM_THREADS.
+It is important that spawn context is used, because
+with fork new processes will get modules like torch
+initialized from the parent process with env vars
+having no effect.
+"""
+
+def initialize_scan_process(num_threads, method):
+    """
+    Each process will have its own exiftool instance
+    so we need to start _and_ stop it for each process.
+    multiprocessing.util.Finalize is _undocumented_ and
+    should perhaps not be relied on but I found no other
+    way. (See https://stackoverflow.com/a/24724452)
+
+    """
+    if num_threads is not None:
+        import os
+        os.environ["OMP_NUM_THREADS"] = str(num_threads)
+
+    if method == "spawn":
+        import django
+        django.setup()
+
+    from multiprocessing.util import Finalize
+
+    from api.util import exiftool_instance
+
+    et = exiftool_instance.__enter__()
+
+    def terminate(et):
+        et.terminate()
+
+    Finalize(et, terminate, args=(et,), exitpriority=16)
+
+


### PR DESCRIPTION
This only affects the case when number of heavy weight processes is more than one. In that case multiprocessing is forced to use spawn instead of fork and env var OMP_NUM_THREADS is set to limit thread usage per process. On my machine (16 cores, 64 gb RAM) I was able to see about ~8x speedup on scanning using 16 heavy processes compared to ~2x before this change.