### PR TITLE
Fix issue where all unknown faces get assigned

### DIFF
--- a/api/cluster_manager.py
+++ b/api/cluster_manager.py
@@ -72,7 +72,6 @@ class ClusterManager:
             idx: int = 0
             for face in known_faces:
                 if face.person.id not in clusters_by_person.keys():
-                    print("adding new cluster: {}".format(idx + 1))
                     idx = idx + 1
                     new_cluster = Cluster.get_or_create_cluster_by_name(
                         user, "Cluster " + str(cluster_id) + "-" + str(idx)
@@ -84,7 +83,6 @@ class ClusterManager:
                     encoding_by_person[face.person.id] = []
                     face_ids_by_cluster[new_cluster.id] = []
                 else:
-                    print("using existing cluster")
                     new_cluster = clusters_by_person[face.person.id]
                 encoding_by_person[face.person.id].append(face.get_encoding_array())
                 face_ids_by_cluster[new_cluster.id].append(face.id)
@@ -106,16 +104,24 @@ class ClusterManager:
 
             # Loop over all unknown faces and find the closest "known" cluster
             for face in unknown_faces:
-                closest_cluster: Cluster
-                min_distance: np.float64 = np.Infinity
                 encoding = face.get_encoding_array()
-                for new_cluster in added_clusters:
-                    distance = math.dist(
-                        encoding, mean_encoding_by_cluster[new_cluster.id]
-                    )
-                    if distance < min_distance:
-                        closest_cluster = new_cluster
-                        min_distance = distance
+                closest_cluster: Cluster
+                if cluster_id == UNKNOWN_CLUSTER_ID:
+                    closest_cluster = unknown_cluster
+                    if unknown_person.id not in clusters_by_person.keys():
+                        clusters_by_person[closest_cluster.person.id] = closest_cluster
+                        added_clusters.append(closest_cluster)
+                        encoding_by_person[closest_cluster.id] = []
+                        face_ids_by_cluster[closest_cluster.id] = []
+                else:
+                    min_distance: np.float64 = np.Infinity
+                    for new_cluster in added_clusters:
+                        distance = math.dist(
+                            encoding, mean_encoding_by_cluster[new_cluster.id]
+                        )
+                        if distance < min_distance:
+                            closest_cluster = new_cluster
+                            min_distance = distance
                 face_ids_by_cluster[closest_cluster.id].append(face.id)
                 encoding_by_person[closest_cluster.person.id].append(encoding)
             for new_cluster in added_clusters:
@@ -124,7 +130,7 @@ class ClusterManager:
                         id__in=face_ids_by_cluster[new_cluster.id]
                     ).update(
                         cluster=new_cluster,
-                        person_label_is_inferred=None,
+                        person_label_is_inferred=False,
                         person=new_cluster.person,
                     )
                 else:

--- a/api/cluster_manager.py
+++ b/api/cluster_manager.py
@@ -125,7 +125,7 @@ class ClusterManager:
                 face_ids_by_cluster[closest_cluster.id].append(face.id)
                 encoding_by_person[closest_cluster.person.id].append(encoding)
             for new_cluster in added_clusters:
-                if new_cluster.person is unknown_person:
+                if new_cluster is unknown_cluster:
                     Face.objects.filter(
                         id__in=face_ids_by_cluster[new_cluster.id]
                     ).update(

--- a/api/face_classify.py
+++ b/api/face_classify.py
@@ -254,7 +254,10 @@ def train_faces(user: User, job_id) -> bool:
                     zip(data["unknown"]["id"], probs)
                 ):
                     face = Face.objects.get(id=face_id)
-                    face.person_label_is_inferred = True
+                    if face.person is unknown_person:
+                        face.person_label_is_inferred = False
+                    else:
+                        face.person_label_is_inferred = True
                     probability: np.float64 = 0
 
                     # Find the probability in the probability array corresponding to the person

--- a/api/models/cluster.py
+++ b/api/models/cluster.py
@@ -52,8 +52,9 @@ def get_unknown_cluster() -> Cluster:
     unknown_cluster: Cluster = Cluster.get_or_create_cluster_by_id(
         get_deleted_user(), UNKNOWN_CLUSTER_ID
     )
-    if unknown_cluster.person is None:
-        unknown_cluster.person = get_unknown_person()
+    unknown_person: Person = get_unknown_person()
+    if unknown_cluster.person is not unknown_person:
+        unknown_cluster.person = unknown_person
         unknown_cluster.name = UNKNOWN_CLUSTER_NAME
         unknown_cluster.save()
     return unknown_cluster


### PR DESCRIPTION
This fixes an issue where labeling at least one face inside the "Unknown - Other" cluster would cause all faces in that cluster to be inferred as a real person. This is inappropriate because these faces are noise points (by definition), so the probabilities were all really low and caused false clustering.