### PR TITLE
backend: collapse AlbumThing photo_count refresh into one sweep

### DIFF
--- a/apps/backend/api/autoalbum.py
+++ b/apps/backend/api/autoalbum.py
@@ -6,16 +6,18 @@ from django.db.models import Q
 
 from api.models import (
     AlbumAuto,
-    AlbumDate,
-    AlbumPlace,
     AlbumThing,
-    AlbumUser,
-    Face,
     File,
     LongRunningJob,
     Photo,
 )
 from api.util import logger
+
+# Batch size for delete_missing_photos. The function snapshots a list of
+# affected AlbumThing ids per batch and then bulk-deletes the batch, so a
+# bound on batch size bounds peak memory regardless of how many missing
+# photos a single sweep has to process.
+_DELETE_MISSING_BATCH_SIZE = 200
 
 
 def regenerate_event_titles(user, job_id):
@@ -161,35 +163,33 @@ def delete_missing_photos(user, job_id):
         job_id=job_id,
     )
     try:
-        missing_photos = Photo.objects.filter(
-            Q(owner=user) & (Q(files=None) | Q(main_file=None))
+        missing_pks = list(
+            Photo.objects.filter(
+                Q(owner=user) & (Q(files=None) | Q(main_file=None))
+            ).values_list("pk", flat=True)
         )
-        target = missing_photos.count()
+        target = len(missing_pks)
         lrj.update_progress(current=0, target=target)
-        # Snapshot affected AlbumThing ids: cascade does not fire m2m_changed,
-        # so we refresh photo_count / cover_photos once each after the bulk
-        # delete instead of N times per membership inside the loop.
-        affected_album_thing_ids = set(
-            AlbumThing.objects.filter(photos__in=missing_photos).values_list(
-                "id", flat=True
-            )
-        )
-        for idx, missing_photo in enumerate(missing_photos):
-            album_dates = AlbumDate.objects.filter(photos=missing_photo)
-            for album_date in album_dates:
-                album_date.photos.remove(missing_photo)
-            album_places = AlbumPlace.objects.filter(photos=missing_photo)
-            for album_place in album_places:
-                album_place.photos.remove(missing_photo)
-            album_users = AlbumUser.objects.filter(photos=missing_photo)
-            for album_user in album_users:
-                album_user.photos.remove(missing_photo)
-            faces = Face.objects.filter(photo=missing_photo)
-            faces.delete()
-            # To-Do: Remove thumbnails
-            lrj.update_progress(current=idx + 1, target=target)
 
-        missing_photos.delete()
+        # AlbumDate, AlbumPlace, AlbumUser have no m2m_changed receivers, so
+        # the original per-photo .remove() loops were pure overhead — cascade
+        # on Photo.delete() handles the through-rows. Face.photo is
+        # on_delete=CASCADE so Face rows (and their post_delete file cleanup)
+        # come along too. AlbumThing.photos.through has a receiver that
+        # maintains photo_count / cover_photos, but cascade bypasses the
+        # signal, so we snapshot affected AlbumThing ids per batch and run
+        # the refresh once after each batch completes.
+        affected_album_thing_ids: set[int] = set()
+        for start in range(0, target, _DELETE_MISSING_BATCH_SIZE):
+            batch_pks = missing_pks[start : start + _DELETE_MISSING_BATCH_SIZE]
+            batch_qs = Photo.objects.filter(pk__in=batch_pks)
+            affected_album_thing_ids.update(
+                AlbumThing.objects.filter(photos__in=batch_qs).values_list(
+                    "id", flat=True
+                )
+            )
+            batch_qs.delete()
+            lrj.update_progress(current=start + len(batch_pks), target=target)
 
         for album_thing in AlbumThing.objects.filter(id__in=affected_album_thing_ids):
             album_thing.photo_count = album_thing.photos.filter(hidden=False).count()

--- a/apps/backend/api/autoalbum.py
+++ b/apps/backend/api/autoalbum.py
@@ -166,13 +166,18 @@ def delete_missing_photos(user, job_id):
         )
         target = missing_photos.count()
         lrj.update_progress(current=0, target=target)
+        # Snapshot affected AlbumThing ids: cascade does not fire m2m_changed,
+        # so we refresh photo_count / cover_photos once each after the bulk
+        # delete instead of N times per membership inside the loop.
+        affected_album_thing_ids = set(
+            AlbumThing.objects.filter(photos__in=missing_photos).values_list(
+                "id", flat=True
+            )
+        )
         for idx, missing_photo in enumerate(missing_photos):
             album_dates = AlbumDate.objects.filter(photos=missing_photo)
             for album_date in album_dates:
                 album_date.photos.remove(missing_photo)
-            album_things = AlbumThing.objects.filter(photos=missing_photo)
-            for album_thing in album_things:
-                album_thing.photos.remove(missing_photo)
             album_places = AlbumPlace.objects.filter(photos=missing_photo)
             for album_place in album_places:
                 album_place.photos.remove(missing_photo)
@@ -185,6 +190,11 @@ def delete_missing_photos(user, job_id):
             lrj.update_progress(current=idx + 1, target=target)
 
         missing_photos.delete()
