### PR TITLE
fix setuptools version for use_2to3

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+setuptools==57.5.0
 ipdb==0.10.3
 ipython==8.0.1
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ pyvips==2.2.1
 rq==1.10.1
 seaborn==0.11.0
 sentence_transformers==1.2.0
+setuptools==57.5.0
 sklearn==0.0
 timezonefinder==5.2.0
 tqdm==4.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ pyvips==2.2.1
 rq==1.10.1
 seaborn==0.11.0
 sentence_transformers==1.2.0
-setuptools==57.5.0
 sklearn==0.0
 timezonefinder==5.2.0
 tqdm==4.51.0


### PR DESCRIPTION
Recently I started having issues when rebuilding the backend from scratch. I did not do much investigation as to why this started to happen now but fixating setuptools version to 57 fixes the issue when building.

```
...
Step 6/9 : RUN if [ "$DEBUG" = 1 ] ; then pip install -r requirements.dev.txt ;  fi                                                                                                                                  
 ---> Running in 8b7eec42e78e                                                                                                                                                                                        
Collecting ipdb==0.10.3                                                                                                                                                                                              
  Downloading ipdb-0.10.3.tar.gz (9.4 kB)                                                                                                                                                                            
  Preparing metadata (setup.py): started                                                                                                                                                                             
  Preparing metadata (setup.py): finished with status 'error'                                                                                                                                                        
  error: subprocess-exited-with-error                                                                                                                                                                                
                                                                                                                                                                                                                     
  × python setup.py egg_info did not run successfully.                                                                                                                                                               
  │ exit code: 1                                                                                                                                                                                                     
  ╰─> [1 lines of output]                                                                                                                                                                                            
      error in ipdb setup command: use_2to3 is invalid.                                                                                                                                                              
      [end of output]  
...
```