### PR TITLE
backend: only mark a job failed when error rate crosses a threshold

### DIFF
--- a/apps/backend/api/directory_watcher/utils.py
+++ b/apps/backend/api/directory_watcher/utils.py
@@ -15,6 +15,23 @@ from api.models import LongRunningJob
 # Lower values are more responsive but increase DB load.
 CANCELLATION_CHECK_INTERVAL = 100
 
+# Threshold for marking the LongRunningJob row's ``failed`` flag (which
+# surfaces as the red "Failed" banner in the admin UI). A scan that
+# errored on a tiny minority of photos — e.g. 4 out of 152520 — is
+# overwhelmingly a success and shouldn't carry the failed flag. Per-photo
+# errors are still accumulated in ``result['errors']`` regardless; the
+# threshold only governs the sticky boolean.
+FAILURE_ERROR_FLOOR = 10  # absolute floor — below this, never sticky
+FAILURE_ERROR_RATE = 0.05  # otherwise: failed if errors exceed 5% of target
+
+
+def _exceeds_failure_threshold(error_count: int, target: int) -> bool:
+    """Return True when aggregate errors should mark ``job.failed`` as True."""
+    if target <= 0:
+        return error_count > 0
+    threshold = max(FAILURE_ERROR_FLOOR, FAILURE_ERROR_RATE * target)
+    return error_count > threshold
+
 
 def should_skip(path):
     """Check if a path should be skipped based on configured patterns."""
@@ -123,55 +140,43 @@ def update_scan_counter(job_id, failed=False, error=None):
     if job.cancelled:
         return
 
-    # Mark the job as finished if the current progress equals the target
-    if job.progress_current >= job.progress_target:
-        # Job is finishing, update result with errors if any
-        result = job.result or {}
-        if failed or error:
-            result["status"] = "failed"
-            if "errors" not in result:
-                result["errors"] = []
-            if error:
-                error_str = str(error)
-                # Avoid duplicate errors
-                if error_str not in result["errors"]:
-                    result["errors"].append(error_str)
-            # Set main error field for backward compatibility
-            if "error" not in result and error:
-                result["error"] = str(error)
-            elif "error" not in result and result.get("errors"):
-                result["error"] = result["errors"][0]  # Use first error as main error
+    is_finishing = job.progress_current >= job.progress_target
+    result = job.result or {}
+
+    # Accumulate this item's error, if any. ``error_count`` tracks the
+    # aggregate (uncapped) — the ``errors`` list itself is capped at 100
+    # to prevent unbounded growth, so its length under-reports.
+    if failed or error:
+        result["error_count"] = result.get("error_count", 0) + 1
+        if "errors" not in result:
+            result["errors"] = []
+        if error:
+            error_str = str(error)
+            # Avoid duplicate errors (limit to last 100 to prevent unbounded growth)
+            if error_str not in result["errors"]:
+                result["errors"].append(error_str)
+                if len(result["errors"]) > 100:
+                    result["errors"] = result["errors"][-100:]
+        # Set main error field for backward compatibility
+        if "error" not in result and error:
+            result["error"] = str(error)
+        elif "error" not in result and result.get("errors"):
+            result["error"] = result["errors"][0]  # Use first error as main error
+
+    job_failed = _exceeds_failure_threshold(
+        result.get("error_count", 0), job.progress_target
+    )
+
+    if is_finishing:
+        if result.get("error_count", 0) > 0:
+            result["status"] = "failed" if job_failed else "partial_failure"
         job.finished = True
         job.finished_at = timezone.now()
-        if failed:
-            job.failed = True
+        job.failed = job_failed
         job.result = result
         job.save(update_fields=["finished", "finished_at", "failed", "result"])
-    else:
-        # Job is still running, accumulate errors in result
-        if failed or error:
-            job = LongRunningJob.objects.filter(job_id=job_id).first()
-            if job:
-                result = job.result or {}
-                result["status"] = "partial_failure" if not job.finished else "failed"
-                if "errors" not in result:
-                    result["errors"] = []
-                if error:
-                    error_str = str(error)
-                    # Avoid duplicate errors (limit to last 100 to prevent unbounded growth)
-                    if error_str not in result["errors"]:
-                        result["errors"].append(error_str)
-                        if len(result["errors"]) > 100:
-                            result["errors"] = result["errors"][
-                                -100:
-                            ]  # Keep last 100 errors
-                # Set main error field for backward compatibility
-                if "error" not in result and error:
-                    result["error"] = str(error)
-                elif "error" not in result and result.get("errors"):
-                    result["error"] = result["errors"][
-                        0
-                    ]  # Use first error as main error
-                job.result = result
-                job.failed = failed or job.failed
-                job.save(update_fields=["failed", "result"])
+    elif failed or error:
+        result["status"] = "partial_failure"
+        job.result = result
+        job.failed = job_failed
+        job.save(update_fields=["failed", "result"])

