### PR TITLE
Replace pylint, black and isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@ default_language_version:
   python: python3
 
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
+      - id: ruff
+        args:
+          - --fix
+      - id: ruff-format
+      
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
@@ -18,3 +18,4 @@ repos:
           - --exclude=.+/migrations/
           - --max-line-length=88
           - --ignore=E501,W503,E203
+  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,5 @@ repos:
           - --fix
       - id: ruff-format
       
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        args:
-          - --exclude=.+/migrations/
-          - --max-line-length=88
-          - --ignore=E501,W503,E203
+
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,12 @@ max-line-length = 88
 
 [tool.isort]
 profile = "black"
+
+[tool.ruff]
+select = [
+    # isort
+    "I001"
+]
+line-length = 88
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,9 @@
-[tool.black]
-line-length = 88
-target-version = ['py311']
-include = '\.pyi?$' # all files that end with .py or .pyi
-
-[tool.pylint.master]
-load-plugins = 'pylint_django'
-django-settings-module = 'ownphotos.settings'
-disable = 'E029,C0111,C0301'
-
-[tool.pylint.format]
-max-line-length = 88
-
-[tool.isort]
-profile = "black"
-
 [tool.ruff]
 select = [
-    # isort
-    "I001"
+    "I001",
+    "YTT",
 ]
+exclude = ["migrations"]
 line-length = 88
 
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,14 +4,10 @@ ipython-genutils==0.2.0
 Pygments==2.15.0
 prompt-toolkit==3.0.38
 nose==1.3.7
-pylint==2.17.2
-pylint-django==2.5.3
-flake8==6.0.0
 pre-commit==2.14.0
 coverage==7.1.0
 Faker==17.6.0
-isort==5.12.0
 setuptools==67.6.1
-black==23.3.0
 pyfakefs==5.2.0
 pytest==7.3.1
+ruff==0.1.3


### PR DESCRIPTION
Issue Link: #778  @derneuere 
what has been done :
- edited `.pre-commit-config.yaml` file for adding ruff
- edited `pyproject.toml` for the same