### PR TITLE
use hdbscan from github

### DIFF
--- a/api/migrations/0031_remove_account.py
+++ b/api/migrations/0031_remove_account.py
@@ -6,17 +6,16 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('api', '0030_user_confidence_person'),
+        ("api", "0030_user_confidence_person"),
     ]
 
     operations = [
         migrations.AlterModelManagers(
-            name='albumdate',
-            managers=[
-            ],
+            name="albumdate",
+            managers=[],
         ),
         migrations.RemoveField(
-            model_name='person',
-            name='account',
+            model_name="person",
+            name="account",
         ),
     ]

--- a/api/views/albums.py
+++ b/api/views/albums.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 
 from django.db.models import Count, F, Prefetch, Q

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ Flask-Cors==3.0.9
 Flask-RESTful==0.3.9
 geopy==2.1.0
 gunicorn==20.1.0
-hdbscan==0.8.28
+git+https://github.com/scikit-learn-contrib/hdbscan@ccd8535#egg=hdbscan
 matplotlib==3.3.2 
 networkx==2.6.3
 nltk==3.6.7


### PR DESCRIPTION
There are errors when starting the backend component:

```
...
  File "/code/api/face_classify.py", line 10, in <module>
    from hdbscan import HDBSCAN
  File "/usr/local/lib/python3.10/dist-packages/hdbscan/__init__.py", line 1, in <module>
    from .hdbscan_ import HDBSCAN, hdbscan
  File "/usr/local/lib/python3.10/dist-packages/hdbscan/hdbscan_.py", line 509, in <module>
    memory=Memory(cachedir=None, verbose=0),
TypeError: Memory.__init__() got an unexpected keyword argument 'cachedir'
...
```

The problem appears that the version of hdbscan wrongly uses arguments. The fix is here https://github.com/scikit-learn-contrib/hdbscan/pull/563

Latest version in PyPI was published 8 Feb 2022 and it does not work (produces errors shown above)