### PR TITLE
backend: add timeouts to sidecar HTTP calls so jobs can't wedge forever

### DIFF
--- a/apps/backend/api/face_recognition.py
+++ b/apps/backend/api/face_recognition.py
@@ -72,7 +72,9 @@ def _get_error_detail(response):
 
 def _post_to_face_service(url, payload):
     """POST to the face service and raise errors with response details."""
-    response = requests.post(url, json=payload)
+    from api.http_timeouts import FACE
+
+    response = requests.post(url, json=payload, timeout=FACE)
 
     try:
         response.raise_for_status()

--- a/apps/backend/api/http_timeouts.py
+++ b/apps/backend/api/http_timeouts.py
@@ -1,0 +1,26 @@
+"""Timeouts for HTTP requests to in-container service sidecars.
+
+`requests` defaults to no timeout, which means a stalled sidecar (e.g.
+face-recognition wedged on a pathological image, or exiftool hung
+mid-process) blocks the caller indefinitely. In practice this surfaces
+as long-running scan jobs that show as "running" forever with no
+progress — the worker is parked on a socket read that never returns.
+
+Each constant below is a ``(connect_timeout, read_timeout)`` tuple
+suitable for passing as ``timeout=`` to ``requests.{get,post,delete}``.
+Connect timeouts are uniformly small because the sidecars are local
+sockets; read timeouts vary with what the operation can legitimately
+take on a slow but functioning server.
+"""
+
+CONNECT_TIMEOUT = 5
+
+HEALTH_CHECK = (CONNECT_TIMEOUT, 5)
+EXIF = (CONNECT_TIMEOUT, 30)
+FACE = (CONNECT_TIMEOUT, 60)
+SIMILARITY = (CONNECT_TIMEOUT, 60)
+TAGS = (CONNECT_TIMEOUT, 60)
+THUMBNAIL = (CONNECT_TIMEOUT, 120)
+CLIP_EMBED = (CONNECT_TIMEOUT, 120)
+CAPTION = (CONNECT_TIMEOUT, 180)
+LLM_GEN = (CONNECT_TIMEOUT, 300)

--- a/apps/backend/api/image_captioning.py
+++ b/apps/backend/api/image_captioning.py
@@ -1,6 +1,8 @@
 import requests
 from constance import config as site_config
 
+from api.http_timeouts import CAPTION, HEALTH_CHECK
+
 
 def generate_caption(image_path, blip=False, prompt=None):
     # Check if Moondream is selected as captioning model
@@ -15,7 +17,9 @@ def generate_caption(image_path, blip=False, prompt=None):
             "max_tokens": 256,
         }
         try:
-            response = requests.post("http://localhost:8008/generate", json=json_data)
+            response = requests.post(
+                "http://localhost:8008/generate", json=json_data, timeout=CAPTION
+            )
 
             if response.status_code != 201:
                 print(
@@ -44,11 +48,11 @@ def generate_caption(image_path, blip=False, prompt=None):
         "blip": blip,
     }
     caption_response = requests.post(
-        "http://localhost:8007/generate-caption", json=json_data
+        "http://localhost:8007/generate-caption", json=json_data, timeout=CAPTION
     ).json()
 
     return caption_response["caption"]
 
 
 def unload_model():
-    requests.get("http://localhost:8007/unload-model")
+    requests.get("http://localhost:8007/unload-model", timeout=HEALTH_CHECK)

--- a/apps/backend/api/image_similarity.py
+++ b/apps/backend/api/image_similarity.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.db.models import Q
 
+from api.http_timeouts import SIMILARITY
 from api.models import Photo
 from api.util import logger
 
@@ -24,7 +25,11 @@ def search_similar_embedding(user, emb, result_count=100, threshold=27):
         "n": result_count,
         "threshold": threshold,
     }
