### PR TITLE
Fix Nextcloud URL validation and add tests

### DIFF
--- a/nextcloud/tests/test_valid_url.py
+++ b/nextcloud/tests/test_valid_url.py
@@ -1,0 +1,31 @@
+import pytest
+
+from nextcloud.utils import valid_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com",
+        "http://example.com/path",
+        "https://example.com:8080/",
+    ],
+)
+def test_valid_url_accepts_http_urls(url):
+    assert valid_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a url",
+        "ftp://example.com",
+        "javascript:alert('xss')",
+        "//missing-scheme.com",
+        "https://",
+        None,
+    ],
+)
+def test_valid_url_rejects_invalid_urls(url):
+    assert valid_url(url) is False

--- a/nextcloud/utils.py
+++ b/nextcloud/utils.py
@@ -1,0 +1,38 @@
+"""Utility helpers for Nextcloud integrations."""
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+def valid_url(url: str | None) -> bool:
+    """Validate that *url* is an HTTP(S) URL with a host component.
+
+    The previous implementation only attempted to ``urlparse`` the string,
+    which mistakenly accepted inputs such as ``javascript:alert(1)`` or
+    ``ftp://example.com`` because ``urlparse`` rarely raises exceptions.
+    We now ensure that the scheme is HTTP(S) and that a network location is
+    present before treating the address as valid.
+    """
+
+    if not isinstance(url, str):
+        return False
+
+    candidate = url.strip()
+    if not candidate:
+        return False
+
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return False
+
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        return False
+
+    if not parsed.netloc:
+        return False
+
+    return True

--- a/nextcloud/views.py
+++ b/nextcloud/views.py
@@ -1,6 +1,4 @@
 import uuid
-from urllib.parse import urlparse
-
 import owncloud as nextcloud
 from django_q.tasks import AsyncTask
 from drf_spectacular.utils import extend_schema
@@ -9,6 +7,7 @@ from rest_framework.views import APIView
 
 from api.util import logger
 from nextcloud.directory_watcher import scan_photos
+from nextcloud.utils import valid_url
 
 
 class ListDir(APIView):
@@ -38,15 +37,6 @@ class ListDir(APIView):
             )
         except nextcloud.HTTPResponseError:
             return Response(status=400)
-
-
-def valid_url(url):
-    try:
-        urlparse(url)
-        return True
-    except BaseException:
-        return False
-
 
 class ScanPhotosView(APIView):
     def post(self, request, format=None):


### PR DESCRIPTION
## Summary
- tighten validation of Nextcloud server URLs and reuse the helper in views
- add a dedicated utility module and tests covering valid and invalid URLs

## Testing
- pytest nextcloud/tests/test_valid_url.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f88f568e108327b5d9c9b04ff7a184