### PR TITLE
Reduced scan photos cost

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -363,8 +363,6 @@ def scan_missing_photos(user, job_id: UUID):
             update_scan_counter(job_id)
 
         util.logger.info("Finished checking paths for missing photos")
-        lrj.finished = True
-        lrj.save()
     except Exception:
         util.logger.exception("An error occurred: ")
         lrj.failed = True

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -449,6 +449,7 @@ def generate_tags(user, job_id: UUID, full_scan=False):
             lrj.progress_target = 0
             lrj.progress_current = 0
             lrj.finished = True
+            lrj.finished_at = datetime.datetime.now().replace(tzinfo=pytz.utc)
             lrj.save()
             return
         lrj.progress_target = existing_photos.count()
@@ -505,6 +506,7 @@ def add_geolocation(user, job_id: UUID, full_scan=False):
         if existing_photos.count() == 0:
             lrj.progress_target = 0
             lrj.finished = True
+            lrj.finished_at = datetime.datetime.now().replace(tzinfo=pytz.utc)
             lrj.progress_current = 0
             lrj.save()
             return
@@ -565,6 +567,7 @@ def scan_faces(user, job_id: UUID, full_scan=False):
             lrj.progress_current = 0
             lrj.progress_target = 0
             lrj.finished = True
+            lrj.finished_at = datetime.datetime.now().replace(tzinfo=pytz.utc)
             lrj.save()
             return
 

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -362,7 +362,6 @@ def scan_missing_photos(user, job_id: UUID):
 
         util.logger.info("Finished checking paths for missing photos")
         lrj.finished = True
-        lrj.save()
     except Exception:
         util.logger.exception("An error occurred: ")
         lrj.failed = True

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -323,10 +323,11 @@ def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=[]):
 
         util.logger.info("Finished updating album things")
 
+        # AsyncTask(batch_calculate_clip_embedding, user).run()
         AsyncTask(scan_missing_photos, user, uuid.uuid4()).run()
         AsyncTask(generate_tags, user, uuid.uuid4(), full_scan).run()
         AsyncTask(add_geolocation, user, uuid.uuid4(), full_scan).run()
-        AsyncTask(batch_calculate_clip_embedding, user).run()
+        batch_calculate_clip_embedding(user)
         AsyncTask(scan_faces, user, uuid.uuid4(), full_scan).run()
 
     except Exception:

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -557,8 +557,9 @@ def scan_faces(user, job_id: UUID, full_scan=False):
             failed = False
             try:
                 photo._extract_faces()
-            except Exception:
+            except Exception as err:
                 util.logger.exception("An error occurred: ")
+                print("[ERR]: {}".format(err))
                 failed = True
             update_scan_counter(job_id, failed)
     except Exception as err:

--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -352,16 +352,19 @@ def scan_missing_photos(user, job_id: UUID):
     lrj.save()
     try:
         exisisting_photos = Photo.objects.filter(owner=user.id).order_by("image_hash")
-        lrj.progress_target = exisisting_photos.count()
 
         paginator = Paginator(exisisting_photos, 5000)
+        lrj.progress_target = paginator.num_pages
+        lrj.save()
         for page in range(1, paginator.num_pages + 1):
             for existing_photo in paginator.page(page).object_list:
                 existing_photo._check_files()
-                update_scan_counter(job_id)
+
+            update_scan_counter(job_id)
 
         util.logger.info("Finished checking paths for missing photos")
         lrj.finished = True
+        lrj.save()
     except Exception:
         util.logger.exception("An error occurred: ")
         lrj.failed = True

--- a/api/models/long_running_job.py
+++ b/api/models/long_running_job.py
@@ -19,6 +19,7 @@ class LongRunningJob(models.Model):
     JOB_ADD_GEOLOCATION = 11
     JOB_GENERATE_TAGS = 12
     JOB_GENERATE_FACE_EMBEDDINGS = 13
+    JOB_SCAN_MISSING_PHOTOS = 14
 
     JOB_TYPES = (
         (JOB_SCAN_PHOTOS, "Scan Photos"),
@@ -34,6 +35,7 @@ class LongRunningJob(models.Model):
         (JOB_ADD_GEOLOCATION, "Add Geolocation"),
         (JOB_GENERATE_TAGS, "Generate Tags"),
         (JOB_GENERATE_FACE_EMBEDDINGS, "Generate Face Embeddings"),
+        (JOB_SCAN_MISSING_PHOTOS, "Scan Missing Photos"),
     )
 
     job_type = models.PositiveIntegerField(


### PR DESCRIPTION
I reduced the cost of re-scanning for new photos, in both the general case of using the rescan button, or in the case of manually specifying a list of specific files:

- Separated scanning for missing photos into a separate task, allowing it to run asynchronously in conjunction with the other tasks related to rescanning
  - Additionally, added behavior to inhibit this task if the scan task was run with either a specified scan directory other than the user's scan directory, or if the task was run with specifying individual files to scan. This behavior was added due to the cost of rescanning the entire library, when just adding a couple pictures.
- For the tasks related to the ingestion of new photos, JOB_SCAN_FACES, JOB_ADD_GEOLOCATION, and JOB_GENERATE_TAGS:
  - If not present, added an argument to specify a full scan
  - Add a check for when the last scan of the type was, and only scan photos that have been added since then. For some, this behavior was already present, but was implemented on the backend, with a for loop moving over all the images and only doing anything if the upload date was after the last scan. The new behavior uses the database to handle that query, vastly decreasing overall computational workload. 
  - Moved the scan faces task to a task chain, completed after the generate embeds task, as it fails if embeds for newly added photos have not yet been generated. 

As I use a script to only ingest files that have been added, instead of re-scanning the whole library, this has brought my scans down from taking 20-40 minutes, to taking less than a minute. However, major speedups are also present on the normal scan, as this avoids fetching massive amounts of data from the database just to not use it. 