### PR TITLE
backend: run delete_missing_photos as background task

### DIFF
--- a/apps/backend/api/tests/test_delete_missing_photos.py
+++ b/apps/backend/api/tests/test_delete_missing_photos.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.autoalbum import delete_missing_photos
+from api.tests.utils import create_test_user
+
+
+class DeleteMissingPhotosAsyncTaskTest(TestCase):
+    """Guards the AsyncTask wrap in DeleteMissingPhotosView._delete_missing_photos.
+
+    Before this fix the work ran synchronously in the request thread, so libraries
+    with many missing photos timed out the gunicorn worker (issues #1405, #672).
+    The endpoint must return immediately and hand the work to django-q2.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+
+    def test_post_queues_async_task_and_returns_immediately(self):
+        with patch("api.views.views.AsyncTask") as async_task_cls:
+            response = self.client.post("/api/deletemissingphotos/")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["status"])
+        self.assertIn("job_id", data)
+
+        async_task_cls.assert_called_once()
+        args = async_task_cls.call_args.args
+        self.assertIs(args[0], delete_missing_photos)
+        self.assertEqual(args[1], self.user)
+        self.assertEqual(str(args[2]), data["job_id"])
+        async_task_cls.return_value.run.assert_called_once_with()

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -454,7 +454,7 @@ class DeleteMissingPhotosView(APIView):
     def _delete_missing_photos(self, request, format=None):
         try:
             job_id = uuid.uuid4()
-            delete_missing_photos(request.user, job_id)
+            AsyncTask(delete_missing_photos, request.user, job_id).run()
             return Response({"status": True, "job_id": job_id})
         except BaseException:
             logger.exception("An Error occurred")


### PR DESCRIPTION
This is the first of a few fixes that are a result of long troubleshooting when deleting large amounts of images.

DeleteMissingPhotosView was calling delete_missing_photos synchronously inside the request thread. On a library with many missing photos (#1405 reports ~400k), gunicorn killed the worker on timeout, surfacing as GreenletExit / SystemExit: 1 and leaving the job hung from the user's perspective.

Mirror the existing pattern used by scan_missing_photos in api/directory_watcher/scan_jobs.py: wrap the call in AsyncTask(...).run() so it executes on the django-q2 worker. The HTTP response now returns immediately with the job_id, and the user can poll job status normally.

Fixes #1405. Related: #672.