-    res = requests.post(settings.IMAGE_SIMILARITY_SERVER + "/search/", json=post_data)
+    res = requests.post(
+        settings.IMAGE_SIMILARITY_SERVER + "/search/",
+        json=post_data,
+        timeout=SIMILARITY,
+    )
     if res.status_code == 200:
         return res.json()["result"]
     else:
@@ -49,7 +54,11 @@ def search_similar_image(user, photo, threshold=27):
         "image_embedding": image_embedding.tolist(),
         "threshold": threshold,
     }
-    res = requests.post(settings.IMAGE_SIMILARITY_SERVER + "/search/", json=post_data)
+    res = requests.post(
+        settings.IMAGE_SIMILARITY_SERVER + "/search/",
+        json=post_data,
+        timeout=SIMILARITY,
+    )
     if res.status_code == 200:
         return res.json()
     else:
@@ -64,6 +73,7 @@ def build_image_similarity_index(user):
     requests.delete(
         settings.IMAGE_SIMILARITY_SERVER + "/build/",
         json={"user_id": user.id},
+        timeout=SIMILARITY,
     )
     start = datetime.now()
     photos = (
@@ -90,6 +100,10 @@ def build_image_similarity_index(user):
             "image_hashes": image_hashes,
             "image_embeddings": image_embeddings,
         }
-        requests.post(settings.IMAGE_SIMILARITY_SERVER + "/build/", json=post_data)
+        requests.post(
+            settings.IMAGE_SIMILARITY_SERVER + "/build/",
+            json=post_data,
+            timeout=SIMILARITY,
+        )
     elapsed = (datetime.now() - start).total_seconds()
     logger.info("building similarity index took %.2f seconds" % elapsed)

--- a/apps/backend/api/llm.py
+++ b/apps/backend/api/llm.py
@@ -4,6 +4,8 @@ import io
 from PIL import Image
 from constance import config as site_config
 
+from api.http_timeouts import LLM_GEN
+
 
 def image_to_base64_data_uri(image_path):
     """Convert image file to base64 data URI, converting to JPEG for compatibility"""
@@ -57,7 +59,9 @@ def generate_prompt(prompt, image_path=None):
             return None
 
     try:
-        response = requests.post("http://localhost:8008/generate", json=json_data)
+        response = requests.post(
+            "http://localhost:8008/generate", json=json_data, timeout=LLM_GEN
+        )
 
         if response.status_code != 201:
             print(

--- a/apps/backend/api/metadata/reader.py
+++ b/apps/backend/api/metadata/reader.py
@@ -49,5 +49,9 @@ def get_metadata(media_file, tags, try_sidecar=True, struct=False):
         "files_by_reverse_priority": files_by_reverse_priority,
         "struct": struct,
     }
-    response = requests.post("http://localhost:8010/get-tags", json=json).json()
+    from api.http_timeouts import EXIF
+
+    response = requests.post(
+        "http://localhost:8010/get-tags", json=json, timeout=EXIF
+    ).json()
     return response["values"]

--- a/apps/backend/api/models/photo_caption.py
+++ b/apps/backend/api/models/photo_caption.py
@@ -289,6 +289,8 @@ class PhotoCaption(models.Model):
         try:
             import requests
 
+            from api.http_timeouts import TAGS
+
             image_path = self.photo.thumbnail.thumbnail_big.path
             confidence = self.photo.owner.confidence
             json_data = {
@@ -297,7 +299,7 @@ class PhotoCaption(models.Model):
                 "tagging_model": tagging_model,
             }
             response = requests.post(
-                "http://localhost:8011/generate-tags", json=json_data
+                "http://localhost:8011/generate-tags", json=json_data, timeout=TAGS
             )
 
             if not response.ok:

--- a/apps/backend/api/semantic_search.py
+++ b/apps/backend/api/semantic_search.py
@@ -2,6 +2,8 @@ import numpy as np
 import requests
 from django.conf import settings
 
