### PR TITLE
Fixed warning of unused statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ api/places365/*.tar.gz
 *.db
 media*
 protected_media
+
+# Vim
+*.swp
+*.swo

--- a/api/serializers/photos.py
+++ b/api/serializers/photos.py
@@ -55,7 +55,7 @@ class PigPhotoSerilizer(serializers.ModelSerializer):
         if obj.exif_timestamp:
             return obj.exif_timestamp.isoformat()
         else:
-            None
+            return ""
 
     def get_video_length(self, obj) -> int:
         if obj.video_length:


### PR DESCRIPTION
Fixed the issue that Sonarcloud declares: [sonarcloud](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&id=LibrePhotos_ownphotos&open=AYK7XSE4y_u9xfhLvveD).

Also added vim swap file extensions to .gitignore for contributers that use vim.