### PR TITLE
backend: actually migrate MAP_API_PROVIDER off photon

### DIFF
--- a/apps/backend/api/migrations/0127_migrate_photon_provider_robustly.py
+++ b/apps/backend/api/migrations/0127_migrate_photon_provider_robustly.py
@@ -1,0 +1,58 @@
+"""
+Re-run of the photon → nominatim Constance migration.
+
+The original 0093_migrate_photon_to_nominatim filtered on
+``config.value == '"photon"'``, but django-constance stores values via
+``constance.codecs.dumps`` which encodes a bare string as
+``{"__type__": "default", "__value__": "photon"}``. The old filter never
+matched, so 0093 was effectively a no-op and existing installations were
+left pointing at a provider that no longer exists.
+
+This migration decodes each candidate value with the codec, so the check
+is robust to whatever JSON shape django-constance happens to be using.
+"""
+
+from django.db import migrations
+
+from constance.codecs import dumps, loads
+
+
+def _decode(raw):
+    try:
+        return loads(raw)
+    except Exception:
+        return None
+
+
+def migrate_photon_provider(apps, schema_editor):
+    try:
+        Constance = apps.get_model("constance", "Constance")
+    except LookupError:
+        return
+
+    for config in Constance.objects.filter(key="MAP_API_PROVIDER"):
+        if _decode(config.value) == "photon":
+            config.value = dumps("nominatim")
+            config.save()
+
+
+def reverse_migrate_photon_provider(apps, schema_editor):
+    try:
+        Constance = apps.get_model("constance", "Constance")
+    except LookupError:
+        return
+
+    for config in Constance.objects.filter(key="MAP_API_PROVIDER"):
+        if _decode(config.value) == "nominatim":
+            config.value = dumps("photon")
+            config.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0126_clear_128dim_face_encodings"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_photon_provider, reverse_migrate_photon_provider),
+    ]

--- a/apps/backend/api/tests/test_migrate_photon_provider.py
+++ b/apps/backend/api/tests/test_migrate_photon_provider.py
@@ -1,0 +1,69 @@
+"""Tests for the photon→nominatim Constance migration (0127).
+
+The original 0093 filtered on the wrong storage format and is a no-op for
+real installations. This migration re-runs the conversion using
+``constance.codecs.loads``/``dumps`` so it matches what django-constance
+actually writes to the database.
+"""
+
+import importlib
+
+from constance.codecs import dumps, loads
+from constance.models import Constance
+from django.apps import apps as django_apps
+from django.test import TestCase
+
+
+migration_module = importlib.import_module(
+    "api.migrations.0127_migrate_photon_provider_robustly"
+)
+
+
+class MigratePhotonProviderTest(TestCase):
+    def _set_provider_value(self, value):
+        # Mirror the path django-constance uses internally so the stored
+        # ``value`` column matches what the live application would write.
+        Constance.objects.update_or_create(
+            key="MAP_API_PROVIDER", defaults={"value": dumps(value)}
+        )
+
+    def _read_provider(self):
+        row = Constance.objects.get(key="MAP_API_PROVIDER")
+        return loads(row.value)
+
+    def test_migrates_photon_to_nominatim(self):
+        self._set_provider_value("photon")
+
+        migration_module.migrate_photon_provider(django_apps, None)
+
+        self.assertEqual(self._read_provider(), "nominatim")
+
+    def test_leaves_other_providers_alone(self):
+        self._set_provider_value("mapbox")
+
+        migration_module.migrate_photon_provider(django_apps, None)
+
+        self.assertEqual(self._read_provider(), "mapbox")
+
+    def test_is_idempotent_when_already_nominatim(self):
+        self._set_provider_value("nominatim")
+
+        migration_module.migrate_photon_provider(django_apps, None)
+        migration_module.migrate_photon_provider(django_apps, None)
+
+        self.assertEqual(self._read_provider(), "nominatim")
+
+    def test_no_op_when_setting_missing(self):
+        Constance.objects.filter(key="MAP_API_PROVIDER").delete()
+
+        # Should not raise.
+        migration_module.migrate_photon_provider(django_apps, None)
+
+        self.assertFalse(Constance.objects.filter(key="MAP_API_PROVIDER").exists())
+
+    def test_reverse_migration_restores_photon(self):
+        self._set_provider_value("nominatim")
+
+        migration_module.reverse_migrate_photon_provider(django_apps, None)
+
+        self.assertEqual(self._read_provider(), "photon")

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -102,7 +102,6 @@ CONSTANCE_ADDITIONAL_FIELDS = {
                 ("maptiler", "MapTiler"),
                 ("nominatim", "Nominatim (OpenStreetMap)"),
                 ("opencage", "OpenCage"),
-                ("photon", "Photon"),
                 ("tomtom", "TomTom"),
             ),
         },


### PR DESCRIPTION
Existing installations were left pointing at "photon" after the provider was removed in 36fb281a. Migration 0093_migrate_photon_to_nominatim was supposed to fix that, but it filters on

  config.value == '"photon"'

while django-constance v4 stores the value via constance.codecs.dumps as

  {"__type__": "default", "__value__": "photon"}

The filter never matches, so 0093 is silently a no-op and every geolocation call in those installs still produces
"Map provider not found: photon." warnings in the scan log.

This change has three parts:

1. A new migration (0127) that decodes each candidate value with constance.codecs.loads, so the conversion is robust to whatever JSON shape django-constance is using. Tests cover the photon→nominatim path, idempotency on already-nominatim, the unrelated-provider case, the missing-row case, and the reverse migration.

2. Removal of the ("photon", "Photon") entry from the admin dropdown in CONSTANCE_ADDITIONAL_FIELDS, so the obsolete provider can no longer be re-selected after the migration runs.

3. The original 0093 is left in place so its django_migrations row stays valid for installs that have already applied it; the new migration supersedes it functionally.