### PR TITLE
Migrate Face Clustering to HDBSCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Step-by-step installation instructions are available in our [documentation](http
 - **Video Conversion:** [FFmpeg](https://github.com/FFmpeg/FFmpeg)
 - **Exif Support:** [ExifTool](https://github.com/exiftool/exiftool)
 - **Face detection:** [face_recognition](https://github.com/ageitgey/face_recognition) 
-- **Face classification/clusterization:** scikit-learn
+- **Face classification/clusterization:** [scikit-learn](https://scikit-learn.org/) and [hdbscan](https://github.com/scikit-learn-contrib/hdbscan)
 - **Image captioning:** [im2txt](https://github.com/HughKu/Im2txt), 
 - **Scene classification** [places365](http://places.csail.mit.edu/)
 - **Reverse geocoding:** [Mapbox](https://www.mapbox.com/): You need to have an API key. First 50,000 geocode lookups are free every month.

--- a/api/cluster_manager.py
+++ b/api/cluster_manager.py
@@ -15,7 +15,7 @@ class ClusterManager:
 
     @staticmethod
     def try_add_cluster(
-        user: User, cluster_id: int, faces: list[Face]
+        user: User, cluster_id: int, faces: list[Face], padLen: int = 1
     ) -> list[Cluster]:
         added_clusters: list[Cluster] = []
         known_faces: list[Face] = []
@@ -28,6 +28,7 @@ class ClusterManager:
         new_cluster: Cluster
         unknown_cluster: Cluster = get_unknown_cluster()
         unknown_person: Person = get_unknown_person()
+        labelStr = str(cluster_id + 1).zfill(padLen)
         for face in faces:
             if (
                 face.person.name == "unknown"
@@ -46,7 +47,7 @@ class ClusterManager:
                 new_person = unknown_person
             else:
                 new_person = get_or_create_person(
-                    name="Unknown " + str(cluster_id + 1), cluster_owner=user
+                    name="Unknown " + labelStr, cluster_owner=user
                 )
                 new_person.kind = Person.KIND_CLUSTER
                 new_person.cluster_owner = user

--- a/api/face_classify.py
+++ b/api/face_classify.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-
+from hdbscan import HDBSCAN
 import numpy as np
 import pytz
 import seaborn as sns
@@ -126,7 +126,8 @@ def create_all_clusters(user: User, lrj: LongRunningJob = None) -> int:
     if target_count == 0:
         return target_count
     # creating DBSCAN object for clustering the encodings with the metric "euclidean"
-    clt = DBSCAN(metric="euclidean", min_samples=2)
+    clt = HDBSCAN(min_cluster_size=2 ,metric="euclidean")
+    # clt = DBSCAN(metric="euclidean", min_samples=2)
 
     clt.fit(np.array(data["all"]["encoding"]))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ Flask-Cors==3.0.9
 Flask-RESTful==0.3.6
 geopy==2.1.0
 gunicorn==20.1.0
+hdbscan==0.8.28
 matplotlib==3.3.2 
 networkx==2.6.3
 nltk==3.6.7


### PR DESCRIPTION
After doing some testing, I think we should migrate the clustering algorithm to HDBSCAN instead of DBSCAN. The algorithm is less sensitive to noise, which should address some of the issues I've noticed with false clustering. This means that fewer faces will be clustered and more clusters created, but it is worth the tradeoff in that false clustering is a bigger problem to deal with (in that users need to manually adjust those). This should also improve our confidence in the clustering since there will be fewer false positives.

I've also bundled in a tweak so that the unknown people that get created have leading zeros added to the number in their names. For example, if we have 500 clusters of unknown people, we will label them "Unknown 001", "Unknown 002", ... , "Unknown 500" instead of 1, 2, ... 500. This allows the unknown people to sort more intelligently in the face dashboard.