### PR TITLE
Fix nextcloud scan to include only Nextcloud enabled user

### DIFF
--- a/api/management/commands/scan.py
+++ b/api/management/commands/scan.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
 
     def nextcloud_scan(self):
         for user in User.objects.all():
-            if not user.scan_directory:
+            if not user.nextcloud_scan_directory:
                 print(
                     f"Skipping nextcloud scan for user {user.username}. No scan directory configured."
                 )


### PR DESCRIPTION
When running CLI scan on nextcloud enabled users, nextcloud is scanning all users and not just nextcloud enabled.

by changing the attribute used to confirm if user has a nextcloud scan directory. we add jobs for the nextcloud only users.