### PR TITLE
Remove django-bulk-update from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ django-cryptography==1.1
 django-extensions==3.2.3
 django-filter==23.3
 django-picklefield==3.1
-django-bulk-update
 django-silk==5.0.4
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.3.0


### PR DESCRIPTION
The django-bulk-update module hasn't been updated since 2018, it is probably abandonware.

It isn't used anywhere in the codebase, so remove it from requirements.txt.