### PR TITLE
Fix path validation to prevent traversal

### DIFF
--- a/api/util.py
+++ b/api/util.py
@@ -26,7 +26,20 @@ def is_valid_path(path, root_path):
     abs_path = os.path.abspath(path)
     abs_root = os.path.abspath(root_path)
 
-    return abs_path.startswith(abs_root)
+    try:
+        common = os.path.commonpath([abs_path, abs_root])
+    except ValueError:
+        # Raised when paths are on different drives
+        return False
+
+    if common != abs_root:
+        return False
+
+    # Guard against paths that merely share a prefix with the root path
+    # (e.g. /root and /root_dir). By normalising with os.path.commonpath
+    # and checking for path separators we ensure the path really resides
+    # within the root directory or is the directory itself.
+    return abs_path == abs_root or abs_path.startswith(abs_root + os.sep)
 
 
 def is_number(s):


### PR DESCRIPTION
## Summary
- tighten `is_valid_path` to confirm resolved paths remain within the configured root
- handle cross-drive paths gracefully and avoid accepting sibling directories that share prefixes

## Testing
- pytest *(fails: missing Django and other dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f105d756108327b4f87b3dfccb5b83