### PR TITLE
pin scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ PyExifTool==0.4.9
 PyJWT==2.4.0
 pyvips==2.2.1
 rq==1.14.1
+scikit-learn<1.3.0
 seaborn==0.11.0
 sentence_transformers==2.2.2
 sklearn==0.0


### PR DESCRIPTION
The backend container for librephotos-docker is throwing an exception on startup:

```
  File "/usr/local/lib/python3.11/dist-packages/hdbscan/hdbscan_.py", line 40, in <module>
    FAST_METRICS = KDTree.valid_metrics + BallTree.valid_metrics + ["cosine", "arccos"]
                   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'builtin_function_or_method' and 'builtin_function_or_method'
```

It looks like this is due to a bug introduced in a newer version of scikit-learn: https://github.com/scikit-learn-contrib/hdbscan/issues/597

If I pin `scikit-learn`, the container starts successfully. 