### PR TITLE
backend: pad get_metadata short returns with None

### DIFF
--- a/apps/backend/api/metadata/reader.py
+++ b/apps/backend/api/metadata/reader.py
@@ -50,4 +50,10 @@ def get_metadata(media_file, tags, try_sidecar=True, struct=False):
         "struct": struct,
     }
     response = requests.post("http://localhost:8010/get-tags", json=json).json()
-    return response["values"]
+    values = response["values"]
+    # The exif service can return fewer values than requested if exiftool
+    # errors mid-loop. Callers unpack the result positionally, so pad with
+    # None to honor the documented one-value-per-tag contract.
+    if len(values) < len(tags):
+        values = list(values) + [None] * (len(tags) - len(values))
+    return values

--- a/apps/backend/api/tests/test_metadata_reader.py
+++ b/apps/backend/api/tests/test_metadata_reader.py
@@ -1,0 +1,54 @@
+"""Regression tests for ``api.metadata.reader.get_metadata``.
+
+The exif service (``service/exif/main.py``) can return a ``values`` list
+shorter than the requested ``tags`` list — for example, when exiftool raises
+mid-loop, the partial list is returned with HTTP 201.  Several callers
+unpack the result positionally (``a, b = get_metadata(...)``) and crash with
+``ValueError: not enough values to unpack`` when that happens.
+
+These tests exercise the padding contract documented in the function's
+docstring: one value per tag, ``None`` when the tag was not found.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from api.metadata.reader import get_metadata
+
+
+class GetMetadataPaddingTest(SimpleTestCase):
+    def _mock_response(self, values):
+        response = MagicMock()
+        response.json.return_value = {"values": values}
+        return response
+
+    @patch("api.metadata.reader.requests.post")
+    def test_returns_values_when_service_returns_expected_count(self, mock_post):
+        mock_post.return_value = self._mock_response([12.34, 56.78])
+
+        result = get_metadata("/tmp/photo.jpg", tags=["GPS:Latitude", "GPS:Longitude"])
+
+        self.assertEqual(result, [12.34, 56.78])
+
+    @patch("api.metadata.reader.requests.post")
+    def test_pads_with_none_when_service_returns_empty_list(self, mock_post):
+        # Reproduces the crash seen in production: exiftool errored on the
+        # first tag, so the service returned an empty list and the caller
+        # crashed unpacking two values.
+        mock_post.return_value = self._mock_response([])
+
+        result = get_metadata("/tmp/photo.jpg", tags=["GPS:Latitude", "GPS:Longitude"])
+
+        self.assertEqual(result, [None, None])
+
+    @patch("api.metadata.reader.requests.post")
+    def test_pads_with_none_when_service_returns_partial_list(self, mock_post):
+        mock_post.return_value = self._mock_response([12.34])
+
+        result = get_metadata(
+            "/tmp/photo.jpg",
+            tags=["GPS:Latitude", "GPS:Longitude", "EXIF:Orientation"],
+        )
+
+        self.assertEqual(result, [12.34, None, None])


### PR DESCRIPTION
api.metadata.reader.get_metadata posts to the local exif Flask service (service/exif/main.py) and returns response["values"]. The service collects values in a list inside a try/except, and if exiftool raises mid-loop the partial list is returned with HTTP 201. The docstring promises one value per tag, but the actual response can be shorter - including empty.

Several callers unpack the result positionally:

  new_gps_lat, new_gps_lon = get_metadata(..., tags=[LAT, LON], ...)
  (orientation, image_width, image_height) = get_metadata(..., tags=[3], ...)
  height, width = get_metadata(..., tags=[HEIGHT, WIDTH], ...)
  (region_info, orientation) = get_metadata(..., tags=[2], ...)

When the service returns a shorter list these all raise ValueError: not enough values to unpack. In the geolocation path that ValueError is caught at the job level and the photo is silently skipped, which is how the issue surfaced in a production log - photos with unreadable EXIF were quietly missing geolocation data after a scan.

Pad the response in the reader to honor the documented contract, so the existing falsy-check guards in the callers (if not new_gps_lat: return) fire on the missing values instead of an exception unwinding past them.

Adds GetMetadataPaddingTest covering the expected-length, empty, and partial-list cases via a mocked requests.post.