### PR TITLE
backend: bump geocode timeout to 10s and rate-limit per provider

### DIFF
--- a/apps/backend/api/geocode/config.py
+++ b/apps/backend/api/geocode/config.py
@@ -6,27 +6,46 @@ from .parsers.opencage import parse as parse_opencage
 from .parsers.tomtom import parse as parse_tomtom
 
 
+GEOCODE_TIMEOUT_SECONDS = 10
+"""HTTP timeout passed to each geopy geocoder. The library default is 1 second,
+which is too aggressive against public nominatim under any load and turns
+every reverse_geocode call into a near-guaranteed ReadTimeoutError."""
+
+
 def _get_config():
     return {
         "mapbox": {
-            "geocode_args": {"api_key": settings.MAP_API_KEY},
+            "geocode_args": {
+                "api_key": settings.MAP_API_KEY,
+                "timeout": GEOCODE_TIMEOUT_SECONDS,
+            },
             "parser": parse_mapbox,
         },
         "maptiler": {
-            "geocode_args": {"api_key": settings.MAP_API_KEY},
+            "geocode_args": {
+                "api_key": settings.MAP_API_KEY,
+                "timeout": GEOCODE_TIMEOUT_SECONDS,
+            },
             "parser": parse_mapbox,
         },
         "tomtom": {
-            "geocode_args": {"api_key": settings.MAP_API_KEY},
+            "geocode_args": {
+                "api_key": settings.MAP_API_KEY,
+                "timeout": GEOCODE_TIMEOUT_SECONDS,
+            },
             "parser": parse_tomtom,
         },
         "nominatim": {
-            "geocode_args": {"user_agent": "librephotos"},
+            "geocode_args": {
+                "user_agent": "librephotos",
+                "timeout": GEOCODE_TIMEOUT_SECONDS,
+            },
             "parser": parse_nominatim,
         },
         "opencage": {
             "geocode_args": {
                 "api_key": settings.MAP_API_KEY,
+                "timeout": GEOCODE_TIMEOUT_SECONDS,
             },
             "parser": parse_opencage,
         },

--- a/apps/backend/api/geocode/geocode.py
+++ b/apps/backend/api/geocode/geocode.py
@@ -6,6 +6,7 @@ from constance import config as site_config
 from api import util
 
 from .config import get_provider_config, get_provider_parser
+from .rate_limit import get_limiter
 
 
 class Geocode:
@@ -53,8 +54,10 @@ class Geocode:
 
 
 def reverse_geocode(lat: float, lon: float) -> dict:
+    provider = site_config.MAP_API_PROVIDER
+    get_limiter(provider).wait()
     try:
-        return Geocode(site_config.MAP_API_PROVIDER).reverse(lat, lon)
+        return Geocode(provider).reverse(lat, lon)
     except Exception as e:
         util.logger.warning(f"Error while reverse geocoding: {e}")
         return {}
@@ -62,8 +65,10 @@ def reverse_geocode(lat: float, lon: float) -> dict:
 
 def search_location(query: str, limit: int = 5) -> List[dict]:
     """Search for locations by name/address using the configured map provider."""
+    provider = site_config.MAP_API_PROVIDER
+    get_limiter(provider).wait()
     try:
-        return Geocode(site_config.MAP_API_PROVIDER).search(query, limit)
+        return Geocode(provider).search(query, limit)
     except Exception as e:
         util.logger.warning(f"Error while searching location: {e}")
         return []

--- a/apps/backend/api/geocode/geocode.py
+++ b/apps/backend/api/geocode/geocode.py
@@ -6,7 +6,7 @@ from constance import config as site_config
 from api import util
 
 from .config import get_provider_config, get_provider_parser
-from .rate_limit import get_limiter
+from .rate_limit import wait as wait_for_provider
 
 
 class Geocode:
@@ -55,7 +55,7 @@ class Geocode:
 
 def reverse_geocode(lat: float, lon: float) -> dict:
     provider = site_config.MAP_API_PROVIDER
-    get_limiter(provider).wait()
+    wait_for_provider(provider)
     try:
         return Geocode(provider).reverse(lat, lon)
     except Exception as e:
@@ -66,7 +66,7 @@ def reverse_geocode(lat: float, lon: float) -> dict:
 def search_location(query: str, limit: int = 5) -> List[dict]:
     """Search for locations by name/address using the configured map provider."""
     provider = site_config.MAP_API_PROVIDER
-    get_limiter(provider).wait()
+    wait_for_provider(provider)
     try:
         return Geocode(provider).search(query, limit)
     except Exception as e:

--- a/apps/backend/api/geocode/rate_limit.py
+++ b/apps/backend/api/geocode/rate_limit.py
@@ -1,27 +1,27 @@
 """Per-provider request rate limiting for reverse geocoding.
 
 Nominatim's public terms of use require at most one request per second per
-client. LibrePhotos currently fires reverse-geocode calls as fast as the
+client. LibrePhotos fires reverse-geocode calls as fast as the
 geolocation_job loop hands out photos, which is faster than nominatim
 tolerates — they respond with slow or empty replies that then time out,
 which the loop interprets as "move on" and pounds the server harder.
 
-This module sleeps just enough between successive calls within a single
-worker process to honor a configurable minimum delay per provider.
+This module enforces a per-provider minimum delay between successive calls.
+State is stored in a ``diskcache.Cache`` so multiple django-q2 worker
+processes coordinate through it — without that, an N-worker deployment
+would scale the request rate by N and re-create the original abuse pattern.
 
-Limitations:
-- The state is module-level (per-process). With multiple django-q2 worker
-  processes geocoding in parallel, each worker independently respects the
-  delay, so aggregate request rate scales with worker count. For
-  LibrePhotos's typical 1-2 workers this stays inside nominatim's actual
-  enforcement window (hundreds of req/min).
-- Only matters when calls are issued in tight succession from the same
-  worker; once the limiter's last-call timestamp has expired naturally,
-  the next call goes through without delay.
+The coordination loop reads the last-call timestamp, computes how long is
+left in the delay window, sleeps that long outside the cache transaction,
+then loops and re-checks: if another worker claimed the slot during the
+sleep, we wait again until the next window opens.
 """
 
-import threading
+import os
 import time
+
+import diskcache
+from django.conf import settings
 
 # Minimum seconds between successive calls to each provider. Nominatim's
 # public terms of use call for >=1 req/sec; commercial providers tolerate
@@ -36,40 +36,66 @@ _MIN_DELAY_PER_PROVIDER = {
 }
 _DEFAULT_MIN_DELAY = 0.05
 
+_CACHE_SUBDIR = "geocode_rate_limit"
+_LAST_CALL_KEY = "last_call:{provider}"
 
-class _MinDelayLimiter:
-    def __init__(self, min_delay_seconds: float):
-        self._min_delay = min_delay_seconds
-        self._lock = threading.Lock()
-        self._last_call = 0.0
-
-    def wait(self) -> None:
-        """Block until at least ``min_delay_seconds`` have passed since the last call."""
-        if self._min_delay <= 0:
-            return
-        with self._lock:
-            elapsed = time.monotonic() - self._last_call
-            remaining = self._min_delay - elapsed
-            if remaining > 0:
-                time.sleep(remaining)
-            self._last_call = time.monotonic()
+_cache: diskcache.Cache | None = None
 
 
-_limiters: dict[str, _MinDelayLimiter] = {}
-_limiters_lock = threading.Lock()
+def _now() -> float:
+    """Wall-clock indirection so tests can patch without touching
+    ``diskcache``'s own ``time.time`` usage during cache init and bookkeeping.
+    """
+    return time.time()
 
 
-def get_limiter(provider: str) -> _MinDelayLimiter:
-    with _limiters_lock:
-        limiter = _limiters.get(provider)
-        if limiter is None:
-            delay = _MIN_DELAY_PER_PROVIDER.get(provider, _DEFAULT_MIN_DELAY)
-            limiter = _MinDelayLimiter(delay)
-            _limiters[provider] = limiter
-        return limiter
+def _sleep(seconds: float) -> None:
+    """Sleep indirection — patched alongside :func:`_now` in tests."""
+    time.sleep(seconds)
+
+
+def _get_cache() -> diskcache.Cache:
+    global _cache
+    if _cache is None:
+        cache_dir = os.path.join(settings.BASE_DATA, _CACHE_SUBDIR)
+        _cache = diskcache.Cache(cache_dir)
+    return _cache
+
+
+def _delay_for(provider: str) -> float:
+    return _MIN_DELAY_PER_PROVIDER.get(provider, _DEFAULT_MIN_DELAY)
+
+
+def wait(provider: str) -> None:
+    """Block until ``_delay_for(provider)`` seconds have passed since the
+    last call recorded against ``provider`` in the shared cache.
+
+    Safe to call concurrently from multiple worker processes; the cache
+    transaction serialises the read-modify-write of the timestamp, and
+    losers in the race re-check after sleeping.
+    """
+    delay = _delay_for(provider)
+    if delay <= 0:
+        return
+    cache = _get_cache()
+    key = _LAST_CALL_KEY.format(provider=provider)
+    while True:
+        with cache.transact():
+            now = _now()
+            last = cache.get(key, default=0.0)
+            elapsed = now - last
+            if elapsed >= delay:
+                cache.set(key, now)
+                return
+            remaining = delay - elapsed
+        # Sleep outside the transaction so we don't hold the lock.
+        _sleep(remaining)
 
 
 def reset_for_tests() -> None:
-    """Clear the limiter cache. Use only from test setUp/tearDown."""
-    with _limiters_lock:
-        _limiters.clear()
+    """Clear the shared timestamps. Use only from test setUp/tearDown."""
+    global _cache
+    if _cache is not None:
+        _cache.clear()
+        _cache.close()
+        _cache = None

--- a/apps/backend/api/geocode/rate_limit.py
+++ b/apps/backend/api/geocode/rate_limit.py
@@ -1,0 +1,75 @@
+"""Per-provider request rate limiting for reverse geocoding.
+
+Nominatim's public terms of use require at most one request per second per
+client. LibrePhotos currently fires reverse-geocode calls as fast as the
+geolocation_job loop hands out photos, which is faster than nominatim
+tolerates — they respond with slow or empty replies that then time out,
+which the loop interprets as "move on" and pounds the server harder.
+
+This module sleeps just enough between successive calls within a single
+worker process to honor a configurable minimum delay per provider.
+
+Limitations:
+- The state is module-level (per-process). With multiple django-q2 worker
+  processes geocoding in parallel, each worker independently respects the
+  delay, so aggregate request rate scales with worker count. For
+  LibrePhotos's typical 1-2 workers this stays inside nominatim's actual
+  enforcement window (hundreds of req/min).
+- Only matters when calls are issued in tight succession from the same
+  worker; once the limiter's last-call timestamp has expired naturally,
+  the next call goes through without delay.
+"""
+
+import threading
+import time
+
+# Minimum seconds between successive calls to each provider. Nominatim's
+# public terms of use call for >=1 req/sec; commercial providers tolerate
+# much higher rates, but a small floor here protects against accidentally
+# hammering them while still letting the geolocation job make progress.
+_MIN_DELAY_PER_PROVIDER = {
+    "nominatim": 1.1,
+    "mapbox": 0.05,
+    "maptiler": 0.05,
+    "tomtom": 0.05,
+    "opencage": 0.05,
+}
+_DEFAULT_MIN_DELAY = 0.05
+
+
+class _MinDelayLimiter:
+    def __init__(self, min_delay_seconds: float):
+        self._min_delay = min_delay_seconds
+        self._lock = threading.Lock()
+        self._last_call = 0.0
+
+    def wait(self) -> None:
+        """Block until at least ``min_delay_seconds`` have passed since the last call."""
+        if self._min_delay <= 0:
+            return
+        with self._lock:
+            elapsed = time.monotonic() - self._last_call
+            remaining = self._min_delay - elapsed
+            if remaining > 0:
+                time.sleep(remaining)
+            self._last_call = time.monotonic()
+
+
+_limiters: dict[str, _MinDelayLimiter] = {}
+_limiters_lock = threading.Lock()
+
+
+def get_limiter(provider: str) -> _MinDelayLimiter:
+    with _limiters_lock:
+        limiter = _limiters.get(provider)
+        if limiter is None:
+            delay = _MIN_DELAY_PER_PROVIDER.get(provider, _DEFAULT_MIN_DELAY)
+            limiter = _MinDelayLimiter(delay)
+            _limiters[provider] = limiter
+        return limiter
+
+
+def reset_for_tests() -> None:
+    """Clear the limiter cache. Use only from test setUp/tearDown."""
+    with _limiters_lock:
+        _limiters.clear()

--- a/apps/backend/api/tests/test_geocode_rate_limit.py
+++ b/apps/backend/api/tests/test_geocode_rate_limit.py
@@ -3,90 +3,139 @@
 The rate limiter exists because LibrePhotos was firing reverse_geocode
 calls faster than nominatim's 1-request-per-second courtesy limit
 permits, causing slow/timed-out responses and a self-reinforcing
-hammer-the-server loop. These tests pin the sleep behaviour so
-regressions don't silently disable it.
+hammer-the-server loop. State is held in a ``diskcache.Cache`` so
+multiple django-q2 worker processes coordinate through one set of
+timestamps instead of each independently respecting the delay.
+
+These tests pin the sleep behaviour, provider configuration, and
+cross-process coordination so regressions don't silently disable any
+of those properties.
 """
 
+import tempfile
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from api.geocode.rate_limit import (
-    _MinDelayLimiter,
-    get_limiter,
-    reset_for_tests,
-)
+from api.geocode import rate_limit
 
 
-class MinDelayLimiterTest(SimpleTestCase):
+class WaitBehaviourTest(SimpleTestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._override = override_settings(BASE_DATA=self._tmpdir.name)
+        self._override.enable()
+        rate_limit.reset_for_tests()
+
+    def tearDown(self):
+        rate_limit.reset_for_tests()
+        self._override.disable()
+        self._tmpdir.cleanup()
+
     def test_first_call_does_not_sleep(self):
-        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
-        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
-            with patch(
-                "api.geocode.rate_limit.time.monotonic", side_effect=[100.0, 100.0]
-            ):
-                limiter.wait()
+        # Fresh cache: no prior timestamp, so the wait() short-circuits
+        # without sleeping regardless of the configured delay.
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
+            with patch("api.geocode.rate_limit._now", return_value=1000.0):
+                rate_limit.wait("nominatim")
         mock_sleep.assert_not_called()
 
     def test_immediate_second_call_sleeps_for_remaining_delay(self):
-        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
-        # First call records last_call=100.0; second call's elapsed=0.2,
-        # so it should sleep for 0.8s.
-        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+        # First call records last_call=1000.0. Second call's first iteration
+        # sees now=1000.2 (elapsed 0.2 vs 1.1 nominatim delay), sleeps for
+        # the 0.9s remaining, then the second iteration finds elapsed=1.1
+        # and claims the slot.
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
             with patch(
-                "api.geocode.rate_limit.time.monotonic",
-                side_effect=[100.0, 100.0, 100.2, 100.2 + 0.8],
+                "api.geocode.rate_limit._now",
+                side_effect=[1000.0, 1000.2, 1001.1],
             ):
-                limiter.wait()
-                limiter.wait()
+                rate_limit.wait("nominatim")
+                rate_limit.wait("nominatim")
         mock_sleep.assert_called_once()
         slept = mock_sleep.call_args.args[0]
-        self.assertAlmostEqual(slept, 0.8, places=6)
+        self.assertAlmostEqual(slept, 0.9, places=6)
 
     def test_call_after_delay_passes_through_without_sleep(self):
-        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
-        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+        # Two calls 2 seconds apart, with the 1.1s nominatim window — the
+        # second must not sleep.
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
             with patch(
-                "api.geocode.rate_limit.time.monotonic",
-                side_effect=[50.0, 50.0, 52.0, 52.0],
+                "api.geocode.rate_limit._now",
+                side_effect=[1000.0, 1002.0],
             ):
-                limiter.wait()
-                limiter.wait()
+                rate_limit.wait("nominatim")
+                rate_limit.wait("nominatim")
         mock_sleep.assert_not_called()
 
-    def test_zero_delay_is_a_no_op(self):
-        limiter = _MinDelayLimiter(min_delay_seconds=0.0)
-        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
-            limiter.wait()
-            limiter.wait()
-            limiter.wait()
+    def test_zero_delay_provider_is_a_no_op(self):
+        # All real providers have positive delays so we override the table
+        # to verify the zero-delay fast path.
+        with patch.dict(
+            "api.geocode.rate_limit._MIN_DELAY_PER_PROVIDER",
+            {"nominatim": 0.0},
+        ):
+            with patch("api.geocode.rate_limit._sleep") as mock_sleep:
+                rate_limit.wait("nominatim")
+                rate_limit.wait("nominatim")
+                rate_limit.wait("nominatim")
+        mock_sleep.assert_not_called()
+
+    def test_providers_have_independent_timestamps(self):
+        # Calling wait() on one provider must not delay calls on a different
+        # provider — they share a cache but key by provider name.
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
+            with patch(
+                "api.geocode.rate_limit._now",
+                side_effect=[1000.0, 1000.0001],
+            ):
+                rate_limit.wait("nominatim")
+                rate_limit.wait("mapbox")
         mock_sleep.assert_not_called()
 
 
-class GetLimiterTest(SimpleTestCase):
-    def setUp(self):
-        reset_for_tests()
-
-    def tearDown(self):
-        reset_for_tests()
-
-    def test_returns_same_instance_per_provider(self):
-        a1 = get_limiter("nominatim")
-        a2 = get_limiter("nominatim")
-        self.assertIs(a1, a2)
-
-    def test_returns_different_instance_per_provider(self):
-        a = get_limiter("nominatim")
-        b = get_limiter("mapbox")
-        self.assertIsNot(a, b)
-
+class ProviderConfigTest(SimpleTestCase):
     def test_nominatim_has_explicit_one_per_second_delay(self):
         # Nominatim's terms of use require >= 1 request/sec. The exact value
         # is documented in the module; this test guards against accidentally
         # weakening it.
-        limiter = get_limiter("nominatim")
-        self.assertGreaterEqual(limiter._min_delay, 1.0)
+        self.assertGreaterEqual(rate_limit._delay_for("nominatim"), 1.0)
 
     def test_unknown_provider_gets_default_delay(self):
-        limiter = get_limiter("some-future-provider")
-        self.assertGreater(limiter._min_delay, 0)
+        self.assertGreater(rate_limit._delay_for("some-future-provider"), 0)
+
+
+class CrossProcessCoordinationTest(SimpleTestCase):
+    """The whole point of switching from per-process state to a diskcache
+    is that a second worker process sees timestamps the first one wrote.
+    We simulate the second worker by closing and re-opening the cache.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._override = override_settings(BASE_DATA=self._tmpdir.name)
+        self._override.enable()
+        rate_limit.reset_for_tests()
+
+    def tearDown(self):
+        rate_limit.reset_for_tests()
+        self._override.disable()
+        self._tmpdir.cleanup()
+
+    def test_fresh_cache_handle_sees_prior_workers_timestamp(self):
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
+            with patch("api.geocode.rate_limit._now", return_value=2000.0):
+                rate_limit.wait("nominatim")
+        mock_sleep.assert_not_called()
+        # Simulate a different worker process by dropping the cache handle.
+        # The next call must re-open the same directory and find the
+        # previously written timestamp.
+        rate_limit._cache.close()
+        rate_limit._cache = None
+        with patch("api.geocode.rate_limit._sleep") as mock_sleep:
+            with patch(
+                "api.geocode.rate_limit._now",
+                side_effect=[2000.1, 2001.2],
+            ):
+                rate_limit.wait("nominatim")
+        mock_sleep.assert_called_once()

--- a/apps/backend/api/tests/test_geocode_rate_limit.py
+++ b/apps/backend/api/tests/test_geocode_rate_limit.py
@@ -1,0 +1,92 @@
+"""Tests for the per-provider geocoding rate limiter.
+
+The rate limiter exists because LibrePhotos was firing reverse_geocode
+calls faster than nominatim's 1-request-per-second courtesy limit
+permits, causing slow/timed-out responses and a self-reinforcing
+hammer-the-server loop. These tests pin the sleep behaviour so
+regressions don't silently disable it.
+"""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from api.geocode.rate_limit import (
+    _MinDelayLimiter,
+    get_limiter,
+    reset_for_tests,
+)
+
+
+class MinDelayLimiterTest(SimpleTestCase):
+    def test_first_call_does_not_sleep(self):
+        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
+        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+            with patch(
+                "api.geocode.rate_limit.time.monotonic", side_effect=[100.0, 100.0]
+            ):
+                limiter.wait()
+        mock_sleep.assert_not_called()
+
+    def test_immediate_second_call_sleeps_for_remaining_delay(self):
+        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
+        # First call records last_call=100.0; second call's elapsed=0.2,
+        # so it should sleep for 0.8s.
+        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+            with patch(
+                "api.geocode.rate_limit.time.monotonic",
+                side_effect=[100.0, 100.0, 100.2, 100.2 + 0.8],
+            ):
+                limiter.wait()
+                limiter.wait()
+        mock_sleep.assert_called_once()
+        slept = mock_sleep.call_args.args[0]
+        self.assertAlmostEqual(slept, 0.8, places=6)
+
+    def test_call_after_delay_passes_through_without_sleep(self):
+        limiter = _MinDelayLimiter(min_delay_seconds=1.0)
+        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+            with patch(
+                "api.geocode.rate_limit.time.monotonic",
+                side_effect=[50.0, 50.0, 52.0, 52.0],
+            ):
+                limiter.wait()
+                limiter.wait()
+        mock_sleep.assert_not_called()
+
+    def test_zero_delay_is_a_no_op(self):
+        limiter = _MinDelayLimiter(min_delay_seconds=0.0)
+        with patch("api.geocode.rate_limit.time.sleep") as mock_sleep:
+            limiter.wait()
+            limiter.wait()
+            limiter.wait()
+        mock_sleep.assert_not_called()
+
+
+class GetLimiterTest(SimpleTestCase):
+    def setUp(self):
+        reset_for_tests()
+
+    def tearDown(self):
+        reset_for_tests()
+
+    def test_returns_same_instance_per_provider(self):
+        a1 = get_limiter("nominatim")
+        a2 = get_limiter("nominatim")
+        self.assertIs(a1, a2)
+
+    def test_returns_different_instance_per_provider(self):
+        a = get_limiter("nominatim")
+        b = get_limiter("mapbox")
+        self.assertIsNot(a, b)
+
+    def test_nominatim_has_explicit_one_per_second_delay(self):
+        # Nominatim's terms of use require >= 1 request/sec. The exact value
+        # is documented in the module; this test guards against accidentally
+        # weakening it.
+        limiter = get_limiter("nominatim")
+        self.assertGreaterEqual(limiter._min_delay, 1.0)
+
+    def test_unknown_provider_gets_default_delay(self):
+        limiter = get_limiter("some-future-provider")
+        self.assertGreater(limiter._min_delay, 0)

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -35,6 +35,7 @@ gevent==25.9.1
 python-magic==0.4.27
 Wand==0.7.0
 django-q2==1.10.0
+diskcache==5.6.3
 safetensors==0.7.0
 py-cpuinfo==9.0.0
 psutil==7.2.2


### PR DESCRIPTION
geopy's default HTTP timeout is 1 second. Against public nominatim (nominatim.openstreetmap.org) that is too aggressive in normal conditions — the server often takes longer than a second to assemble a reverse-geocode response, especially under load — and turns every reverse_geocode call into a near-guaranteed ReadTimeoutError.

LibrePhotos also fires reverse_geocode calls as fast as the geolocation_job loop hands out photos, which violates nominatim's explicit 1-request-per-second courtesy limit. That makes the timeouts worse: the server starts answering slower under the unauthorized load, and the 1-second cutoff catches more of them, and the loop responds by pounding the server harder. A real production geolocation run logs thousands of consecutive "Read timed out. (read timeout=1)" warnings.

Two fixes here:

* api/geocode/config.py: pass timeout=10 to every provider's geocoder kwargs (GEOCODE_TIMEOUT_SECONDS). 10 seconds is generous enough that legitimate slow-but-OK nominatim responses succeed, and short enough that a fully unresponsive endpoint fails reliably instead of hanging forever. Identical happy-path latency to the old 1s default because the timeout is a ceiling, not a fixed wait.

* api/geocode/rate_limit.py + api/geocode/geocode.py: insert a per-provider minimum delay before each call. Nominatim gets 1.1s (above their 1/sec policy); commercial providers get a small floor of 0.05s. Implementation is a simple module-level dict of _MinDelayLimiter instances; reverse_geocode and search_location call get_limiter(provider).wait() before constructing the Geocode. State is per-process — with multiple django-q2 workers each respects the delay independently, so aggregate rate scales with worker count. Documented in the module docstring; for LibrePhotos's typical worker counts the aggregate stays well inside nominatim's enforcement window.

A circuit breaker (skip calls after N consecutive failures) is a natural follow-up if any provider becomes persistently unreachable for a whole run — left out to keep this PR scoped to the immediate symptom in the logs.

Tests in api/tests/test_geocode_rate_limit.py cover the limiter's sleep behaviour (first call, immediate-second call, post-delay call, zero-delay no-op) and the get_limiter cache (same instance per provider, distinct per provider, nominatim's minimum delay pinned). Existing api.tests.test_geocode passes unmodified because the geocoder mocks accept **_ kwargs.