### PR TITLE
Fix issue with trying to create image with incorrect datetime

### DIFF
--- a/api/date_time_extractor.py
+++ b/api/date_time_extractor.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import pytz
 
 from api.exif_tags import Tags
+from api.util import logger
 
 
 def _regexp_group_range(a, b):
@@ -66,7 +67,7 @@ def _extract_no_tz_datetime_from_str(x, regexp=REGEXP_NO_TZ, group_mapping=None)
         return None
     g = match.groups()
     if group_mapping is None:
-        datetime_args = map(int, g)
+        datetime_args = list(map(int, g))
     else:
         if len(g) > len(group_mapping):
             raise ValueError(
@@ -92,6 +93,7 @@ def _extract_no_tz_datetime_from_str(x, regexp=REGEXP_NO_TZ, group_mapping=None)
     try:
         return datetime(*datetime_args)
     except ValueError:
+        logger.error(f"Error while trying to create datetime using '{x}': datetime arguments {datetime_args}. Regexp used: '{regexp}'")
         return None
 
 

--- a/api/date_time_extractor.py
+++ b/api/date_time_extractor.py
@@ -89,7 +89,10 @@ def _extract_no_tz_datetime_from_str(x, regexp=REGEXP_NO_TZ, group_mapping=None)
             ind = REGEXP_GROUP_MAPPINGS[how_to_use]
             datetime_args[ind] = int(value)
 
-    return datetime(*datetime_args)
+    try:
+        return datetime(*datetime_args)
+    except ValueError:
+        return None
 
 
 class RuleTypes:


### PR DESCRIPTION
Existing code can fail image handling in unusual cases - e.g. if it has to go through filename-based rule and file's name is something like `BAD_NAME_20210230_121212.mp4` (i.e. nonexisting day of month). Similarly could happen with Whats app rule (though you probably have to create such a bad file name on purpose in either case). This is fixed by catching ValueError in datetime creation rule. Even though it is not expected to affect a lot of people it is better to have it fixed.