### PR TITLE
Add sort by date on faces dashboard

### DIFF
--- a/api/views/faces.py
+++ b/api/views/faces.py
@@ -49,7 +49,7 @@ class FaceListView(ListViewSet):
     def get_queryset(self):
         personid = self.request.query_params.get("person")
         inferred = False
-        orderBy = ["-person_label_probability", "id"]
+        order_by = ["-person_label_probability", "id"]
         conditional_filter = Q(person_label_is_inferred=inferred) | Q(
             person__name=Person.UNKNOWN_PERSON_NAME
         )
@@ -61,7 +61,7 @@ class FaceListView(ListViewSet):
             conditional_filter = Q(person_label_is_inferred=inferred)
         if self.request.query_params.get("orderby"):
             if self.request.query_params.get("orderby").lower() == "date":
-                orderBy = ["photo__exif_timestamp", "-person_label_probability", "id"]
+                order_by = ["photo__exif_timestamp", "-person_label_probability", "id"]
         return (
             Face.objects.filter(
                 Q(photo__owner=self.request.user),
@@ -69,7 +69,7 @@ class FaceListView(ListViewSet):
                 conditional_filter,
             )
             .prefetch_related("photo")
-            .order_by(*orderBy)
+            .order_by(*order_by)
         )
 
     @extend_schema(

--- a/api/views/faces.py
+++ b/api/views/faces.py
@@ -49,6 +49,7 @@ class FaceListView(ListViewSet):
     def get_queryset(self):
         personid = self.request.query_params.get("person")
         inferred = False
+        orderBy = ["-person_label_probability", "id"]
         conditional_filter = Q(person_label_is_inferred=inferred) | Q(
             person__name=Person.UNKNOWN_PERSON_NAME
         )
@@ -58,6 +59,9 @@ class FaceListView(ListViewSet):
         ):
             inferred = True
             conditional_filter = Q(person_label_is_inferred=inferred)
+        if self.request.query_params.get("orderby"):
+            if self.request.query_params.get("orderby").lower() == "date":
+                orderBy = ["photo__exif_timestamp", "-person_label_probability", "id"]
         return (
             Face.objects.filter(
                 Q(photo__owner=self.request.user),
@@ -65,7 +69,7 @@ class FaceListView(ListViewSet):
                 conditional_filter,
             )
             .prefetch_related("photo")
-            .order_by("-person_label_probability", "id")
+            .order_by(*orderBy)
         )
 
     @extend_schema(

--- a/api/views/faces.py
+++ b/api/views/faces.py
@@ -59,8 +59,8 @@ class FaceListView(ListViewSet):
         ):
             inferred = True
             conditional_filter = Q(person_label_is_inferred=inferred)
-        if self.request.query_params.get("orderby"):
-            if self.request.query_params.get("orderby").lower() == "date":
+        if self.request.query_params.get("order_by"):
+            if self.request.query_params.get("order_by").lower() == "date":
                 order_by = ["photo__exif_timestamp", "-person_label_probability", "id"]
         return (
             Face.objects.filter(
@@ -76,6 +76,7 @@ class FaceListView(ListViewSet):
         parameters=[
             OpenApiParameter("person", OpenApiTypes.STR),
             OpenApiParameter("inferred", OpenApiTypes.BOOL),
+            OpenApiParameter("order_by", OpenApiTypes.STR),
         ],
     )
     def list(self, *args, **kwargs):


### PR DESCRIPTION
Working on implementing feature request #655
Change order_by in query to retrieve faces to order result either by descending confidence score or ascending date.
I still have a few issues to fix before validating this PR.