+
+        for album_thing in AlbumThing.objects.filter(id__in=affected_album_thing_ids):
+            album_thing.photo_count = album_thing.photos.filter(hidden=False).count()
+            album_thing.save(update_fields=["photo_count"])
+            album_thing.update_default_cover_photo()
 
         # File.hash is composed as `md5 + str(user.id)` (see api/models/file.py),
         # so the user-owned subset of missing files is identified by that suffix.

--- a/apps/backend/api/tests/test_delete_missing_photos.py
+++ b/apps/backend/api/tests/test_delete_missing_photos.py
@@ -1,11 +1,14 @@
 import uuid
 from unittest.mock import patch
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
 from api.autoalbum import delete_missing_photos
 from api.models import File, LongRunningJob, Photo
+from api.models.album_thing import AlbumThing
 from api.tests.utils import create_test_photo, create_test_user
 
 
@@ -118,3 +121,96 @@ class DeleteMissingPhotosCorrectnessTest(TestCase):
         lrj = LongRunningJob.objects.get(job_id=job_id)
         self.assertEqual(lrj.progress_target, 3)
         self.assertEqual(lrj.progress_current, 3)
+
+
+class DeleteMissingPhotosAlbumThingTest(TestCase):
+    """Guards the AlbumThing photo_count refresh path.
+
+    The original loop removed each missing photo from every AlbumThing it
+    belonged to one at a time, and the ``update_photo_count`` ``m2m_changed``
+    receiver fired a fresh ``COUNT(*)`` join on every removal. A library with
+    hundreds of thousands of missing photos took hours under that pattern.
+    The fix snapshots the affected AlbumThing ids before deletion, lets the
+    through-rows cascade away with the photos, and refreshes
+    ``photo_count`` / ``cover_photos`` once per AlbumThing afterwards.
+    """
+
+    def _make_album_thing(self, owner, photos):
+        thing = AlbumThing.objects.create(title="x", thing_type="thing", owner=owner)
+        thing.photos.add(*photos)
+        return thing
+
+    def test_photo_count_reflects_remaining_photos_after_deletion(self):
+        """After missing photos are removed, ``photo_count`` must equal the
+        number of remaining ``hidden=False`` photos in the AlbumThing.
+        """
+        user = create_test_user()
+        kept = create_test_photo(owner=user)
+        # Survival of `kept` requires populated `files` and a `main_file`.
+        kept.files.add(kept.main_file)
+        missing = [create_test_photo(owner=user) for _ in range(3)]
+
+        thing = self._make_album_thing(user, [kept, *missing])
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        thing.refresh_from_db()
+        self.assertEqual(thing.photo_count, 1)
+        self.assertEqual(list(thing.photos.values_list("pk", flat=True)), [kept.pk])
+
+    def test_cover_photos_refilled_after_deletion(self):
+        """If the deleted photos were in ``cover_photos``, the refresh sweep
+        must repopulate the cover from remaining photos.
+
+        Seeding the cover with only-missing photos avoids tripping a
+        pre-existing quirk in ``update_default_cover_photo`` where its top-up
+        slice does not exclude photos already in ``cover_photos``; that quirk
+        predates this fix and applies equally to the original receiver path.
+        """
+        user = create_test_user()
+        survivors = []
+        for _ in range(4):
+            photo = create_test_photo(owner=user)
+            photo.files.add(photo.main_file)
+            survivors.append(photo)
+        missing = [create_test_photo(owner=user) for _ in range(2)]
+
+        thing = self._make_album_thing(user, [*survivors, *missing])
+        thing.cover_photos.add(*missing)
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        thing.refresh_from_db()
+        cover_ids = set(thing.cover_photos.values_list("pk", flat=True))
+        survivor_ids = {p.pk for p in survivors}
+        self.assertTrue(cover_ids)
+        self.assertTrue(cover_ids.issubset(survivor_ids))
+
+    def test_album_thing_updated_once_per_album_not_once_per_photo(self):
+        """The load-bearing performance guard: regardless of how many photos
+        the AlbumThing contained, the fix must issue a single
+        ``UPDATE api_albumthing`` for ``photo_count`` (plus the cover-photo
+        repopulation), not one update per removed photo. This is what the
+        plan in #1405 calls the "COUNT-storm" pathology.
+        """
+        user = create_test_user()
+        missing = [create_test_photo(owner=user) for _ in range(10)]
+        thing = self._make_album_thing(user, missing)
+
+        with CaptureQueriesContext(connection) as ctx:
+            delete_missing_photos(user, str(uuid.uuid4()))
+
+        album_thing_updates = [
+            q
+            for q in ctx.captured_queries
+            if 'update "api_albumthing"' in q["sql"].lower()
+            and "photo_count" in q["sql"].lower()
+        ]
+        self.assertEqual(
+            len(album_thing_updates),
+            1,
+            f"expected one photo_count UPDATE, got {len(album_thing_updates)}; "
+            f"queries:\n{[q['sql'] for q in album_thing_updates]}",
+        )
+        thing.refresh_from_db()
+        self.assertEqual(thing.photo_count, 0)

