### PR TITLE
Revert "chore(deps): update dependency networkx to v3.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ geopy==2.4.1
 gunicorn==23.0.0
 hdbscan==0.8.40
 matplotlib==3.10.3
-networkx==3.5
+networkx==3.4.2
 nltk==3.9.1
 markupsafe==3.0.2
 Pillow==11.3.0


### PR DESCRIPTION
Reverts LibrePhotos/librephotos#1597

networkx==3.5 erfordert mindestens python 3.9 docker-gpu läuft auf python 3.8