### PR TITLE
Revert "Update dependency Django to v5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.0.1
+Django==4.2.9
 django-constance==3.1.0
 django-cors-headers==4.3.1
 git+https://github.com/derneuere/django-chunked-upload@master#egg=django-chunked-upload


### PR DESCRIPTION
Reverts LibrePhotos/librephotos#1091

Issue we hit is this dependency: https://github.com/georgemarshall/django-cryptography/issues/74