+from api.http_timeouts import CLIP_EMBED
+
 dir_clip_ViT_B_32_model = settings.CLIP_ROOT
 
 
@@ -11,7 +13,7 @@ def create_clip_embeddings(imgs):
         "model": dir_clip_ViT_B_32_model,
     }
     clip_embeddings = requests.post(
-        "http://localhost:8006/clip-embeddings", json=json
+        "http://localhost:8006/clip-embeddings", json=json, timeout=CLIP_EMBED
     ).json()
 
     imgs_emb = clip_embeddings["imgs_emb"]
@@ -29,7 +31,7 @@ def calculate_query_embeddings(query):
         "model": dir_clip_ViT_B_32_model,
     }
     query_embedding = requests.post(
-        "http://localhost:8006/query-embeddings", json=json
+        "http://localhost:8006/query-embeddings", json=json, timeout=CLIP_EMBED
     ).json()
 
     emb = query_embedding["emb"]

--- a/apps/backend/api/services.py
+++ b/apps/backend/api/services.py
@@ -51,7 +51,9 @@ def check_services():
 def is_healthy(service):
     port = SERVICES.get(service)
     try:
-        res = requests.get(f"http://localhost:{port}/health")
+        from api.http_timeouts import HEALTH_CHECK
+
+        res = requests.get(f"http://localhost:{port}/health", timeout=HEALTH_CHECK)
         # If response has timestamp, check if it needs to be restarted
         if res.json().get("last_request_time") is not None:
             if res.json()["last_request_time"] < time.time() - 120:

