### PR TITLE
Limit number of threads used by heavyweight processes for photo scanning

### DIFF
--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -3,16 +3,15 @@ import os
 from datetime import datetime
 from io import BytesIO
 
-import face_recognition
 import numpy as np
 import PIL
 import pytz
-from timezonefinder import TimezoneFinder
 from django.contrib.postgres.fields import ArrayField
 from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models import Q
+from timezonefinder import TimezoneFinder
 
 import api.models
 import api.util as util
@@ -358,7 +357,9 @@ class Photo(models.Model):
         if self.exif_gps_lon and self.exif_gps_lat:
             tzfinder = TimezoneFinder()
             tz_name = tzfinder.timezone_at(lng=self.exif_gps_lon, lat=self.exif_gps_lat)
-            util.logger.info(f"{self.image_paths[0]} marked as timezone {tz_name} based on lat/lon {self.exif_gps_lat}/{self.exif_gps_lon}")
+            util.logger.info(
+                f"{self.image_paths[0]} marked as timezone {tz_name} based on lat/lon {self.exif_gps_lat}/{self.exif_gps_lon}"
+            )
             if tz_name:
                 return timestamp.astimezone(pytz.timezone(tz_name))
         return timestamp
@@ -385,9 +386,9 @@ class Photo(models.Model):
                 )
                 # Try to get actual timezone using geolocation before stripping it off to get correct local time for video
                 # Video timestamp expected to be in UTC (as per standard)
-                timestamp_from_exif = self._try_getting_timezone_from_geolocation(timestamp_from_exif).replace(
-                    tzinfo=pytz.utc
-                )
+                timestamp_from_exif = self._try_getting_timezone_from_geolocation(
+                    timestamp_from_exif
+                ).replace(tzinfo=pytz.utc)
             except Exception:
                 timestamp_from_exif = None
 
@@ -482,7 +483,6 @@ class Photo(models.Model):
         if commit:
             self.save()
 
-
     def _add_location_to_album_dates(self):
         if not self.geolocation_json:
             return
@@ -517,6 +517,8 @@ class Photo(models.Model):
                 self.save(save_metadata=False)
 
     def _extract_faces(self):
+        import face_recognition
+
         qs_unknown_person = api.models.person.Person.objects.filter(name="unknown")
         if qs_unknown_person.count() == 0:
             unknown_person = api.models.person.Person(name="unknown")


### PR DESCRIPTION
This is a slightly different version of https://github.com/LibrePhotos/librephotos/pull/399 . I also fix some linting issues from my previous change (had to do it because I touch the same api/models/photo.py). The goal is to improve usage of `HEAVYWEIGHT_PROCESS`  which currently doesn't scale well for higher number of threads.

Main idea here:
1. Remove importing of `face_recognition` module from header or `api/models/photo.py` and put it instead inside `_extrac_faces` method. Mainly this is done to make sure that rqworker process (and its fork that is doing the `scan_photos` under @job decorator) don't have `face_recognition` module imported too early.
2. `scan_photos` is setting OMP_NUM_THREADS and torch threads to the number appropriate to the number of the heavy-weight processes (torch threading is set because torch is already imported at that point due to places365 and some other modules).
3. Right before spawning multiprocessing pool (but after setting OMP_NUM_THREADS) face_recognition module is imported in `scan_photos` (so it is loaded before forking, but after module was loaded).
4. Since `api/models/photos.py` no logner importing face_recognition by default job `scan_faces` has to import the module before starting multiprocessing pool (to avoid duplicate memory usage in forked processes).

I did some tests using docker stats and capturing the usage for baseline and new version using 1/2/4/8/16 threads (my machine has 16 cores and 64 GB RAM).

Results:

| N of heavy-weight  threads | Time baseline | Time new  | Mem peak baseline | Mem peak new |
| ---------------------------- | --------------- | ----------- | ---------------------- | ----------------- |
| 1                                        |          602 s     |     602 s     |          2660 MB          |        2467 MB                   |
| 2                                        |          326 s     |     316 s    |              4035 MB        |        3418 MB                   |
| 4                                        |          201 s     |    177 s     |              6270 MB        |          5442 MB                 |
| 8                                        |         280 s       |      113 s   |                10639 MB    |            9213 MB               |
| 16                                      |        352 s       |       82 s  |              16922 MB      |           16543 MB                |

In all of these memory usage went down and performance improved (though much more significantly on higher number of threads).

All graphs below show memory usage (again as measured by docker stats command)

## Baseline scaling (1->2->4 improves time, 8 and 16 are worse) 
![baseline_scaling](https://user-images.githubusercontent.com/1651059/143527291-03b9f947-36ef-4224-852f-334ce839ab69.png)

## New scaling (1->2->4->8->16 all improve time)
![new_scaling](https://user-images.githubusercontent.com/1651059/143527292-efe11ff8-6273-42ab-a448-b7f278ff016d.png)

## Base vs New 1 thread:
![1thread](https://user-images.githubusercontent.com/1651059/143527299-689bf070-561f-4e9a-9cac-caf79c98ae78.png)

## Base vs New 2 threads:
![2thread](https://user-images.githubusercontent.com/1651059/143527298-cece6d4f-53eb-4dd6-9388-10a8ffedd6b6.png)

## Base vs New 4 threads:
![4thread](https://user-images.githubusercontent.com/1651059/143527297-9cbe3cc6-c4ff-45cb-8da0-92a704eff0ec.png)

## Base vs New 8 threads:
![8thread](https://user-images.githubusercontent.com/1651059/143527296-5bf4336d-0b91-4e30-b2e2-248710a75ee9.png)

## Base vs New 16 threads:
![16thread](https://user-images.githubusercontent.com/1651059/143527293-f66f78bf-84f6-4d00-a6bb-a84937f8f426.png)