--- a/apps/backend/api/tests/test_job_failure_threshold.py
+++ b/apps/backend/api/tests/test_job_failure_threshold.py
@@ -1,0 +1,152 @@
+"""Tests for the failure-threshold logic in ``update_scan_counter``.
+
+Previously a single per-photo error would sticky ``job.failed = True``
+for the whole job, so a 152,520-photo geolocation run with 4 erroring
+photos showed as "Failed" in the admin UI even though 99.997% of work
+succeeded. The threshold added in
+``api.directory_watcher.utils._exceeds_failure_threshold`` only marks
+the job as failed when the absolute error count is meaningful relative
+to the total work.
+
+The per-photo errors are still accumulated in ``result['errors']`` and
+``result['status']`` distinguishes ``partial_failure`` from a true
+``failed``, so callers that want per-photo detail are unaffected.
+"""
+
+from django.test import TestCase
+
+from api.directory_watcher.utils import (
+    FAILURE_ERROR_FLOOR,
+    _exceeds_failure_threshold,
+    update_scan_counter,
+)
+from api.models import LongRunningJob
+from api.tests.utils import create_test_user
+
+
+class ExceedsFailureThresholdTest(TestCase):
+    """Direct tests of the threshold function — no DB involvement."""
+
+    def test_no_errors_is_not_failed(self):
+        self.assertFalse(_exceeds_failure_threshold(0, 1000))
+
+    def test_single_error_below_floor_is_not_failed(self):
+        # 1 / 1000 → 0.1% — well below the rate threshold AND below the floor.
+        self.assertFalse(_exceeds_failure_threshold(1, 1000))
+
+    def test_few_errors_in_large_target_below_floor_not_failed(self):
+        # Real production case: 4 errors out of 152520 photos.
+        self.assertFalse(_exceeds_failure_threshold(4, 152520))
+
+    def test_errors_above_floor_but_below_rate_not_failed_on_large_target(self):
+        # Above the floor but below the 5% rate for the target.
+        self.assertFalse(_exceeds_failure_threshold(FAILURE_ERROR_FLOOR + 1, 1000))
+
+    def test_errors_above_floor_when_no_target_is_failed(self):
+        # Defensive: when target is unknown, any error tips the flag.
+        self.assertTrue(_exceeds_failure_threshold(1, 0))
+        self.assertTrue(_exceeds_failure_threshold(1, -1))
+
+    def test_errors_above_rate_on_large_target_is_failed(self):
+        # 100 errors / 100 photos = 100% — clearly failed.
+        self.assertTrue(_exceeds_failure_threshold(100, 100))
+
+    def test_majority_failures_marks_failed(self):
+        self.assertTrue(_exceeds_failure_threshold(600, 1000))
+
+
+class UpdateScanCounterThresholdTest(TestCase):
+    """Integration tests that drive update_scan_counter against a real LongRunningJob."""
+
+    def setUp(self):
+        self.user = create_test_user()
+
+    def _new_job(self, target):
+        job = LongRunningJob.create_job(
+            user=self.user,
+            job_type=LongRunningJob.JOB_ADD_GEOLOCATION,
+            start_now=True,
+        )
+        job.update_progress(current=0, target=target)
+        return job
+
+    def test_zero_errors_finish_clean(self):
+        job = self._new_job(target=3)
+        for _ in range(3):
+            update_scan_counter(job.job_id)
+        job.refresh_from_db()
+        self.assertTrue(job.finished)
+        self.assertFalse(job.failed)
+
+    def test_four_errors_in_huge_run_not_marked_failed(self):
+        # Reproduces the production case in PR description: ~152k photos,
+        # 4 erroring photos. We use a 200-photo target to keep the test
+        # fast — the absolute floor still applies because 5% × 200 = 10,
+        # so 4 errors stays below max(10, 10) = 10.
+        target = 200
+        job = self._new_job(target=target)
+        for i in range(target):
+            failed = i < 4
+            error = f"err-{i}" if failed else None
+            update_scan_counter(job.job_id, failed=failed, error=error)
+        job.refresh_from_db()
+        self.assertTrue(job.finished)
+        self.assertFalse(
+            job.failed,
+            "4 errors in 200 photos must not sticky the job-level failed flag",
+        )
+        self.assertEqual(job.result["status"], "partial_failure")
+        self.assertEqual(job.result["error_count"], 4)
+        self.assertEqual(len(job.result["errors"]), 4)
+
+    def test_many_errors_above_threshold_marks_failed(self):
+        target = 200
+        job = self._new_job(target=target)
+        # 30 errors out of 200 = 15%, well above the 5% rate.
+        for i in range(target):
+            failed = i < 30
+            error = f"err-{i}" if failed else None
+            update_scan_counter(job.job_id, failed=failed, error=error)
+        job.refresh_from_db()
+        self.assertTrue(job.finished)
+        self.assertTrue(job.failed)
+        self.assertEqual(job.result["status"], "failed")
+        self.assertEqual(job.result["error_count"], 30)
+
+    def test_mid_run_error_does_not_sticky_failed_flag(self):
+        # Single error early in a 200-photo run: job.failed must stay False
+        # while the run is in progress, and result.status must become
+        # 'partial_failure' so the UI can distinguish from a clean run.
+        job = self._new_job(target=200)
+        update_scan_counter(job.job_id, failed=True, error="boom")
+        job.refresh_from_db()
+        self.assertFalse(job.finished)
+        self.assertFalse(job.failed)
+        self.assertEqual(job.result["status"], "partial_failure")
+        self.assertEqual(job.result["error_count"], 1)
+
+    def test_error_count_survives_errors_list_cap_at_100(self):
+        # The errors list is capped at 100 to bound DB-row growth, but
+        # error_count must keep increasing past the cap for the threshold
+        # decision.
+        target = 250
+        job = self._new_job(target=target)
+        for i in range(target):
+            failed = i < 130
+            error = f"unique-error-{i}" if failed else None
+            update_scan_counter(job.job_id, failed=failed, error=error)
+        job.refresh_from_db()
+        self.assertEqual(len(job.result["errors"]), 100, "errors list is capped")
+        self.assertEqual(job.result["error_count"], 130, "but error_count is uncapped")
+        self.assertTrue(job.failed)
+        self.assertEqual(job.result["status"], "failed")
+
+    def test_cancelled_job_does_not_get_failed_flag(self):
+        # Pre-existing contract from test_job_cancel — cancellation
+        # short-circuits before any failed/status mutation.
+        job = self._new_job(target=10)
+        job.cancel()
+        update_scan_counter(job.job_id, failed=True, error="boom")
+        job.refresh_from_db()
+        self.assertTrue(job.cancelled)
+        self.assertFalse(job.failed)