--- a/apps/backend/api/tests/test_sidecar_http_timeouts.py
+++ b/apps/backend/api/tests/test_sidecar_http_timeouts.py
@@ -1,0 +1,196 @@
+"""Verify that every backend → sidecar HTTP call passes an explicit timeout.
+
+`requests` has no default timeout, so a stalled sidecar (face-recognition
+hung on a pathological image, exiftool wedged mid-process, etc.) parks
+the caller on an infinite socket read. Long-running jobs then appear as
+"running" forever without making progress.
+
+These tests don't try to exercise the sidecar protocol — they just
+intercept ``requests.{post,get,delete}`` for each caller and assert
+that ``timeout=`` is set to a finite tuple. The timeout values are
+defined in ``api.http_timeouts`` so tightening or relaxing them is a
+one-place edit.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from api import http_timeouts
+
+
+def _ok_response(json_body=None):
+    response = MagicMock()
+    response.status_code = 200
+    response.ok = True
+    response.json.return_value = json_body or {}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _assert_finite_timeout(call):
+    """Both connect and read components must be set and finite."""
+    timeout = call.kwargs.get("timeout")
+    assert timeout is not None, f"call missing timeout=: {call}"
+    if isinstance(timeout, tuple):
+        connect, read = timeout
+        assert connect > 0 and read > 0, f"non-positive timeout: {timeout}"
+    else:
+        assert timeout > 0, f"non-positive timeout: {timeout}"
+
+
+class FaceRecognitionTimeoutTest(SimpleTestCase):
+    @patch("api.face_recognition.requests.post")
+    def test_get_face_locations_passes_timeout(self, mock_post):
+        mock_post.return_value = _ok_response({"face_locations": []})
+
+        from api.face_recognition import get_face_locations
+
+        with patch("api.face_recognition.site_config") as mock_cfg:
+            mock_cfg.FACE_RECOGNITION_MODEL = "buffalo_sc"
+            get_face_locations("/tmp/photo.jpg")
+
+        _assert_finite_timeout(mock_post.call_args)
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], http_timeouts.FACE)
+
+
+class SemanticSearchTimeoutTest(SimpleTestCase):
+    @patch("api.semantic_search.requests.post")
+    def test_create_clip_embeddings_passes_timeout(self, mock_post):
+        mock_post.return_value = _ok_response({"imgs_emb": [], "magnitudes": []})
+
+        from api.semantic_search import create_clip_embeddings
+
+        create_clip_embeddings([])
+
+        _assert_finite_timeout(mock_post.call_args)
+        self.assertEqual(
+            mock_post.call_args.kwargs["timeout"], http_timeouts.CLIP_EMBED
+        )
+
+    @patch("api.semantic_search.requests.post")
+    def test_calculate_query_embeddings_passes_timeout(self, mock_post):
+        mock_post.return_value = _ok_response({"emb": [], "magnitude": 0})
+
+        from api.semantic_search import calculate_query_embeddings
+
+        calculate_query_embeddings("test")
+
+        _assert_finite_timeout(mock_post.call_args)
+
+
+class ExifReaderTimeoutTest(SimpleTestCase):
+    @patch("api.metadata.reader.requests.post")
+    @patch("api.metadata.reader._get_existing_metadata_files_reversed")
+    def test_get_metadata_passes_timeout(self, mock_files, mock_post):
+        mock_files.return_value = ["/tmp/photo.jpg"]
+        mock_post.return_value = _ok_response({"values": [None, None]})
+
+        from api.metadata.reader import get_metadata
+
+        get_metadata("/tmp/photo.jpg", tags=["EXIF:Make", "EXIF:Model"])
+
+        _assert_finite_timeout(mock_post.call_args)
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], http_timeouts.EXIF)
+
+
+class ImageSimilarityTimeoutTest(SimpleTestCase):
+    @patch("api.image_similarity.requests.post")
+    def test_search_similar_embedding_passes_timeout(self, mock_post):
+        mock_post.return_value = _ok_response({"result": []})
+
+        from api.image_similarity import search_similar_embedding
+
+        search_similar_embedding(user=1, emb=[0.0] * 512)
+
+        _assert_finite_timeout(mock_post.call_args)
+        self.assertEqual(
+            mock_post.call_args.kwargs["timeout"], http_timeouts.SIMILARITY
+        )
+
+
+class ServicesHealthCheckTimeoutTest(SimpleTestCase):
+    @patch("api.services.requests.get")
+    def test_is_healthy_passes_timeout(self, mock_get):
+        mock_get.return_value = _ok_response({"last_request_time": None})
+        mock_get.return_value.status_code = 200
+
+        from api.services import is_healthy
+
+        is_healthy("image_similarity")
+
+        _assert_finite_timeout(mock_get.call_args)
+        self.assertEqual(
+            mock_get.call_args.kwargs["timeout"], http_timeouts.HEALTH_CHECK
+        )
+
+
+class CaptionAndLLMTimeoutTest(SimpleTestCase):
+    @patch("api.image_captioning.requests.post")
+    def test_generate_caption_legacy_passes_timeout(self, mock_post):
+        # Forces the non-moondream path which uses port 8007.
+        mock_post.return_value = _ok_response({"caption": "x"})
+
+        from api.image_captioning import generate_caption
+
+        with patch("api.image_captioning.site_config") as mock_cfg:
+            mock_cfg.CAPTIONING_MODEL = "im2txt"
+            generate_caption("/tmp/photo.jpg")
+
+        _assert_finite_timeout(mock_post.call_args)
+
+    @patch("api.llm.requests.post")
+    def test_llm_generate_passes_timeout(self, mock_post):
+        response = _ok_response({"response": "hi"})
+        response.status_code = 201
+        mock_post.return_value = response
+
+        from api.llm import generate_prompt
+
+        with patch("api.llm.site_config") as mock_cfg:
+            mock_cfg.LLM_MODEL = "mistral-7b-instruct-v0.2.Q5_K_M"
+            generate_prompt("prompt")
+
+        _assert_finite_timeout(mock_post.call_args)
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], http_timeouts.LLM_GEN)
+
+
+class TimeoutPolicyTest(SimpleTestCase):
+    """The numbers themselves are policy and should be sane."""
+
+    def test_all_timeouts_are_finite_positive_tuples(self):
+        for name in (
+            "HEALTH_CHECK",
+            "EXIF",
+            "FACE",
+            "SIMILARITY",
+            "TAGS",
+            "THUMBNAIL",
+            "CLIP_EMBED",
+            "CAPTION",
+            "LLM_GEN",
+        ):
+            value = getattr(http_timeouts, name)
+            self.assertIsInstance(value, tuple, f"{name} must be a tuple")
+            self.assertEqual(len(value), 2, f"{name} must be (connect, read)")
+            connect, read = value
+            self.assertGreater(connect, 0, f"{name} connect timeout must be positive")
+            self.assertGreater(read, 0, f"{name} read timeout must be positive")
+
+    def test_connect_timeout_uniformly_short(self):
+        # Local-socket connect should never legitimately take longer than a
+        # few seconds. Keeping it uniform makes the policy easy to reason
+        # about.
+        for name in (
+            "HEALTH_CHECK",
+            "EXIF",
+            "FACE",
+            "SIMILARITY",
+            "TAGS",
+            "THUMBNAIL",
+            "CLIP_EMBED",
+            "CAPTION",
+            "LLM_GEN",
+        ):
+            connect, _ = getattr(http_timeouts, name)
+            self.assertLessEqual(connect, 10, f"{name} connect timeout too generous")

--- a/apps/backend/api/thumbnails.py
+++ b/apps/backend/api/thumbnails.py
@@ -68,7 +68,11 @@ def create_thumbnail(
                     "destination": complete_path,
                     "height": output_height,
                 }
-                response = requests.post("http://localhost:8003/", json=json).json()
+                from api.http_timeouts import THUMBNAIL
+
+                response = requests.post(
+                    "http://localhost:8003/", json=json, timeout=THUMBNAIL
+                ).json()
                 # The RAW service applies auto-orientation internally.  Apply
                 # any user-specified rotation on top.
                 if local_orientation and local_orientation != 1:


### PR DESCRIPTION
Every backend → sidecar HTTP client (face_recognition, image_similarity, clip_embeddings, exif/metadata reader, image_captioning, llm, thumbnail, tags, plus the periodic health checker) calls requests.post/get/delete with no timeout. requests defaults to no timeout, which means a stalled sidecar — face_recognition wedged on a pathological image, exiftool hung mid-process, image_similarity in a tight loop — parks the caller on an infinite socket read. The caller is most often a long-running scan job running inside a single django-q2 task; the task ends up "running" forever in the admin UI with no progress, and the global Q_CLUSTER timeout is set to 10000000 (115 days) so the supervisor never reaps it either. Real-world symptom seen in production logs: a Scan Faces job progresses to photo 7 of 152520, then sits in this state for 20+ hours while the worker burns CPU on the wedged socket read.

Adds api/http_timeouts.py with named (connect, read) tuples per operation class — small connect timeouts uniformly (5s, local sockets), read timeouts scaled to what each operation can legitimately take on a slow-but-functioning server. Each sidecar call site now passes the appropriate constant as timeout=. When a sidecar stalls, the caller now raises requests.Timeout instead of hanging; existing per-photo try / except wrappers (e.g. processing_jobs.scan_faces lines 269-280) catch it and the loop moves on.

Out of scope here:
- External HTTP (model downloads in ml_models.py) — different bug class.
- Q_CLUSTER.timeout reduction — can't safely lower it until the bigger scan tasks are split into per-photo subtasks (separate PR).
- A circuit breaker for repeated failures against the same sidecar — natural follow-up if any sidecar starts failing for many photos in a row.

Tests in api/tests/test_sidecar_http_timeouts.py intercept each client's requests.post/get and assert a finite (connect, read) tuple is passed, plus a policy test that all named timeouts are positive and have a uniformly small connect component. 10 tests, all pass on test_sqlite.