### PR TITLE
Fix filter for images with location but missing lookup

### DIFF
--- a/api/api_util.py
+++ b/api/api_util.py
@@ -81,10 +81,14 @@ def jump_by_month(start_date, end_date, month_step=1):
 
 def get_location_timeline(user):
     qs_photos = (
-        Photo.objects.exclude(geolocation_json={})
-        .exclude(exif_timestamp=None)
-        .filter(owner=user)
-        .order_by("exif_timestamp")
+        Photo
+            .objects
+            .filter(**{
+                'geolocation_json__features__-1__text__isnull': False,
+                'exif_timestamp__isnull': False,
+                'owner': user
+            })
+            .order_by("exif_timestamp")
     )
     timestamp_loc = []
     paginator = Paginator(qs_photos, 5000)


### PR DESCRIPTION
I have a picture taken inside of an airplane with a valid geolocation.

https://www.google.com/maps/place/51%C2%B031'46.6%22N+2%C2%B006'49.9%22E/@50.5495598,-0.1600842,7.21z/data=!4m5!3m4!1s0x0:0x1e93c1a35cd9a3f6!8m2!3d51.529606!4d2.113856

However, when this gets put through MapBox we see that the following `geolocation_json` is produced:

```
{'type': 'FeatureCollection', 'query': [2.113856, 51.529606], 'features': [], 'attribution': 'NOTICE: © 2022 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained. POI(s) provided by Foursquare.', 'search_text': ''}
```

No `features`. Oops. 

This provides issues with the code on line 93: https://github.com/LibrePhotos/librephotos/blob/a5ab77839c6fb24d24293f28ba4154d42511e245/api/api_util.py#L93

I updated the check to expand the null-check to ensure that the whole chain is not null, not just `geolocation_json`. 

Interestingly this, by proxy, fixes another bug.

If we consider the query

```
Photo.objects.exclude(geolocation_json={})
```
as the basis for the filter 'get all photos where we have a `geolocation_json`', then it fails on an object where `geolocation: None`. Now, I'm not sure if that is ever possible from the point view of code, but it is definitely possible from the model's point of view: https://github.com/LibrePhotos/librephotos/blob/0a465a5dbee71247e8fad6ad23e694b91d7bb8f7/api/migrations/0001_initial.py#L427-L428

If we open a shell like this:

```
$ docker exec -it librephotos-backend python /code/manage.py shell_plus
# ...initialization
>>> temp = Photo.objects.first()
>>> temp.pk = "none_geolocation"
>>> temp.geolocation_json = None
>>> temp.save()
>>> for p in Photo.objects.exclude(geolocation_json={}):
...     if (p.geolocation_json == None):
...         print("ERROR: p.geolocation_json is None")
...
p.geolocation_json is None
```

Looking at the generated code shows that the test `exclude(geolocation_json={})` doesn't match with the model and our output's expectations:
```
 WHERE NOT ("api_photo"."geolocation_json" = '{}' AND "api_photo"."geolocation_json" IS NOT NULL)
```
This where only excludes `{}`, but not `None`: 
| | `"api_photo"."geolocation_json" = '{}'` | `"api_photo"."geolocation_json" IS NOT NULL` | `NOT(condition1 AND condition2)` (i.e. will it be included?) | 
| ----------- | ----------- | ----------- | ----------- |
| `None` (or `NULL`)   | `FALSE` | `FALSE` | `TRUE`, but we don't expect it to be, 👎  |
| `{}` (i.e. empty dict   | `TRUE` | `TRUE` | `FALSE`, 👍  |
| `{'...': '...'}`   | `FALSE` | `TRUE` | `TRUE`, 👍  |

As this `exclude(geolocation_json={})` is being used across the code I'm not sure though if we ever end up in that case.

If we expect it will `None`, then I believe a better filter across the board would be `filter(geolocation_json__isnull=False).filter(...other properties...)`.

If we don't, then I suggest setting the DB model's `nullable` to `FALSE`.