### PR DESCRIPTION
The current update_scan_counter sets job.failed = True after a single per-photo error and the flag is sticky for the rest of the run:

    job.failed = failed or job.failed

So a scan that processes 152520 photos and errors on 4 of them — a real production case visible in LongRunningJob row
58b891a5-5776-4a27-9ae3-c5610a80ee27 from a user's instance, with progress 152520/152520 and result.status='partial_failure' — shows up as the red "Failed" banner in the admin UI even though 99.997% of work succeeded. result already correctly carries the partial_failure status and the per-photo error list; only the sticky boolean is wrong.

This change replaces both occurrences of the sticky assignment with a threshold-based decision:

  threshold = max(FAILURE_ERROR_FLOOR, FAILURE_ERROR_RATE * target)
  job.failed = error_count > threshold

with FAILURE_ERROR_FLOOR = 10 and FAILURE_ERROR_RATE = 0.05, so:

  * Few errors in a large run (e.g. 4 / 152520) ⇒ failed=False, status=partial_failure. UI shows green, but the errors list and error_count are still on the row for anyone who wants per-photo detail.
  * Many errors out of a small target ⇒ failed=True, status=failed.
  * Zero errors ⇒ failed=False, no status change.

A new uncapped result['error_count'] field is added so the threshold keeps working past the existing 100-entry cap on result['errors'] (present to bound DB-row growth).

Also folds the two parallel result-mutation blocks (finishing vs running) into a single accumulator-then-decide flow, which removes a duplicate refetch of the LongRunningJob row.

Tests in api/tests/test_job_failure_threshold.py cover the threshold function directly (no DB), then drive update_scan_counter end-to-end: zero errors stay clean, four errors in a 200-photo run does not stick the failed flag, thirty errors in 200 does, mid-run errors mark partial_failure without stickying failed, the error_count counter survives the 100-entry list cap, and the pre-existing cancellation contract is preserved. test_job_cancel and test_scan_percentage_bug continue to pass.