### PR TITLE
Resolve logger warnings

### DIFF
--- a/api/tests/test_im2txt.py
+++ b/api/tests/test_im2txt.py
@@ -107,18 +107,18 @@ class Im2TxtBenchmark(TestCase):
         )
 
         if not os.path.exists(self.coco_fixture_path):
-            logger.warn(
+            logger.warning(
                 f"Skipping tests. Directory not found: {self.coco_fixture_path}. Please add a coco folder to the fixtures directory."
             )
             self.skipTest("Directory not found")
 
         if not os.path.exists(self.val2017_fixture_path):
-            logger.warn(
+            logger.warning(
                 f"Skipping tests. Directory not found: {self.val2017_fixture_path}. Validation images are required for the COCO benchmark. Please download the COCO validation images and place them in the fixtures/coco/val2017 directory."
             )
             self.skipTest("Directory not found")
         if not os.path.exists(self.val2017captions_fixture_path):
-            logger.warn(
+            logger.warning(
                 f"Skipping tests. Directory not found: {self.val2017captions_fixture_path}. Captions of Validation images are required for the COCO benchmark. Please download the COCO validation images and place them in the fixtures/coco/ directory."
             )
             self.skipTest("Directory not found")

--- a/service/image_captioning/api/im2txt/blip/med.py
+++ b/service/image_captioning/api/im2txt/blip/med.py
@@ -473,7 +473,7 @@ class BertEncoder(nn.Module):
 
             if self.gradient_checkpointing and self.training:
                 if use_cache:
-                    logger.warn(
+                    logger.warning(
                         "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                     )
                     use_cache = False


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```