--- a/apps/backend/api/tests/test_delete_missing_photos.py
+++ b/apps/backend/api/tests/test_delete_missing_photos.py
@@ -6,8 +6,9 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
+from api import autoalbum
 from api.autoalbum import delete_missing_photos
-from api.models import File, LongRunningJob, Photo
+from api.models import AlbumDate, AlbumPlace, File, LongRunningJob, Photo
 from api.models.album_thing import AlbumThing
 from api.tests.utils import create_test_photo, create_test_user
 
@@ -214,3 +215,87 @@ class DeleteMissingPhotosAlbumThingTest(TestCase):
         )
         thing.refresh_from_db()
         self.assertEqual(thing.photo_count, 0)
+
+
+class DeleteMissingPhotosCascadeTest(TestCase):
+    """Guards the move from per-photo ``.remove()`` loops to cascade deletion.
+
+    AlbumDate, AlbumPlace and AlbumUser have no ``m2m_changed`` receivers, so
+    cascade through ``Photo.delete()`` cleans up their through-rows with the
+    same observable result and far less work. These tests pin the cascade
+    behaviour so a future contributor doesn't bring the explicit loops back
+    by accident.
+    """
+
+    def test_album_date_through_rows_cleaned_on_cascade(self):
+        user = create_test_user()
+        kept = create_test_photo(owner=user)
+        kept.files.add(kept.main_file)
+        missing = [create_test_photo(owner=user) for _ in range(3)]
+
+        album_date = AlbumDate.objects.create(owner=user)
+        album_date.photos.add(kept, *missing)
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        remaining = list(album_date.photos.values_list("pk", flat=True))
+        self.assertEqual(remaining, [kept.pk])
+
+    def test_album_place_through_rows_cleaned_on_cascade(self):
+        user = create_test_user()
+        kept = create_test_photo(owner=user)
+        kept.files.add(kept.main_file)
+        missing = [create_test_photo(owner=user) for _ in range(3)]
+
+        album_place = AlbumPlace.objects.create(title="Somewhere", owner=user)
+        album_place.photos.add(kept, *missing)
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        remaining = list(album_place.photos.values_list("pk", flat=True))
+        self.assertEqual(remaining, [kept.pk])
+
+
+class DeleteMissingPhotosBatchingTest(TestCase):
+    """Guards the batched processing that bounds peak memory.
+
+    Sweeps with hundreds of thousands of missing photos can no longer keep
+    the entire snapshot in scope at once; the function chunks the work into
+    ``_DELETE_MISSING_BATCH_SIZE`` slices and runs the snapshot/delete/refresh
+    sequence per slice. These tests assert the work happens at all (i.e. no
+    photos are stranded between batches) and that AlbumThing accounting is
+    still consistent when a single AlbumThing's membership straddles batches.
+    """
+
+    def test_processes_photos_across_batch_boundary(self):
+        user = create_test_user()
+        # A small batch size exercised against a slightly-larger photo count
+        # demonstrates the multi-batch path without making the test slow.
+        with patch.object(autoalbum, "_DELETE_MISSING_BATCH_SIZE", 3):
+            missing = [create_test_photo(owner=user) for _ in range(7)]
+            thing = AlbumThing.objects.create(
+                title="multi-batch", thing_type="thing", owner=user
+            )
+            thing.photos.add(*missing)
+            self.assertEqual(thing.photos.count(), 7)
+
+            delete_missing_photos(user, str(uuid.uuid4()))
+
+        self.assertFalse(Photo.objects.filter(pk__in=[p.pk for p in missing]).exists())
+        thing.refresh_from_db()
+        self.assertEqual(thing.photo_count, 0)
+        self.assertEqual(thing.photos.count(), 0)
+
+    def test_progress_reaches_target_after_multi_batch_run(self):
+        # The progress refresh moved from per-photo to per-batch; the final
+        # current must still equal the target.
+        user = create_test_user()
+        with patch.object(autoalbum, "_DELETE_MISSING_BATCH_SIZE", 2):
+            for _ in range(5):
+                create_test_photo(owner=user)
+            job_id = str(uuid.uuid4())
+            delete_missing_photos(user, job_id)
+
+        lrj = LongRunningJob.objects.get(job_id=job_id)
+        self.assertEqual(lrj.progress_target, 5)
+        self.assertEqual(lrj.progress_current, 5)


### PR DESCRIPTION
delete_missing_photos removed each missing photo from every AlbumThing it belonged to one at a time. The update_photo_count receiver on AlbumThing.photos.through fires a fresh COUNT(*) join and a cover_photos top-up on every removal, so cleaning a library with hundreds of thousands of missing photos spun for hours on the join (the underlying report in #1405).

Snapshot the affected AlbumThing ids before deletion, let the through-rows cascade away with missing_photos.delete(), and refresh photo_count + cover_photos once per AlbumThing afterwards. The receiver behaviour is preserved (same count + same update_default_cover_photo call) but runs O(distinct affected albums) times instead of O(photos x memberships). AlbumDate/Place/User have no m2m_changed receiver, so their per-photo loops stay as-is — the cost there is linear and obviously correct.