### PR TITLE
Fix write_meatadata call, change this.main_file to this.main_file.path

### DIFF
--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -152,7 +152,7 @@ class Photo(models.Model):
             # To-Do: Only works for files and not for the sidecar file
             tags_to_write[Tags.DATE_TIME] = self.timestamp
         if tags_to_write:
-            util.write_metadata(self.main_file, tags_to_write, use_sidecar=use_sidecar)
+            util.write_metadata(self.main_file.path, tags_to_write, use_sidecar=use_sidecar)
 
     def _generate_captions_im2txt(self, commit=True):
         image_path = self.thumbnail_big.path


### PR DESCRIPTION
current code will throw an exception when set or unset favorite to a photo.

  File "/code/api/views/photos.py", line 276, in post
    photo.save()
  File "/code/api/models/photo.py", line 136, in save
    self._save_metadata(
  File "/code/api/models/photo.py", line 155, in _save_metadata
    util.write_metadata(self.main_file, tags_to_write, use_sidecar=use_sidecar)
  File "/code/api/util.py", line 163, in write_metadata
    params.append(os.fsencode(file_path))
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 812, in fsencode
TypeError: expected str, bytes or os.PathLike object, not File