### PR TITLE
trigger face training using POST

### DIFF
--- a/api/views/faces.py
+++ b/api/views/faces.py
@@ -32,7 +32,8 @@ class ScanFacesView(APIView):
 
 
 class TrainFaceView(APIView):
-    def get(self, request, format=None):
+    @staticmethod
+    def _train_faces(request):
         try:
             job_id = uuid.uuid4()
             cluster_all_faces.delay(request.user, job_id)
@@ -40,6 +41,13 @@ class TrainFaceView(APIView):
         except BaseException:
             logger.exception()
             return Response({"status": False})
+
+    @extend_schema(deprecated=True)
+    def get(self, request, format=None):
+        return self._train_faces(request)
+
+    def post(self, request, format=None):
+        return self._train_faces(request)
 
 
 class FaceListView(ListViewSet):


### PR DESCRIPTION
There are a couple of reasons for this change:
— Currently, faces training can be triggered using HTTP GET operation. In frontend, this creates a cached version of a training response, and all subsequent calls to train faces won't be triggered because RTK will return a cached version of the very first response. I think there is a way to invalidate the cache entry, but the solution is too complex for such a trivial operation.
— It's cleaner to have a write operation to request to train faces because it is a command-like request.

Keeping GET handler for the time being so existing clients don't break.

There will be another PR for frontend to fix faces training button behavior that will use POST request.