### PR TITLE
Fix album date exists checks

### DIFF
--- a/api/models/photo.py
+++ b/api/models/photo.py
@@ -177,7 +177,7 @@ class Photo(models.Model):
                 possible_old_album_date is not None
                 and possible_old_album_date.photos.filter(
                     image_hash=self.image_hash
-                ).exists
+                ).exists()
             ):
                 old_album_date = possible_old_album_date
         else:
@@ -188,7 +188,7 @@ class Photo(models.Model):
                 possible_old_album_date is not None
                 and possible_old_album_date.photos.filter(
                     image_hash=self.image_hash
-                ).exists
+                ).exists()
             ):
                 old_album_date = possible_old_album_date
         return old_album_date


### PR DESCRIPTION
## Summary
- ensure album date lookup filters call QuerySet.exists() correctly in Photo._find_album_date

## Testing
- pytest api/tests/test_photo_model_integration.py *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68f10b817cf48327aff4bffa60fbda6a