### PR TITLE
Adapt tests

### DIFF
--- a/api/tests/test_delete_photos.py
+++ b/api/tests/test_delete_photos.py
@@ -62,7 +62,7 @@ class DeletePhotosTest(TestCase):
         self.assertEqual(0, len(data["updated"]))
         self.assertEqual(2, len(data["not_updated"]))
 
-    @patch("api.util.logger.warning", autospec=True)
+    @patch("api.views.photos.logger.warning", autospec=True)
     def test_tag_for_removal_nonexistent_photo(self, logger):
         payload = {"image_hashes": ["nonexistent_photo"], "deleted": True}
         headers = {"Content-Type": "application/json"}

--- a/api/tests/test_favorite_photos.py
+++ b/api/tests/test_favorite_photos.py
@@ -64,7 +64,7 @@ class FavoritePhotosTest(TestCase):
         self.assertEqual(0, len(data["updated"]))
         self.assertEqual(2, len(data["not_updated"]))
 
-    @patch("api.util.logger.warning", autospec=True)
+    @patch("api.views.photos.logger.warning", autospec=True)
     def test_tag_nonexistent_photo_as_favorite(self, logger):
         payload = {"image_hashes": ["nonexistent_photo"], "favorite": True}
         headers = {"Content-Type": "application/json"}

--- a/api/tests/test_geocode.py
+++ b/api/tests/test_geocode.py
@@ -82,31 +82,31 @@ class OpenCageLocation:
 class TestGeocodeParsers(TestCase):
     def test_mapbox_parser(self):
         for index, raw in enumerate(mapbox_responses):
