### PR TITLE
Initial backend changes to sync python timezone list with client

### DIFF
--- a/api/date_time_extractor.py
+++ b/api/date_time_extractor.py
@@ -241,8 +241,8 @@ class TimeExtractionRule:
     def _check_condition_filename(self, path):
         if "condition_filename" in self.params:
             return (
-                re.search(self.params["condition_filename"], pathlib.Path(path).name)
-                is not None
+                    re.search(self.params["condition_filename"], pathlib.Path(path).name)
+                    is not None
             )
         else:
             return True
@@ -271,13 +271,13 @@ class TimeExtractionRule:
 
     def _check_conditions(self, path, exif_tags, gps_lat, gps_lon):
         return (
-            self._check_condition_exif(exif_tags)
-            and self._check_condition_path(path)
-            and self._check_condition_filename(path)
+                self._check_condition_exif(exif_tags)
+                and self._check_condition_path(path)
+                and self._check_condition_filename(path)
         )
 
     def apply(
-        self, path, exif_tags, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
+            self, path, exif_tags, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
     ):
         if not self._check_conditions(path, exif_tags, gps_lat, gps_lon):
             return None
@@ -376,13 +376,15 @@ class TimeExtractionRule:
 
 def _check_gps_ok(lat, lon):
     return (
-        lat is not None
-        and lon is not None
-        and math.isfinite(lat)
-        and math.isfinite(lon)
-        and (lat != 0.0 or lon != 0.0)
+            lat is not None
+            and lon is not None
+            and math.isfinite(lat)
+            and math.isfinite(lon)
+            and (lat != 0.0 or lon != 0.0)
     )
 
+
+ALL_TIME_ZONES = pytz.all_timezones
 
 DEFAULT_RULES_PARAMS = [
     {
@@ -503,6 +505,7 @@ def _as_json(configs):
 
 DEFAULT_RULES_JSON = _as_json(DEFAULT_RULES_PARAMS)
 PREDEFINED_RULES_JSON = _as_json(PREDEFINED_RULES_PARAMS)
+ALL_TIME_ZONES_JSON = _as_json(ALL_TIME_ZONES)
 
 
 def as_rules(configs):
@@ -510,7 +513,7 @@ def as_rules(configs):
 
 
 def extract_local_date_time(
-    path, rules, exif_getter, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
+        path, rules, exif_getter, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
 ):
     required_tags = set()
     for rule in rules:

--- a/api/date_time_extractor.py
+++ b/api/date_time_extractor.py
@@ -241,8 +241,8 @@ class TimeExtractionRule:
     def _check_condition_filename(self, path):
         if "condition_filename" in self.params:
             return (
-                    re.search(self.params["condition_filename"], pathlib.Path(path).name)
-                    is not None
+                re.search(self.params["condition_filename"], pathlib.Path(path).name)
+                is not None
             )
         else:
             return True
@@ -271,13 +271,13 @@ class TimeExtractionRule:
 
     def _check_conditions(self, path, exif_tags, gps_lat, gps_lon):
         return (
-                self._check_condition_exif(exif_tags)
-                and self._check_condition_path(path)
-                and self._check_condition_filename(path)
+            self._check_condition_exif(exif_tags)
+            and self._check_condition_path(path)
+            and self._check_condition_filename(path)
         )
 
     def apply(
-            self, path, exif_tags, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
+        self, path, exif_tags, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
     ):
         if not self._check_conditions(path, exif_tags, gps_lat, gps_lon):
             return None
@@ -376,11 +376,11 @@ class TimeExtractionRule:
 
 def _check_gps_ok(lat, lon):
     return (
-            lat is not None
-            and lon is not None
-            and math.isfinite(lat)
-            and math.isfinite(lon)
-            and (lat != 0.0 or lon != 0.0)
+        lat is not None
+        and lon is not None
+        and math.isfinite(lat)
+        and math.isfinite(lon)
+        and (lat != 0.0 or lon != 0.0)
     )
 
 
@@ -513,7 +513,7 @@ def as_rules(configs):
 
 
 def extract_local_date_time(
-        path, rules, exif_getter, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
+    path, rules, exif_getter, gps_lat, gps_lon, user_default_tz, user_defined_timestamp
 ):
     required_tags = set()
     for rule in rules:

--- a/api/views/timezone.py
+++ b/api/views/timezone.py
@@ -1,7 +1,6 @@
+from rest_framework.response import Response
 from rest_framework.views import APIView
 import api.date_time_extractor as date_time_extractor
-from rest_framework.response import Response
-import api.util as util
 
 
 class TimeZoneView(APIView):

--- a/api/views/timezone.py
+++ b/api/views/timezone.py
@@ -1,0 +1,9 @@
+from rest_framework.views import APIView
+import api.date_time_extractor as date_time_extractor
+from rest_framework.response import Response
+import api.util as util
+
+
+class TimeZoneView(APIView):
+    def get(self, request, format=None):
+        return Response(date_time_extractor.ALL_TIME_ZONES_JSON)

--- a/ownphotos/urls.py
+++ b/ownphotos/urls.py
@@ -39,6 +39,7 @@ from api.views import (
     upload,
     user,
     views,
+    timezone,
 )
 from nextcloud import views as nextcloud_views
 
@@ -244,6 +245,7 @@ urlpatterns = [
     url(r"^api/nextcloud/listdir", nextcloud_views.ListDir.as_view()),
     url(r"^api/nextcloud/scanphotos", nextcloud_views.ScanPhotosView.as_view()),
     url(r"^api/photos/download", views.ZipListPhotosView.as_view()),
+    url(r"^api/timezones", timezone.TimeZoneView.as_view()),
 ]
 urlpatterns += [url("api/django-rq/", include("django_rq.urls"))]
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/ownphotos/urls.py
+++ b/ownphotos/urls.py
@@ -36,10 +36,10 @@ from api.views import (
     photos,
     search,
     sharing,
+    timezone,
     upload,
     user,
     views,
-    timezone,
 )
 from nextcloud import views as nextcloud_views
 


### PR DESCRIPTION
This is the backend changes to create an API to send python's timezone list to the client. This allows the user to set their default timezone using the Settings page.

This also closes #440 