### PR TITLE
Improved service management

### DIFF
--- a/api/management/commands/start_service.py
+++ b/api/management/commands/start_service.py
@@ -1,0 +1,71 @@
+import subprocess
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Start one of the services."
+
+    # Define all the services that can be started
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "service",
+            type=str,
+            help="The service to start",
+            choices=[
+                "image_similarity",
+                "thumbnail",
+                "face_recognition",
+                "clip_embeddings",
+                "image_captioning",
+                "llm",
+            ],
+        )
+
+    def handle(self, *args, **kwargs):
+        service = kwargs["service"]
+
+        if service == "image_similarity":
+            subprocess.Popen(
+                [
+                    "python",
+                    "image_similarity/main.py",
+                    "2>&1 | tee /logs/image_similarity.log",
+                ]
+            )
+        elif service == "thumbnail":
+            subprocess.Popen(
+                [
+                    "python",
+                    "service/thumbnail/main.py",
+                    "2>&1 | tee /logs/thumbnail.log",
+                ]
+            )
+        elif service == "face_recognition":
+            subprocess.Popen(
+                [
+                    "python",
+                    "service/face_recognition/main.py",
+                    "2>&1 | tee /logs/face_recognition.log",
+                ]
+            )
+        elif service == "clip_embeddings":
+            subprocess.Popen(
+                [
+                    "python",
+                    "service/clip_embeddings/main.py",
+                    "2>&1 | tee /logs/clip_embeddings.log",
+                ]
+            )
+        elif service == "image_captioning":
+            subprocess.Popen(
+                [
+                    "python",
+                    "service/image_captioning/main.py",
+                    "2>&1 | tee /logs/image_captioning.log",
+                ]
+            )
+        elif service == "llm":
+            subprocess.Popen(
+                ["python", "service/llm/main.py", "2>&1 | tee /logs/llm.log"]
+            )

--- a/api/services.py
+++ b/api/services.py
@@ -1,0 +1,53 @@
+import subprocess
+
+import requests
+
+from api.util import logger
+
+# Define all the services that can be started, with their respective ports
+SERVICES = {
+    "image_similarity": 8002,
+    "thumbnail": 8003,
+    "face_recognition": 8005,
+    "clip_embeddings": 8006,
+    "llm": 8008,
+    "image_captioning": 8007,
+}
+
+
+def check_services():
+    for service in SERVICES.keys():
+        if not is_healthy(service):
+            logger.info(f"Starting {service}")
+            start_service(service)
+
+
+def is_healthy(service):
+    port = SERVICES.get(service)
+    try:
+        res = requests.get(f"http://localhost:{port}/health")
+        return res.status_code == 200
+    except BaseException as e:
+        logger.warning(f"Error checking health of {service}: {str(e)}")
+        return False
+
+
+def start_service(service):
+    if service == "image_similarity":
+        subprocess.Popen(
+            [
+                "python",
+                "image_similarity/main.py",
+                "2>&1 | tee /logs/image_similarity.log",
+            ]
+        )
+    elif service in SERVICES.keys():
+        subprocess.Popen(
+            [
+                "python",
+                f"service/{service}/main.py",
+                "2>&1 | tee /logs/{service}.log",
+            ]
+        )
+    else:
+        logger.warning("Unknown service:", service)