-            self.assertEquals(
+            self.assertEqual(
                 parse_mapbox(MapboxLocation(raw)), mapbox_expectations[index]
             )
 
     def test_tomtom_parser(self):
         for index, raw in enumerate(tomtom_responses):
-            self.assertEquals(
+            self.assertEqual(
                 parse_tomtom(TomTomLocation(raw)), tomtom_expectations[index]
             )
 
     def test_photon_parser(self):
         for index, raw in enumerate(photon_responses):
-            self.assertEquals(
+            self.assertEqual(
                 parse_photon(PhotonLocation(raw)), photon_expectations[index]
             )
 
     def test_nominatim_parser(self):
         for index, raw in enumerate(nominatim_responses):
-            self.assertEquals(
+            self.assertEqual(
                 parse_nominatim(NominatimLocation(raw)), nominatim_expectations[index]
             )
 
     def test_opencage_parser(self):
         for index, raw in enumerate(opencage_responses):
-            self.assertEquals(
+            self.assertEqual(
                 parse_opencage(OpenCageLocation(raw)), opencage_expectations[index]
             )
 
@@ -138,11 +138,11 @@ class TestGeocoder(TestCase):
     def test_reverse_geocode(self, get_geocoder_for_service_mock):
         get_geocoder_for_service_mock.return_value = fake_geocoder(mapbox_responses[1])
         result = reverse_geocode(0, 0)
-        self.assertEquals(result, mapbox_expectations[1])
+        self.assertEqual(result, mapbox_expectations[1])
 
     @override_config(MAP_API_PROVIDER="mapbox")
     @override_config(MAP_API_KEY="")
     def test_reverse_geocode_no_api_key(self):
         result = reverse_geocode(0, 0)
         print(result)
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})

--- a/api/tests/test_hide_photos.py
+++ b/api/tests/test_hide_photos.py
@@ -62,7 +62,7 @@ class FavoritePhotosTest(TestCase):
         self.assertEqual(0, len(data["updated"]))
         self.assertEqual(2, len(data["not_updated"]))
 
-    @patch("api.util.logger.warning", autospec=True)
+    @patch("api.views.photos.logger.warning", autospec=True)
     def test_tag_nonexistent_photo_as_favorite(self, logger):
         payload = {"image_hashes": ["nonexistent_photo"], "hidden": True}
         headers = {"Content-Type": "application/json"}

--- a/api/tests/test_public_photos.py
+++ b/api/tests/test_public_photos.py
@@ -1,9 +1,14 @@
+import logging
+import unittest.mock
 from unittest.mock import patch
 
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from api.tests.utils import create_test_photos, create_test_user
+
+
+logger = logging.getLogger(__name__)
 
 
 class PublicPhotosTest(TestCase):
@@ -61,19 +66,20 @@ class PublicPhotosTest(TestCase):
         self.assertEqual(0, len(data["updated"]))
         self.assertEqual(2, len(data["not_updated"]))
 
-    @patch("api.util.logger.warning", autospec=True)
-    def test_tag_nonexistent_photo_as_favorite(self, logger):
+    @patch("api.views.photos.logger.warning", autospec=True)
+    def test_tag_nonexistent_photo_as_favorite(self, logger_ext: unittest.mock.Mock):
         payload = {"image_hashes": ["nonexistent_photo"], "val_public": True}
         headers = {"Content-Type": "application/json"}
         response = self.client.post(
             "/api/photosedit/makepublic/", format="json", data=payload, headers=headers
         )
         data = response.json()
+        logger.debug(data)
 
         self.assertTrue(data["status"])
         self.assertEqual(0, len(data["results"]))
         self.assertEqual(0, len(data["updated"]))
         self.assertEqual(0, len(data["not_updated"]))
-        logger.assert_called_with(
+        logger_ext.assert_called_with(
             "Could not set photo nonexistent_photo to public. It does not exist."
         )

--- a/api/tests/test_share_photos.py
+++ b/api/tests/test_share_photos.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import skip
 
 from django.test import TestCase
@@ -5,6 +6,9 @@ from rest_framework.test import APIClient
 
 from api.models import Photo
 from api.tests.utils import create_test_photos, create_test_user, share_test_photos
+
+
+logger = logging.getLogger(__name__)
 
 
 class SharePhotosTest(TestCase):
@@ -20,7 +24,7 @@ class SharePhotosTest(TestCase):
 
         payload = {
             "image_hashes": image_hashes,
-            "shared": True,
+            "val_shared": True,
             "target_user_id": self.user2.id,
         }
         headers = {"Content-Type": "application/json"}
@@ -45,7 +49,7 @@ class SharePhotosTest(TestCase):
 
         payload = {
             "image_hashes": image_hashes,
-            "shared": False,
+            "val_shared": False,
             "target_user_id": self.user2.id,
         }
         headers = {"Content-Type": "application/json"}
@@ -70,7 +74,7 @@ class SharePhotosTest(TestCase):
 
         payload = {
             "image_hashes": image_hashes,
-            "shared": True,
+            "val_shared": True,
             "target_user_id": self.user1.id,
         }
         headers = {"Content-Type": "application/json"}

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 from constance.test import override_config
@@ -7,6 +8,9 @@ from rest_framework.test import APIClient
 
 from api.models import User
 from api.tests.utils import create_test_user, create_user_details
+
+
+logger = logging.getLogger(__name__)
 
 
 def delete_all_users():
@@ -58,6 +62,7 @@ class UserTest(TestCase):
         "confidence_unknown_face",
         "min_samples",
         "cluster_selection_epsilon",
+        "llm_settings",
     ]
 
     def setUp(self):
@@ -70,7 +75,7 @@ class UserTest(TestCase):
     def test_public_user_list_count(self):
         response = self.client.get("/api/user/")
         data = response.json()
-        self.assertEquals(
+        self.assertEqual(
             len(User.objects.filter(public_sharing=True)), len(data["results"])
         )
 
@@ -86,16 +91,24 @@ class UserTest(TestCase):
         self.client.force_authenticate(user=self.user1)
         response = self.client.get("/api/user/")
         data = response.json()
-        self.assertEquals(len(User.objects.all()), len(data["results"]))
+        self.assertEqual(len(User.objects.all()), len(data["results"]))
 
     def test_authenticated_user_list_properties(self):
         self.client.force_authenticate(user=self.user1)
         response = self.client.get("/api/user/")
         data = response.json()
+        logger.debug(data)
+
         for user in data["results"]:
-            self.assertEqual(len(self.private_user_properties), len(user.keys()))
             for key in self.private_user_properties:
                 self.assertTrue(key in user, f"user does not have key: {key}")
+            for key in user:
+                self.assertTrue(
+                    key in self.private_user_properties,
+                    f"user has superfluous key: {key}"
+                )
+
+            self.assertEqual(len(self.private_user_properties), len(user.keys()))
 
     def test_user_update_self(self):
         self.client.force_authenticate(user=self.user1)

--- a/api/views/views.py
+++ b/api/views/views.py
@@ -695,7 +695,6 @@ class ZipListPhotosView_V2(APIView):
 
 class DeleteZipView(APIView):
     def delete(self, request, fname):
-        print("hello")
         jwt = request.COOKIES.get("jwt")
         if jwt is not None:
             try:


### PR DESCRIPTION
- Changed patched logger to use the one from file (I find it easier to work with a new logger per file `logger = logging.getLogger(__name__)` and to include the logger name in the log message; the change supports both variants)
- assertEquals -> assertEqual (this has been deprecated since 3.1 and has [now been removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#id3))
- SharePhotosTest: `shared` -> `val_shared` (not sure, but since the FE also uses val_shared, I assume this is correct)
- test_user: added `llm_settings`

The following tests did not work with `python manage.py test` and I couldn't figure out how to adapt them:
- api/tests/test_photo_summary.py: the whole `PhotoSummaryViewTest` (`reverse("photo-summary",..)` fails as there is no endpoint)
- api/tests/test_reading_exif.py: `ReadFacesFromPhotosTest.test_reading_from_photo` (in `get_face_encodings()` it tries to connect to `http://localhost:8005/face-encodings`, but the tests do not start this endpoint - maybe this should be mocked)
