### PR TITLE
Add option to scan a list of files

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -263,11 +263,7 @@ def rescan_image(user, image_path, job_id):
 
 
 def walk_directory(directory, callback):
-    if os.path.isfile(directory):
-        callback.append(directory)
-        return
     for file in os.scandir(directory):
-        print(f"file is {file}")
         fpath = os.path.join(directory, file)
         if not is_hidden(fpath) and not should_skip(fpath):
             if os.path.isdir(fpath):
@@ -278,7 +274,7 @@ def walk_directory(directory, callback):
 
 def walk_files(scan_files, callback):
     for fpath in scan_files:
-        if os.path.isfile(fpath) and not is_hidden(fpath) and not should_skip(fpath):
+        if os.path.isfile(fpath):
             callback.append(fpath)
 
 
@@ -369,8 +365,6 @@ def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=[]):
             walk_files(scan_files, photo_list)
         else:
             walk_directory(scan_directory, photo_list)
-        print(f"Photo list is {photo_list}")
-        return
         files_found = len(photo_list)
         last_scan = (
             LongRunningJob.objects.filter(finished=True)

--- a/api/management/commands/scan.py
+++ b/api/management/commands/scan.py
@@ -18,6 +18,9 @@ class Command(BaseCommand):
             "-f", "--full-scan", help=("Run full directory scan"), action="store_true"
         )
         parser_group.add_argument(
+            "-s", "--scan-files", help=("Scan a list of files"), nargs='+', default=[]
+        )
+        parser_group.add_argument(
             "-n",
             "--nextcloud",
             help=("Run nextcloud scan instead of directory scan"),
@@ -28,6 +31,23 @@ class Command(BaseCommand):
         # Nextcloud scan
         if options["nextcloud"]:
             self.nextcloud_scan()
+            return
+
+        # Add a single file.
+        if options["scan_files"]:
+            scan_files = options["scan_files"]
+            deleted_user: User = get_deleted_user()
+            for user in User.objects.all():
+                user_files = []
+                if user == deleted_user:
+                    continue
+                for scan_file in scan_files:
+                    if scan_file.startswith(user.scan_directory):
+                        user_files.append(scan_file)
+                if user_files:
+                    scan_photos(
+                        user, options["full_scan"], uuid.uuid4(), scan_files=user_files
+                    )
             return
 
         # Directory scan

--- a/api/management/commands/scan.py
+++ b/api/management/commands/scan.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                         user_files.append(scan_file)
                 if user_files:
                     scan_photos(
-                        user, options["full_scan"], uuid.uuid4(), scan_files=user_files
+                        user, False, uuid.uuid4(), scan_files=user_files
                     )
             return
 


### PR DESCRIPTION
This PR adds the ability to scan only single files by passing the flag `--scan-files FILE1 FILE2 FILE3 ...` to the `manage.py scan` command.

This can be useful if another tool (such as `inotifywait`) is used to monitor the data folder for changes. When a change is detected, `manage.py scan` can be called with just the newly added photos and videos which significantly reduces the processing time needed to complete the scan.

Example usage:
```
sudo docker exec --user root backend python3 manage.py scan --scan-files /data/photo1.jpg /data/photo2.jpg /data/photo5.jpg
```