### PR TITLE
Add gps time as fallback for timestamp from exif

### DIFF
--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -395,7 +395,7 @@ class Photo(models.Model):
 
         if gps_time:
             try:
-                timestamp_from_exif = datetime.strptime(exifvideo, date_format).replace(
+                timestamp_from_exif = datetime.strptime(gps_time, date_format).replace(
                     tzinfo=pytz.utc
                 )
             except Exception:

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -43,6 +43,7 @@ class Tags:
     IMAGE_HEIGHT = "ImageHeight"
     IMAGE_WIDTH = "ImageWidth"
     DATE_TIME_ORIGINAL = "EXIF:DateTimeOriginal"
+    GPS_DATE_TIME = "EXIF:GPSDateTime"
     QUICKTIME_CREATE_DATE = "QuickTime:CreateDate"
     LATITUDE = "Composite:GPSLatitude"
     LONGITUDE = "Composite:GPSLongitude"
@@ -367,9 +368,9 @@ class Photo(models.Model):
     def _extract_date_time_from_exif(self, commit=True):
         date_format = "%Y:%m:%d %H:%M:%S"
         timestamp_from_exif = None
-        exif, exifvideo = get_metadata(
+        exif, exifvideo, gps_time = get_metadata(
             self.image_paths[0],
-            tags=[Tags.DATE_TIME_ORIGINAL, Tags.QUICKTIME_CREATE_DATE],
+            tags=[Tags.DATE_TIME_ORIGINAL, Tags.QUICKTIME_CREATE_DATE, Tags.GPS_DATE_TIME],
             try_sidecar=True,
         )
         if exif:
@@ -391,6 +392,15 @@ class Photo(models.Model):
                 ).replace(tzinfo=pytz.utc)
             except Exception:
                 timestamp_from_exif = None
+
+        if gps_time:
+            try:
+                timestamp_from_exif = datetime.strptime(exifvideo, date_format).replace(
+                    tzinfo=pytz.utc
+                )
+            except Exception:
+                timestamp_from_exif = None
+
 
         old_album_date = self._find_album_date()
 

--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -370,7 +370,11 @@ class Photo(models.Model):
         timestamp_from_exif = None
         exif, exifvideo, gps_time = get_metadata(
             self.image_paths[0],
-            tags=[Tags.DATE_TIME_ORIGINAL, Tags.QUICKTIME_CREATE_DATE, Tags.GPS_DATE_TIME],
+            tags=[
+                Tags.DATE_TIME_ORIGINAL,
+                Tags.QUICKTIME_CREATE_DATE,
+                Tags.GPS_DATE_TIME,
+            ],
             try_sidecar=True,
         )
         if exif:


### PR DESCRIPTION
As described here: [Try additional fields for photo datetime #300
](https://github.com/LibrePhotos/librephotos/issues/300) 
I've added `GPS_DATE_TIME` fallback, but I've no idea what can be a fallback too.