### PR TITLE
Fix PhotoViewSet permissions for writes

### DIFF
--- a/api/tests/test_photo_viewset_permissions.py
+++ b/api/tests/test_photo_viewset_permissions.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.tests.utils import (
+    create_test_photo,
+    create_test_user,
+    share_test_photos,
+)
+
+
+class PhotoViewSetPermissionsTest(TestCase):
+    def setUp(self):
+        self.owner = create_test_user()
+        self.other_user = create_test_user()
+        self.photo = create_test_photo(owner=self.owner)
+        self.url = f"/api/photos/{self.photo.image_hash}/"
+
+    def test_owner_can_update_photo(self):
+        client = APIClient()
+        client.force_authenticate(user=self.owner)
+
+        response = client.patch(self.url, {"rating": 5}, format="json")
+
+        self.assertEqual(200, response.status_code)
+        self.photo.refresh_from_db()
+        self.assertEqual(5, self.photo.rating)
+
+    def test_non_owner_cannot_update_photo(self):
+        share_test_photos([self.photo.image_hash], self.other_user)
+        client = APIClient()
+        client.force_authenticate(user=self.other_user)
+
+        response = client.patch(self.url, {"rating": 3}, format="json")
+
+        self.assertEqual(403, response.status_code)
+        self.photo.refresh_from_db()
+        self.assertNotEqual(3, self.photo.rating)

--- a/api/views/photos.py
+++ b/api/views/photos.py
@@ -370,7 +370,10 @@ class PhotoViewSet(viewsets.ModelViewSet):
         if self.action in ("list", "retrieve", "summary"):
             permission_classes = [IsPhotoOrAlbumSharedTo]
         else:  # pragma: no cover - unused
-            permission_classes = [IsAdminUser or IsOwnerOrReadOnly]
+            if getattr(self.request, "user", None) and self.request.user.is_staff:
+                permission_classes = [IsAdminUser]
+            else:
+                permission_classes = [IsOwnerOrReadOnly]
         return [permission() for permission in permission_classes]
 
     def get_queryset(self):


### PR DESCRIPTION
## Summary
- ensure PhotoViewSet uses the correct instantiated permission classes for write operations
- add regression tests covering owner write access and non-owner rejection

## Testing
- NO_COVERAGE=1 python manage.py test api.tests.test_photo_viewset_permissions *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68f88b03e4ac8327b35cf6838093c7fd