--- a/api/views/services.py
+++ b/api/views/services.py
@@ -1,0 +1,69 @@
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+
+from api.services import SERVICES, is_healthy, start_service, stop_service
+
+
+class ServiceViewSet(viewsets.ViewSet):
+    permission_classes = [IsAdminUser]
+
+    def list(self, request):
+        return Response({"services": SERVICES})
+
+    def retrieve(self, request, pk=None):
+        service_name = pk
+
+        if service_name not in SERVICES:
+            return Response(
+                {"error": f"Service {service_name} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        healthy = is_healthy(service_name)
+        return Response({"service_name": service_name, "healthy": healthy})
+
+    @action(detail=True, methods=["post"])
+    def start(self, request, pk=None):
+        service_name = pk
+
+        if service_name not in SERVICES:
+            return Response(
+                {"error": f"Service {service_name} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        start_result = start_service(service_name)
+        if start_result:
+            return Response(
+                {"message": f"Service {service_name} started successfully"},
+                status=status.HTTP_200_OK,
+            )
+        else:
+            return Response(
+                {"error": f"Failed to start service {service_name}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    @action(detail=True, methods=["post"])
+    def stop(self, request, pk=None):
+        service_name = pk
+
+        if service_name not in SERVICES:
+            return Response(
+                {"error": f"Service {service_name} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        stop_result = stop_service(service_name)
+        if stop_result:
+            return Response(
+                {"message": f"Service {service_name} stopped successfully"},
+                status=status.HTTP_200_OK,
+            )
+        else:
+            return Response(
+                {"error": f"Failed to stop service {service_name}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/image_similarity/main.py
+++ b/image_similarity/main.py
@@ -1,6 +1,5 @@
 import json
 
-import gevent
 from flask import Flask, jsonify, request
 from flask_restful import Api, Resource
 from gevent.pywsgi import WSGIServer
@@ -51,11 +50,21 @@ class SearchIndex(Resource):
             return jsonify({"status": False, "result": []}), 500
 
 
+class Health(Resource):
+    def get(self):
+        return jsonify({"status": True})
+
+
 api.add_resource(BuildIndex, "/build/")
 api.add_resource(SearchIndex, "/search/")
+api.add_resource(Health, "/health/")
+
+
+def start_server():
+    logger.info("Starting server")
+    server = WSGIServer(("0.0.0.0", 8002), app)
+    server.serve_forever()
+
 
 if __name__ == "__main__":
-    logger.info("starting server")
-    server = WSGIServer(("0.0.0.0", 8002), app)
-    server_thread = gevent.spawn(server.serve_forever)
-    gevent.joinall([server_thread])
+    start_server()

--- a/librephotos/urls.py
+++ b/librephotos/urls.py
@@ -33,6 +33,7 @@ from api.views import (
     jobs,
     photos,
     search,
+    services,
     sharing,
     timezone,
     upload,
@@ -170,8 +171,9 @@ router.register(
 router.register(r"api/faces", faces.FaceListView, basename="faces")
 
 router.register(r"api/exists", upload.UploadPhotoExists, basename="photo_exists")
-
 router.register(r"api/jobs", jobs.LongRunningJobViewSet, basename="jobs")
+router.register(r"api/services", services.ServiceViewSet, basename="service")
+
 urlpatterns = [
     re_path(r"^", include(router.urls)),
     re_path(r"^api/django-admin/", admin.site.urls),

--- a/service/clip_embeddings/main.py
+++ b/service/clip_embeddings/main.py
@@ -41,6 +41,11 @@ def calculate_query_embeddings():
     return {"emb": emb, "magnitude": magnitude}, 201
 
 
+@app.route("/health", methods=["GET"])
+def health():
+    return "OK", 200
+
+
 if __name__ == "__main__":
     log("service starting")
     server = WSGIServer(("0.0.0.0", 8006), app)

--- a/service/face_recognition/main.py
+++ b/service/face_recognition/main.py
@@ -48,6 +48,11 @@ def create_face_locations():
     return {"face_locations": face_locations}, 201
 
 
+@app.route("/health", methods=["GET"])
+def health():
+    return "OK", 200
+
+
 if __name__ == "__main__":
     log("service starting")
     server = WSGIServer(("0.0.0.0", 8005), app)

--- a/service/image_captioning/main.py
+++ b/service/image_captioning/main.py
@@ -64,6 +64,11 @@ def export_onnx():
     return "", 200
 
 
+@app.route("/health", methods=["GET"])
+def health():
+    return "OK", 200
+
+
 def check_inactivity():
     global last_request_time
     idle_threshold = 120

--- a/service/llm/main.py
+++ b/service/llm/main.py
@@ -35,6 +35,11 @@ def generate_prompt():
     return {"prompt": output}, 201
 
 
+@app.route("/health", methods=["GET"])
+def health():
+    return "OK", 200
+
+
 if __name__ == "__main__":
     log("service starting")
     server = WSGIServer(("0.0.0.0", 8008), app)

--- a/service/thumbnail/main.py
+++ b/service/thumbnail/main.py
@@ -31,6 +31,11 @@ def create_thumbnail():
     return {"thumbnail": destination}, 201
 
 
+@app.route("/health", methods=["GET"])
+def health():
+    return "OK", 200
+
+
 if __name__ == "__main__":
     log("service starting")
     server = WSGIServer(("0.0.0.0", 8003), app)


### PR DESCRIPTION
This pull request addresses #1124. 
The services now get started with Django and there is a cron job, which checks if the service is still running.

There are now a bunch of new endpoints:

[GET] /services/: List all services
[GET] /services/<service_name>/: Retrieve the health status of a service
[POST] /services/<service_name>/start/: Start a service
[POST] /services/<service_name>/stop/: Stop a service

Current limitations:
All stopped jobs, would start again on the reboot of the container as they are currently not persisted.
Maybe the implementation is a bit naive, I just start the process as sub processes and the keep in them in a list, if I want to terminate them.

Needs to be merged with: https://github.com/LibrePhotos/librephotos-docker/pull/122