### PR TITLE
refactor scan methods to use post

### DIFF
--- a/api/tests/test_public_photos.py
+++ b/api/tests/test_public_photos.py
@@ -7,7 +7,6 @@ from rest_framework.test import APIClient
 
 from api.tests.utils import create_test_photos, create_test_user
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/api/tests/test_share_photos.py
+++ b/api/tests/test_share_photos.py
@@ -7,7 +7,6 @@ from rest_framework.test import APIClient
 from api.models import Photo
 from api.tests.utils import create_test_photos, create_test_user, share_test_photos
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -9,7 +9,6 @@ from rest_framework.test import APIClient
 from api.models import User
 from api.tests.utils import create_test_user, create_user_details
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -105,7 +104,7 @@ class UserTest(TestCase):
             for key in user:
                 self.assertTrue(
                     key in self.private_user_properties,
-                    f"user has superfluous key: {key}"
+                    f"user has superfluous key: {key}",
                 )
 
             self.assertEqual(len(self.private_user_properties), len(user.keys()))

--- a/api/views/views.py
+++ b/api/views/views.py
@@ -228,7 +228,17 @@ class SearchTermExamples(APIView):
 
 # long running jobs
 class ScanPhotosView(APIView):
+    def post(self, request, format=None):
+        self._scan_photos(request)
+
+    @extend_schema(
+        deprecated=True,
+        description="Use POST method instead",
+    )
     def get(self, request, format=None):
+        self._scan_photos(request)
+
+    def _scan_photos(self, request):
         chain = Chain()
         if not do_all_models_exist():
             chain.append(download_models, request.user)
@@ -268,7 +278,17 @@ class SelectiveScanPhotosView(APIView):
 
 
 class FullScanPhotosView(APIView):
+    def post(self, request, format=None):
+        self._scan_photos(request)
+
+    @extend_schema(
+        deprecated=True,
+        description="Use POST method instead",
+    )
     def get(self, request, format=None):
+        self._scan_photos(request)
+
+    def _scan_photos(self, request):
         chain = Chain()
         if not do_all_models_exist():
             chain.append(download_models, request.user)

--- a/nextcloud/views.py
+++ b/nextcloud/views.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 import owncloud as nextcloud
 from django_q.tasks import AsyncTask
+from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -48,7 +49,17 @@ def valid_url(url):
 
 
 class ScanPhotosView(APIView):
+    def post(self, request, format=None):
+        self._scan_photos(request)
+
+    @extend_schema(
+        deprecated=True,
+        description="Use POST method instead",
+    )
     def get(self, request, format=None):
+        self._scan_photos(request)
+
+    def _scan_photos(self, request):
         try:
             job_id = uuid.uuid4()
             AsyncTask(scan_photos, request.user, job_id).run()


### PR DESCRIPTION
Deprecate get methods for triggering scan
This makes the API a tiny bit more RESTful and a POST method (mutation) is required in the frontend to invalidate cached entries (when we will have them)