### PR TITLE
Fix issue with scan_photos needing a directory now

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -321,7 +321,7 @@ def initialize_scan_process(*args, **kwargs):
 
 
 @job
-def scan_photos(user, full_scan, job_id, scan_directory):
+def scan_photos(user, full_scan, job_id, scan_directory = ""):
     if not os.path.exists(
         os.path.join(ownphotos.settings.MEDIA_ROOT, "thumbnails_big")
     ):
@@ -343,6 +343,8 @@ def scan_photos(user, full_scan, job_id, scan_directory):
     photo_count_before = Photo.objects.count()
 
     try:
+        if scan_directory == "":
+            scan_directory = user.scan_directory
         photo_list = []
         walk_directory(scan_directory, photo_list)
         files_found = len(photo_list)

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -321,7 +321,7 @@ def initialize_scan_process(*args, **kwargs):
 
 
 @job
-def scan_photos(user, full_scan, job_id, scan_directory = ""):
+def scan_photos(user, full_scan, job_id, scan_directory=""):
     if not os.path.exists(
         os.path.join(ownphotos.settings.MEDIA_ROOT, "thumbnails_big")
     ):

--- a/api/management/commands/scan.py
+++ b/api/management/commands/scan.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 
 from api.directory_watcher import scan_photos
 from api.models import User
+from api.models.user import get_deleted_user
 from nextcloud.directory_watcher import scan_photos as scan_photos_nextcloud
 
 
@@ -30,8 +31,10 @@ class Command(BaseCommand):
             return
 
         # Directory scan
+        deleted_user: User = get_deleted_user()
         for user in User.objects.all():
-            scan_photos(user, options["full_scan"], uuid.uuid4())
+            if user != deleted_user:
+                scan_photos(user, options["full_scan"], uuid.uuid4(), user.scan_directory)
 
     def nextcloud_scan(self):
         for user in User.objects.all():

--- a/api/management/commands/scan.py
+++ b/api/management/commands/scan.py
@@ -34,7 +34,9 @@ class Command(BaseCommand):
         deleted_user: User = get_deleted_user()
         for user in User.objects.all():
             if user != deleted_user:
-                scan_photos(user, options["full_scan"], uuid.uuid4(), user.scan_directory)
+                scan_photos(
+                    user, options["full_scan"], uuid.uuid4(), user.scan_directory
+                )
 
     def nextcloud_scan(self):
         for user in User.objects.all():


### PR DESCRIPTION
The "scan" CLI command broken with the latest release, for some reason (although this hasn't been touched in a while). I updated "scan" to pass the scan directory in, then future-proofed the scan_photos command to make that an optional parameter as well.