### PR TITLE
Fix encoding of X-Accel-Redirect for original photo paths

### DIFF
--- a/api/views/views.py
+++ b/api/views/views.py
@@ -858,7 +858,7 @@ class UnifiedMediaAccessView(APIView):
                     )
                 else:
                     internal_path = quote(photo.main_file.path)
-                response["X-Accel-Redirect"] = internal_path
+                response["X-Accel-Redirect"] = iri_to_uri(internal_path)
                 return response
             try:
                 mime = magic.Magic(mime=True)
@@ -897,7 +897,7 @@ class UnifiedMediaAccessView(APIView):
                 response["Content-Disposition"] = 'inline; filename="{}"'.format(
                     photo.main_file.path.split("/")[-1]
                 )
-                response["X-Accel-Redirect"] = internal_path
+                response["X-Accel-Redirect"] = iri_to_uri(internal_path)
                 return response
             return self._serve_file_direct(photo.main_file.path)
         else:
@@ -924,7 +924,7 @@ class UnifiedMediaAccessView(APIView):
                             )
                         else:
                             internal_path = quote(photo.main_file.path)
-                        response["X-Accel-Redirect"] = internal_path
+                        response["X-Accel-Redirect"] = iri_to_uri(internal_path)
                         return response
                     return self._serve_file_direct(photo.main_file.path)
         return HttpResponse(status=404)


### PR DESCRIPTION
## Summary
- ensure X-Accel-Redirect headers produced by UnifiedMediaAccessView use iri_to_uri for original photos served via the proxy
- prevent nginx from receiving unencoded file paths containing non-ASCII characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6ad3ae118832784c8968e268c1da9