### PR TITLE
backend: guard album-date geolocation against missing/short places (#…

### DIFF
--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -371,14 +371,12 @@ class Photo(models.Model):
             self.save()
 
     def _add_location_to_album_dates(self):
-        if not self.geolocation_json:
-            return
-        if len(self.geolocation_json["places"]) < 2:
-            logger.info(self.geolocation_json)
+        places = (self.geolocation_json or {}).get("places") or []
+        if len(places) < 2:
             return
 
         album_date = self._find_album_date()
-        city_name = self.geolocation_json["places"][-2]
+        city_name = places[-2]
         if album_date.location and len(album_date.location) > 0:
             prev_value = album_date.location
             new_value = prev_value

--- a/apps/backend/api/tests/test_photo_model_integration.py
+++ b/apps/backend/api/tests/test_photo_model_integration.py
@@ -340,3 +340,52 @@ class PhotoModelIntegrationTest(TestCase):
         photos = list(photo_qs)
         self.assertEqual(len(photos), 1)
         self.assertEqual(photos[0].search_instance.search_location, "New York")
+
+
+class AddLocationToAlbumDatesTest(TestCase):
+    """Regression tests for Photo._add_location_to_album_dates (issue #1268).
+
+    The function reaches into geolocation_json["places"][-2] to pick a city name.
+    Real-world data is messy: photos may have no geolocation, a partial geocode
+    result, only a country-level place, or stale-format JSON missing the
+    "places" key entirely. None of those should crash the rescan job.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user, exif_timestamp=timezone.now())
+
+    def test_does_not_crash_when_geolocation_json_is_none(self):
+        self.photo.geolocation_json = None
+        self.photo._add_location_to_album_dates()
+
+    def test_does_not_crash_when_geolocation_json_is_empty_dict(self):
+        self.photo.geolocation_json = {}
+        self.photo._add_location_to_album_dates()
+
+    def test_does_not_crash_when_places_key_is_missing(self):
+        # Legacy-format records seen in long-lived databases (the schema
+        # carried a top-level "city" before commit 134e8847 in 2023).
+        self.photo.geolocation_json = {"city": "Berlin", "_v": "1"}
+        self.photo._add_location_to_album_dates()
+
+    def test_does_not_crash_when_places_is_empty(self):
+        self.photo.geolocation_json = {"places": []}
+        self.photo._add_location_to_album_dates()
+
+    def test_does_not_crash_when_places_has_one_entry(self):
+        # Remote locations where the geocoder only resolves the country.
+        self.photo.geolocation_json = {"places": ["Antarctica"]}
+        self.photo._add_location_to_album_dates()
+
+    def test_writes_city_to_album_date_location(self):
+        album_date = AlbumDate.objects.create(
+            date=self.photo.exif_timestamp.date(), owner=self.user
+        )
+        album_date.photos.add(self.photo)
+
+        self.photo.geolocation_json = {"places": ["Berlin", "Germany"]}
+        self.photo._add_location_to_album_dates()
+
+        album_date.refresh_from_db()
+        self.assertEqual(album_date.location, {"places": ["Berlin"]})


### PR DESCRIPTION
…1268)

_add_location_to_album_dates reads geolocation_json["places"][-2] to pick the city out of the geocode result. The existing length guard prevents the IndexError that was reported in the issue, but it still KeyErrors on records that lack a "places" key altogether — possible either from a partial geocode result or from stale-format JSON written before the schema moved off a top-level "city" field in 2023.

Pull the array via .get() with an empty-list fallback, collapse the two early-return guards into one, and drop the logger.info that was firing on every photo with a short places list (very common for rural or poorly-geocoded photos — turned into background-job noise).

Adds an AddLocationToAlbumDatesTest class covering None, empty-dict, missing-places-key, empty-places, single-entry, and the happy two-entry path that writes the city to AlbumDate.location.