### PR TITLE
Ensure scan_photos creates thumbnail directories idempotently

### DIFF
--- a/api/directory_watcher.py
+++ b/api/directory_watcher.py
@@ -260,10 +260,13 @@ def photo_scanner(user, last_scan, full_scan, path, job_id):
 
 
 def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=[]):
-    if not os.path.exists(os.path.join(settings.MEDIA_ROOT, "thumbnails_big")):
-        os.mkdir(os.path.join(settings.MEDIA_ROOT, "square_thumbnails_small"))
-        os.mkdir(os.path.join(settings.MEDIA_ROOT, "square_thumbnails"))
-        os.mkdir(os.path.join(settings.MEDIA_ROOT, "thumbnails_big"))
+    thumbnail_dirs = [
+        os.path.join(settings.MEDIA_ROOT, "square_thumbnails_small"),
+        os.path.join(settings.MEDIA_ROOT, "square_thumbnails"),
+        os.path.join(settings.MEDIA_ROOT, "thumbnails_big"),
+    ]
+    for directory in thumbnail_dirs:
+        os.makedirs(directory, exist_ok=True)
     if LongRunningJob.objects.filter(job_id=job_id).exists():
         lrj = LongRunningJob.objects.get(job_id=job_id)
         lrj.started_at = datetime.datetime.now().replace(tzinfo=pytz.utc)

--- a/api/tests/test_scan_photos_directories.py
+++ b/api/tests/test_scan_photos_directories.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+import uuid
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from api.directory_watcher import scan_photos
+from api.tests.utils import create_test_user
+
+
+class DummyAsyncTask:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run(self):
+        return None
+
+
+class DummyChain:
+    def __init__(self, *args, **kwargs):
+        self.appended = []
+
+    def append(self, *args, **kwargs):
+        self.appended.append((args, kwargs))
+        return self
+
+    def run(self):
+        return None
+
+
+class ScanPhotosDirectoryCreationTest(TestCase):
+    def test_existing_thumbnail_directory_does_not_raise(self):
+        user = create_test_user()
+        with tempfile.TemporaryDirectory() as media_root:
+            preexisting_dir = os.path.join(media_root, "square_thumbnails_small")
+            os.makedirs(preexisting_dir, exist_ok=True)
+
+            user.scan_directory = media_root
+            user.save(update_fields=["scan_directory"])
+
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch("api.directory_watcher.walk_directory"), patch(
+                    "api.directory_watcher.walk_files"
+                ), patch("api.directory_watcher.photo_scanner"), patch(
+                    "api.directory_watcher.AsyncTask", DummyAsyncTask
+                ), patch("api.directory_watcher.Chain", DummyChain):
+                    scan_photos(user, full_scan=False, job_id=str(uuid.uuid4()))
+
+            expected_directories = [
+                "square_thumbnails_small",
+                "square_thumbnails",
+                "thumbnails_big",
+            ]
+            for directory_name in expected_directories:
+                directory_path = os.path.join(media_root, directory_name)
+                self.assertTrue(
+                    os.path.isdir(directory_path),
+                    msg=f"Expected directory {directory_path} to exist",
+                )


### PR DESCRIPTION
## Summary
- update `scan_photos` to create each thumbnail directory with `os.makedirs(..., exist_ok=True)`
- add a regression test that pre-creates one thumbnail directory and ensures `scan_photos` finishes and all directories exist

## Testing
- `BASE_LOGS=/workspace/librephotos/tmp_logs NO_COVERAGE=1 python manage.py test api.tests.test_scan_photos_directories -v 2` *(fails: missing libmagic system dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68f113095cb08327acc437ab847a863c