### PR TITLE
Optimized queries in api_util

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/api/api_util.py
+++ b/api/api_util.py
@@ -113,7 +113,7 @@ def get_location_timeline(user):
     for idx, sted in enumerate(city_start_end_duration):
         data.append(
             {
-                "data": sted[3].timestamp(),
+                "data": sted[3],
                 "color": colors[idx],
                 "loc": sted[0],
                 "start": sted[1].timestamp(),

--- a/api/api_util.py
+++ b/api/api_util.py
@@ -80,66 +80,55 @@ def jump_by_month(start_date, end_date, month_step=1):
 
 
 def get_location_timeline(user):
-    qs_photos = (
-        Photo.objects.exclude(geolocation_json={})
-        .exclude(exif_timestamp=None)
-        .filter(owner=user)
-        .order_by("exif_timestamp")
-    )
-    timestamp_loc = []
-    paginator = Paginator(qs_photos, 5000)
-    for page in range(1, paginator.num_pages + 1):
-        current_page = [
-            (p.exif_timestamp, p.geolocation_json["features"][-1]["text"])
-            for p in paginator.page(page).object_list
-        ]
-        timestamp_loc = timestamp_loc + current_page
-
-    groups = []
-    uniquekeys = []
-    for k, g in groupby(timestamp_loc, lambda x: x[1]):
-        groups.append(list(g))  # Store group iterator as a list
-        uniquekeys.append(k)
-
     city_start_end_duration = []
-    for idx, group in enumerate(groups):
-        city = group[0][1]
-        start = group[0][0]
-        if idx < len(groups) - 1:
-            end = groups[idx + 1][0][0]
-        else:
-            end = group[-1][0]
-        time_in_city = (end - start).total_seconds()
+    with connection.cursor() as cursor:
+        raw_sql = """
+            WITH time_in_location AS (
+                SELECT
+                    DISTINCT ON("feature" ->> 'text') "feature" ->> 'text' "location"
+                    , MIN("api_photo"."exif_timestamp") "start"
+                    , MAX("api_photo"."exif_timestamp") "end"
+                    , EXTRACT(EPOCH FROM MAX("api_photo"."exif_timestamp") - MIN("api_photo"."exif_timestamp")) "duration"
+                FROM
+                    "api_photo"
+                    , json_array_elements(CAST("api_photo"."geolocation_json" -> 'features' AS JSON)) "feature"
+                WHERE
+                    ("api_photo"."exif_timestamp" IS NOT NULL AND "feature" ->> 'text' IS NOT NULL AND "api_photo"."owner_id" = %s)
+                GROUP BY
+                    "location"
+            )
 
-        if time_in_city > 0:
-            city_start_end_duration.append([city, start, end, time_in_city])
+            SELECT 
+                "time_in_location"."location"
+                , "time_in_location"."start"
+                , "time_in_location"."end"
+                , "time_in_location"."duration"
+            FROM
+                "time_in_location"
+            WHERE
+                ("time_in_location"."duration" > 0)
+            ORDER BY
+                "location" ASC;
 
-    locs = list(set([e[0] for e in city_start_end_duration]))
-    colors = sns.color_palette("Paired", len(locs)).as_hex()
+        """
+        cursor.execute(raw_sql, [user.id])
+        city_start_end_duration = [
+            (row[0], row[1], row[2], row[3]) for row in cursor.fetchall()
+        ]
 
-    loc2color = dict(zip(locs, colors))
+    colors = sns.color_palette("Paired", len(city_start_end_duration)).as_hex()
 
-    intervals_in_seconds = []
+    data = []
     for idx, sted in enumerate(city_start_end_duration):
-        intervals_in_seconds.append(
+        data.append(
             {
+                "data": sted[3].timestamp(),
+                "color": colors[idx],
                 "loc": sted[0],
                 "start": sted[1].timestamp(),
                 "end": sted[2].timestamp(),
-                "dur": sted[2].timestamp() - sted[1].timestamp(),
             }
         )
-
-    data = [
-        {
-            "data": [d["dur"]],
-            "color": loc2color[d["loc"]],
-            "loc": d["loc"],
-            "start": d["start"],
-            "end": d["end"],
-        }
-        for d in intervals_in_seconds
-    ]
     return data
 
 
@@ -313,91 +302,77 @@ def get_count_stats(user):
 
 def get_location_clusters(user):
     start = datetime.now()
-    photos = (
-        Photo.objects.filter(owner=user)
-        .exclude(geolocation_json={})
-        .only("geolocation_json")
-        .all()
-    )
+    with connection.cursor() as cursor:
+        raw_sql = """
+            SELECT
+                DISTINCT ON ("feature" ->> 'text') "feature" ->> 'text' "location"
+                , "feature" -> 'center' ->> 0
+                , "feature" -> 'center' ->> 1
+            FROM
+                "api_photo"
+                , json_array_elements(CAST("api_photo"."geolocation_json" -> 'features' AS JSON)) "feature"
+            WHERE
+                ("api_photo"."owner_id" = %s AND NOT ("feature" ->> 'text' ~ '^(-)?[0-9]+$'))
+            ORDER BY 
+                "location" ASC;
+        """
+        cursor.execute(raw_sql, [user.id])
+        res = [[row[1], row[2], row[0]] for row in cursor.fetchall()]
 
-    coord_names = []
-    paginator = Paginator(photos, 5000)
-    for page in range(1, paginator.num_pages + 1):
-        for p in paginator.page(page).object_list:
-            for feature in p.geolocation_json["features"]:
-                if not feature["text"].isdigit():
-                    coord_names.append([feature["text"], feature["center"]])
-
-    groups = []
-    uniquekeys = []
-    coord_names.sort(key=lambda x: x[0])
-    for k, g in groupby(coord_names, lambda x: x[0]):
-        groups.append(list(g))  # Store group iterator as a list
-        uniquekeys.append(k)
-
-    res = [[g[0][1][1], g[0][1][0], g[0][0]] for g in groups]
-    elapsed = (datetime.now() - start).total_seconds()
-    logger.info("location clustering took %.2f seconds" % elapsed)
-    return res
+        elapsed = (datetime.now() - start).total_seconds()
+        logger.info("location clustering took %.2f seconds" % elapsed)
+        return res
 
 
 def get_photo_country_counts(user):
-    photos_with_gps = Photo.objects.exclude(geolocation_json=None).filter(owner=user)
-    geolocations = [p.geolocation_json for p in photos_with_gps]
-    countries = []
-    for gl in geolocations:
-        if "features" in gl.keys():
-            for feature in gl["features"]:
-                if feature["place_type"][0] == "country":
-                    countries.append(feature["place_name"])
-
-    counts = Counter(countries)
-    return counts
+    with connection.cursor() as cursor:
+        raw_sql = """
+            SELECT
+                "feature" ->> 'place_name'
+                , COUNT("feature" ->> 'place_name')
+            FROM
+                "api_photo"
+                , json_array_elements(CAST("api_photo"."geolocation_json" -> 'features' AS JSON)) "feature"
+            WHERE
+                ("api_photo"."owner_id" = %s AND ("feature" -> 'place_type' ->> 0) = 'country')
+            GROUP BY
+                "feature" ->> 'place_name';
+        """
+        cursor.execute(raw_sql, [user.id])
+        return Counter({row[0]: row[1] for row in cursor.fetchall()})
 
 
 def get_location_sunburst(user):
-    photos_with_gps = (
-        Photo.objects.exclude(geolocation_json={})
-        .exclude(geolocation_json=None)
-        .filter(owner=user)
-    )
-
-    if photos_with_gps.count() == 0:
-        return {"children": []}
-    geolocations = []
-    paginator = Paginator(photos_with_gps, 5000)
-    for page in range(1, paginator.num_pages + 1):
-        for p in paginator.page(page).object_list:
-            geolocations.append(p.geolocation_json)
-
-    four_levels = []
-    for gl in geolocations:
-        out_dict = {}
-        if "features" in gl.keys():
-            if len(gl["features"]) >= 1:
-                out_dict[1] = gl["features"][-1]["text"]
-            if len(gl["features"]) >= 2:
-                out_dict[2] = gl["features"][-2]["text"]
-            if len(gl["features"]) >= 3:
-                out_dict[3] = gl["features"][-3]["text"]
-            four_levels.append(out_dict)
-
-    df = pd.DataFrame(four_levels)
-    df = (
-        df.groupby(df.columns.tolist())
-        .size()
-        .reset_index()
-        .rename(columns={4: "count"})
-    )
+    levels = []
+    with connection.cursor() as cursor:
+        raw_sql = """
+            SELECT
+                "api_photo"."geolocation_json" -> 'features' -> -1 ->> 'text' "l1"
+                , "api_photo"."geolocation_json" -> 'features' -> -2 ->> 'text' "l2"
+                , "api_photo"."geolocation_json" -> 'features' -> -3 ->> 'text' "l3",
+                COUNT(*)
+            FROM
+                "api_photo"
+            WHERE
+                ("api_photo"."owner_id" = %s AND jsonb_array_length("api_photo"."geolocation_json" -> 'features') >= 3)
+            GROUP BY
+                "l1"
+                , "l2"
+                , "l3"
+            ORDER BY
+                "l1"
+                , "l2"
+                , "l3"
+        """
+        cursor.execute(raw_sql, [user.id])
+        levels = [[row[0], row[1], row[2], row[3]] for row in cursor.fetchall()]
 
     data_structure = {"name": "Places I've visited", "children": []}
     palette = sns.color_palette("hls", 10).as_hex()
 
-    for data in df.iterrows():
-
-        current = data_structure
-        depth_cursor = current["children"]
-        for i, item in enumerate(data[1][:-2]):
+    for data in levels:
+        depth_cursor = data_structure["children"]
+        for i, item in enumerate(data[0:-2]):
             idx = None
             j = None
             for j, c in enumerate(depth_cursor):
@@ -410,11 +385,11 @@ def get_location_sunburst(user):
                 idx = len(depth_cursor) - 1
 
             depth_cursor = depth_cursor[idx]["children"]
-            if i == len(data[1]) - 3:
+            if i == len(data) - 3:
                 depth_cursor.append(
                     {
-                        "name": "{}".format(list(data[1])[-2]),
-                        "value": list(data[1])[-1],
+                        "name": data[-2],
+                        "value": data[-1],
                         "hex": random.choice(palette),
                     }
                 )

--- a/api/api_util.py
+++ b/api/api_util.py
@@ -84,17 +84,17 @@ def get_location_timeline(user):
     with connection.cursor() as cursor:
         raw_sql = """
             SELECT
-                DISTINCT jsonb_extract_path_text("feature", 'text') "location"
+                DISTINCT jsonb_extract_path("feature", 'text') "location"
                 , MIN("api_photo"."exif_timestamp") "start"
                 , MAX("api_photo"."exif_timestamp") "end"
                 , EXTRACT(EPOCH FROM MAX("api_photo"."exif_timestamp") - MIN("api_photo"."exif_timestamp")) "duration"
             FROM
                 "api_photo"
-                , jsonb_array_elements(jsonb_extract_path_text("api_photo"."geolocation_json", 'features')) "feature"
+                , jsonb_array_elements(jsonb_extract_path("api_photo"."geolocation_json", 'features')) "feature"
             WHERE
                 (
-                    "api_photo"."exif_timestamp" IS NOT NULL 
-                    AND jsonb_extract_path_text("feature", 'text') IS NOT NULL 
+                    "api_photo"."exif_timestamp" IS NOT NULL
+                    AND jsonb_extract_path("feature", 'text') IS NOT NULL
                     AND "api_photo"."owner_id" = %s
                 )
             GROUP BY

--- a/api/api_util.py
+++ b/api/api_util.py
@@ -84,7 +84,7 @@ def get_location_timeline(user):
     with connection.cursor() as cursor:
         raw_sql = """
             SELECT
-                DISTINCT jsonb_extract_path("feature", 'text') "location"
+                DISTINCT jsonb_extract_path("feature", '-1', 'text') "location"
                 , MIN("api_photo"."exif_timestamp") "start"
                 , MAX("api_photo"."exif_timestamp") "end"
                 , EXTRACT(EPOCH FROM MAX("api_photo"."exif_timestamp") - MIN("api_photo"."exif_timestamp")) "duration"
@@ -94,7 +94,7 @@ def get_location_timeline(user):
             WHERE
                 (
                     "api_photo"."exif_timestamp" IS NOT NULL
-                    AND jsonb_extract_path("feature", 'text') IS NOT NULL
+                    AND jsonb_extract_path("feature", '-1', 'text') IS NOT NULL
                     AND "api_photo"."owner_id" = %s
                 )
             GROUP BY


### PR DESCRIPTION
This is an update of #498.

I've gone through all the queries except for `get_search_term_examples` (as this one wasn't bugged, but I'll revisit it).

I looked at what the code did and noticed that in reality a LOT of data was being passed over the wire only to then be thrown away...

In my testing, on my dataset with ~10,000 photos:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/864376/169172813-9c74c038-6cc7-452a-b45e-6e69b06554fd.png">

| Endpoint | Before | After  |
|----------------------|--------|--------|
| `api/locationtimeline` | 6.34s  | 265 ms |
| `api/locclust` | 2.85s  | 383 ms |
| `api/locationsunburst` | 6.78s  | 424ms  |

Non-scientific of course, I refreshed a couple of times so that stuff was nicely cached and the wrote down the measurement in the Developer tools.

Now, caveats:

The data is 95% identical. But that doesn't mean that the new version is incorrect. It's just that ordering differs between Python and Postgres, and that if you have 2 locations `United States`, the order isn't defined between the 2. So between runs of the application the order might differ. 

Anyway, let's look at the differences:

### `api/locationtimeline` 
I removed the `color` (it's auto generated) and then there is ZERO difference between before and after. 

### `api/locclust`
2 overall differences here:
1) There seems to be a case where location `FOOBAR` has multiple `center` points, and in Postgres a different row gets selected than in Python. In the grand scheme of things, that's ok. 
E.g.:

<table>
<tr>
<th>Old</th><th>New</th>
</tr>
<tr>
<td>

```json
[
    34.212642,
    -118.765539,
    "Albertson Motorway"
]
```
</td>
<td>

```json
[
    34.2131066937852,
    -118.77435513389975,
    "Albertson Motorway"
]
```
</td>
</tr>
</table>

Looking at the data this is based on

```
❯ docker exec -it postgres psql -U librephotos
psql (14.3 (Debian 14.3-1.pgdg110+1))
Type "help" for help.

librephotos=>SELECT
                jsonb_extract_path_text("feature", 'text') "location"
                , jsonb_extract_path_text("feature", 'center', '0')
                , jsonb_extract_path_text("feature", 'center', '1')
            FROM
                "api_photo"
                , jsonb_array_elements(jsonb_extract_path("api_photo"."geolocation_json", 'features')) "feature"
            WHERE (
                "api_photo"."owner_id" = 1
                AND NOT (jsonb_extract_path_text("feature", 'text') ~ '^(-)?[0-9]+$') 
                AND jsonb_extract_path_text("feature", 'text') = 'Albertson Motorway'
            )
            ORDER BY
                "location";
      location      | jsonb_extract_path_text | jsonb_extract_path_text
--------------------+-------------------------+-------------------------
 Albertson Motorway | -118.77435513389975     | 34.2131066937852
 Albertson Motorway | -118.765539             | 34.212642
 Albertson Motorway | -118.76902              | 34.21227
 Albertson Motorway | -118.77778947224327     | 34.21313046635135
 Albertson Motorway | -118.7706               | 34.212324
 Albertson Motorway | -118.76902              | 34.21227
 Albertson Motorway | -118.76946946161694     | 34.21227492691228
 Albertson Motorway | -118.76528957590156     | 34.212641040676544
 Albertson Motorway | -118.76917433989823     | 34.212272051785945
 Albertson Motorway | -118.765539             | 34.212642
 Albertson Motorway | -118.76945875265037     | 34.21227488571074
 Albertson Motorway | -118.77426691188886     | 34.21311322874897
 Albertson Motorway | -118.76529759658607     | 34.212641071525326
 Albertson Motorway | -118.767988             | 34.212391
 Albertson Motorway | -118.767988             | 34.212391
 Albertson Motorway | -118.7679131168037      | 34.21241081036939
 Albertson Motorway | -118.77426691188886     | 34.21311322874897
 Albertson Motorway | -118.767988             | 34.212391
 Albertson Motorway | -118.770701             | 34.212369
 Albertson Motorway | -118.765539             | 34.212642
 Albertson Motorway | -118.785065             | 34.211886
 Albertson Motorway | -118.756957             | 34.211929
 Albertson Motorway | -118.756957             | 34.211929
 Albertson Motorway | -118.756957             | 34.211929
 Albertson Motorway | -118.756957             | 34.211929
 Albertson Motorway | -118.78574210856424     | 34.211788163770834
 Albertson Motorway | -118.7699823            | 34.2122769
 Albertson Motorway | -118.7949393            | 34.2110446
 Albertson Motorway | -118.76835              | 34.212322
 Albertson Motorway | -118.79325245109773     | 34.21076844046635
 Albertson Motorway | -118.76977146673944     | 34.212276088842856
 Albertson Motorway | -118.76990775111406     | 34.21227661318159
 Albertson Motorway | -118.765279             | 34.212641
 Albertson Motorway | -118.76528957590156     | 34.212641040676544
 Albertson Motorway | -118.765279             | 34.212641
(35 rows)

```

We can see that there are differences that resolve to the same main 'point' and that which one gets picked is different in Postgres and in Python.

But this is impossible to reproduce 100% in SQL unless we find out the internal sort order of unsorted things in Python.

2) order of the objects. It doesn't impact the rendered result however. For an explanation as to how the order is different, see the `api/locationsunburst` ordering explanation. 

### `api/locationsunburst`
After zeroing out the colors it is 99% identical.

The difference is in the sort order.

Consider the following letters: A, O, Ö, and Z. In Python sort it would be A, O, Z, Ö.  However in the Postgres sort it is be A, O, Ö, Z because that is where you expect them to be in a natural sort order. 

This exhibits in for example the following cities being sorted differently: 
```diff
{
    "name": "Veszprém",
    "children": [
        {
            "name": "Alsóörs",
            "value": 13,
            "hex": "#000000"
        },
        {
            "name": "Balatonalmádi",
            "value": 3,
            "hex": "#000000"
        },
        {
            "name": "Balatonfüred",
            "value": 32,
            "hex": "#000000"
        },
        {
            "name": "Felsőörs",
            "value": 4,
            "hex": "#000000"
        },
        {
            "name": "Monoszló",
            "value": 17,
            "hex": "#000000"
        },
+       {
+           "name": "Örvényes",
+           "value": 4,
+           "hex": "#000000"
+       },
        {
            "name": "Tapolca",
            "value": 16,
            "hex": "#000000"
        },
        {
            "name": "Tihany",
            "value": 32,
            "hex": "#000000"
        },
        {
            "name": "Veszprém",
            "value": 37,
            "hex": "#000000"
        },
-       {
-           "name": "Örvényes",
-           "value": 4,
-           "hex": "#000000"
-       }
    ],
    "hex": "#000000"
}
```

Let me know what you think!!!