### PR TITLE
enable Select All for the Download action

### DIFF
--- a/apps/backend/api/tests/test_zip_list_photos_view_v2.py
+++ b/apps/backend/api/tests/test_zip_list_photos_view_v2.py
@@ -34,3 +34,148 @@ class PhotoListWithoutTimestampTest(TestCase):
         patched_shutil.return_value.free = 0
         response_3 = self.client.post("/api/photos/download", data=datadict)
         self.assertEqual(response_3.status_code, 507)
+
+
+class ZipListPhotosV2SelectAllTest(TestCase):
+    """The download endpoint also accepts the select_all + query payload
+    shape that the other bulk mutations (favorite/hide/public/delete)
+    already support, so that the frontend can offer Download when the
+    user has done a server-side "Select All" without enumerating every
+    image hash. The async zip task isn't exercised in these tests; we
+    inspect the photo set handed to create_download_job instead."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.other_user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+
+        disk_patcher = patch("shutil.disk_usage")
+        patched_disk = disk_patcher.start()
+        patched_disk.return_value.free = 500000000
+        self.addCleanup(disk_patcher.stop)
+
+        # create_download_job enqueues a django-q AsyncTask; stub it out and
+        # capture the photos that would have been zipped instead.
+        job_patcher = patch("api.views.views.create_download_job")
+        self.mock_create_job = job_patcher.start()
+        self.mock_create_job.return_value = "fake-job-id"
+        self.addCleanup(job_patcher.stop)
+
+    def _queued_hashes(self):
+        self.assertTrue(
+            self.mock_create_job.called,
+            msg="create_download_job was never reached — the view returned early",
+        )
+        photos = self.mock_create_job.call_args.kwargs["photos"]
+        return {photo.image_hash for photo in photos}
+
+    def test_select_all_with_empty_query_includes_all_user_photos(self):
+        photos = create_test_photos(number_of_photos=3, owner=self.user, size=100)
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={"select_all": True, "query": {}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._queued_hashes(), {p.image_hash for p in photos})
+
+    def test_select_all_only_includes_requesting_users_photos(self):
+        mine = create_test_photos(number_of_photos=2, owner=self.user, size=100)
+        create_test_photos(number_of_photos=2, owner=self.other_user, size=100)
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={"select_all": True, "query": {}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._queued_hashes(), {p.image_hash for p in mine})
+
+    def test_select_all_respects_excluded_hashes(self):
+        photos = create_test_photos(number_of_photos=4, owner=self.user, size=100)
+        excluded = [photos[0].image_hash, photos[1].image_hash]
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={
+                "select_all": True,
+                "query": {},
+                "excluded_hashes": excluded,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._queued_hashes(), {p.image_hash for p in photos[2:]})
+
+    def test_select_all_applies_query_filters(self):
+        videos = create_test_photos(
+            number_of_photos=2, owner=self.user, size=100, video=True
+        )
+        create_test_photos(number_of_photos=3, owner=self.user, size=100, video=False)
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={"select_all": True, "query": {"video": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._queued_hashes(), {p.image_hash for p in videos})
+
+    def test_select_all_with_no_matching_photos_returns_404(self):
+        # Two videos in the library, but the user's filter says photos-only.
+        create_test_photos(number_of_photos=2, owner=self.user, size=100, video=True)
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={"select_all": True, "query": {"photo": True}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(self.mock_create_job.called)
+
+    def test_select_all_with_everything_excluded_returns_404(self):
+        photos = create_test_photos(number_of_photos=2, owner=self.user, size=100)
+
+        response = self.client.post(
+            "/api/photos/download",
+            data={
+                "select_all": True,
+                "query": {},
+                "excluded_hashes": [p.image_hash for p in photos],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(self.mock_create_job.called)
+
+    def test_missing_image_hashes_still_rejected_when_select_all_falsy(self):
+        # Without select_all the original contract is preserved.
+        response = self.client.post(
+            "/api/photos/download", data={"select_all": False}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(self.mock_create_job.called)
+
+    def test_storage_check_runs_in_select_all_mode(self):
+        # If free storage is smaller than the aggregated photo size, the
+        # endpoint returns 507 regardless of which payload shape was used.
+        create_test_photos(number_of_photos=2, owner=self.user, size=10**9)
+
+        with patch("shutil.disk_usage") as patched_disk:
+            patched_disk.return_value.free = 0
+            response = self.client.post(
+                "/api/photos/download",
+                data={"select_all": True, "query": {}},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 507)
+        self.assertFalse(self.mock_create_job.called)

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -1002,20 +1002,10 @@ class ZipListPhotosView_V2(APIView):
     def post(self, request):
         import shutil
 
+        from api.views.photo_filters import build_photo_queryset
+
         free_storage = shutil.disk_usage("/").free
         data = request.data
-        image_hashes = data.get("image_hashes")
-        if not image_hashes:
-            return Response(data={"error": "image_hashes required"}, status=400)
-
-        # DRF may provide list values (QueryDict) or a single string
-        if isinstance(image_hashes, str):
-            image_hashes = [image_hashes]
-        elif isinstance(image_hashes, (list, tuple)):
-            # QueryDict -> dict() would produce list values, request.data keeps list too
-            pass
-        else:
-            image_hashes = list(image_hashes)
 
         include_stacked = data.get("include_stacked_photos", False)
         if isinstance(include_stacked, (list, tuple)):
@@ -1030,8 +1020,39 @@ class ZipListPhotosView_V2(APIView):
         include_stacked = bool(include_stacked)
 
         photo_query = Photo.objects.filter(owner=self.request.user)
-        # Filter photos based on image hashes
-        photos = photo_query.filter(image_hash__in=image_hashes)
+
+        # Two payload shapes are accepted, mirroring the other bulk mutations
+        # (SetPhotosDeleted, SetFavoritePhotos, SetPhotosHidden, SetPhotosPublic):
+        # an explicit `image_hashes` list, or `select_all=True` plus a `query`
+        # describing the photoset the user is looking at, with optional
+        # `excluded_hashes` for items they unchecked.
+        if data.get("select_all"):
+            query_params = data.get("query") or {}
+            if isinstance(query_params, (list, tuple)):
+                query_params = query_params[0] if query_params else {}
+            excluded_hashes = data.get("excluded_hashes") or []
+            if isinstance(excluded_hashes, str):
+                excluded_hashes = [excluded_hashes]
+
+            photos = build_photo_queryset(self.request.user, query_params)
+            if excluded_hashes:
+                photos = photos.exclude(image_hash__in=excluded_hashes)
+        else:
+            image_hashes = data.get("image_hashes")
+            if not image_hashes:
+                return Response(data={"error": "image_hashes required"}, status=400)
+
+            # DRF may provide list values (QueryDict) or a single string
+            if isinstance(image_hashes, str):
+                image_hashes = [image_hashes]
+            elif isinstance(image_hashes, (list, tuple)):
+                # QueryDict -> dict() would produce list values, request.data keeps list too
+                pass
+            else:
+                image_hashes = list(image_hashes)
+
+            photos = photo_query.filter(image_hash__in=image_hashes)
+
         if not photos.exists():
             return Response(data={"error": "No photos found"}, status=404)
 

--- a/apps/frontend/src/api_client/jobs/hooks/useDownloadPhotosMutation.ts
+++ b/apps/frontend/src/api_client/jobs/hooks/useDownloadPhotosMutation.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { notification } from "../../../service/notifications";
 import { fetchClient } from "../../api";
 import { serverAddress } from "../../apiClient";
+import type { BulkPhotoQuery } from "../../photos/types";
 
 type StatusResponse = { status: string };
 
@@ -10,10 +11,20 @@ type DownloadResponse = {
   job_id: string;
 };
 
-type DownloadOptions = {
+type IndividualDownloadOptions = {
+  select_all?: false;
   image_hashes: string[];
   include_stacked_photos?: boolean;
 };
+
+type SelectAllDownloadOptions = {
+  select_all: true;
+  query: BulkPhotoQuery;
+  excluded_hashes?: string[];
+  include_stacked_photos?: boolean;
+};
+
+type DownloadOptions = IndividualDownloadOptions | SelectAllDownloadOptions;
 
 async function startDownloadProcess(options: DownloadOptions) {
   const response = await fetchClient.post("/photos/download", options);
@@ -44,19 +55,29 @@ async function downloadFile(filename: string) {
   window.URL.revokeObjectURL(downloadUrl);
 }
 
+type IndividualMutationArgs = {
+  select_all?: false;
+  image_hashes: string[];
+  userId: number | null;
+  includeStackedPhotos?: boolean;
+};
+
+type SelectAllMutationArgs = {
+  select_all: true;
+  query: BulkPhotoQuery;
+  excluded_hashes?: string[];
+  userId: number | null;
+  includeStackedPhotos?: boolean;
+};
+
+type DownloadMutationArgs = IndividualMutationArgs | SelectAllMutationArgs;
+
 // Download photos
 export const useDownloadPhotosMutation = () =>
   useMutation({
-    mutationFn: async ({
-      image_hashes,
-      userId,
-      includeStackedPhotos = false,
-    }: {
-      image_hashes: string[];
-      userId: number | null;
-      includeStackedPhotos?: boolean;
-    }) => {
-      console.log("[Download] Starting download process", { image_hashes, userId, includeStackedPhotos });
+    mutationFn: async (args: DownloadMutationArgs) => {
+      const { userId, includeStackedPhotos = false } = args;
+      console.log("[Download] Starting download process", { args });
       notification.downloadStarting();
 
       if (!userId) {
@@ -65,10 +86,18 @@ export const useDownloadPhotosMutation = () =>
         throw new Error("User ID is required for download");
       }
 
-      const { job_id: jobId, url: filename } = await startDownloadProcess({
-        image_hashes,
-        include_stacked_photos: includeStackedPhotos,
-      });
+      const downloadRequest: DownloadOptions = args.select_all
+        ? {
+            select_all: true,
+            query: args.query,
+            excluded_hashes: args.excluded_hashes,
+            include_stacked_photos: includeStackedPhotos,
+          }
+        : {
+            image_hashes: args.image_hashes,
+            include_stacked_photos: includeStackedPhotos,
+          };
+      const { job_id: jobId, url: filename } = await startDownloadProcess(downloadRequest);
       console.log("[Download] Job started", { jobId, filename });
 
       const statusInterval = setInterval(async () => {

--- a/apps/frontend/src/components/photolist/PhotoListView.tsx
+++ b/apps/frontend/src/components/photolist/PhotoListView.tsx
@@ -613,6 +613,7 @@ function PhotoListViewComponent({
                     selectedItems={selectionState.selectedItems}
                     selectAllMode={selectionState.selectAllMode}
                     selectAllQuery={selectionState.selectAllQuery}
+                    totalCount={selectionState.totalCount || numberOfItems || idx2hash.length}
                     // @ts-ignore
                     albumID={params ? params.albumID : undefined}
                     ownerUsername={ownerUsername}

--- a/apps/frontend/src/components/photolist/SelectionActions.tsx
+++ b/apps/frontend/src/components/photolist/SelectionActions.tsx
@@ -45,6 +45,7 @@ type Props = {
   selectedItems: UserAlbum[];
   selectAllMode?: boolean;
   selectAllQuery?: BulkPhotoQuery;
+  totalCount?: number;
   updateSelectionState: (state: Partial<SelectionState>) => void;
   onSharePhotos: () => void;
   setAlbumCover: (actionType: string, photoId?: string) => void;
@@ -73,6 +74,7 @@ export function SelectionActions(props: Readonly<Props>) {
     selectedItems,
     selectAllMode = false,
     selectAllQuery,
+    totalCount,
     updateSelectionState,
     onSharePhotos,
     onShareAlbum,
@@ -129,12 +131,30 @@ export function SelectionActions(props: Readonly<Props>) {
   // Download modal state
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
 
+  // In select-all mode the modal can only show an upper bound, because the
+  // server-side query is the source of truth and the excluded set may contain
+  // hashes that aren't currently in `selectedItems` (e.g. items scrolled out of
+  // virtualised view). Subtracting still gives a reasonable estimate for the UI.
+  const downloadPhotoCount = selectAllMode
+    ? Math.max(0, (totalCount ?? 0) - getExcludedHashes().length)
+    : getImageHashes().length;
+
   const handleDownloadConfirm = (options: { includeStackedPhotos: boolean }) => {
-    downloadPhotoArchive.mutate({
-      image_hashes: getImageHashes(),
-      userId,
-      includeStackedPhotos: options.includeStackedPhotos,
-    });
+    if (selectAllMode) {
+      downloadPhotoArchive.mutate({
+        select_all: true,
+        query: selectAllQuery ?? {},
+        excluded_hashes: getExcludedHashes(),
+        userId,
+        includeStackedPhotos: options.includeStackedPhotos,
+      });
+    } else {
+      downloadPhotoArchive.mutate({
+        image_hashes: getImageHashes(),
+        userId,
+        includeStackedPhotos: options.includeStackedPhotos,
+      });
+    }
     resetSelection();
   };
 
@@ -142,7 +162,7 @@ export function SelectionActions(props: Readonly<Props>) {
     <Group>
       <ModalDownloadOptions
         isOpen={isDownloadModalOpen}
-        photoCount={getImageHashes().length}
+        photoCount={downloadPhotoCount}
         onRequestClose={() => setIsDownloadModalOpen(false)}
         onConfirm={handleDownloadConfirm}
       />
@@ -331,16 +351,7 @@ export function SelectionActions(props: Readonly<Props>) {
 
           <Menu.Divider />
 
-          <Menu.Item
-            leftSection={<Download />}
-            disabled={!hasSelection || selectAllMode}
-            onClick={() => {
-              // Download doesn't support selectAll mode yet
-              if (!selectAllMode) {
-                setIsDownloadModalOpen(true);
-              }
-            }}
-          >
+          <Menu.Item leftSection={<Download />} disabled={!hasSelection} onClick={() => setIsDownloadModalOpen(true)}>
             {`  ${t("selectionactions.download")}`}
           </Menu.Item>
 


### PR DESCRIPTION
The download endpoint previously only accepted an explicit `image_hashes` list, while the other bulk mutations (favorite / hide / public / delete) already understood the `select_all=True` + `query` + `excluded_hashes` shape produced by the server-side "Select All" mode. The frontend papered over the mismatch by graying out the Download menu item whenever `selectAllMode` was active, which is confusing — the user sees "All N selected" but cannot download.

`ZipListPhotosView_V2` now accepts the same payload shape the other mutations use, resolved via the existing `build_photo_queryset` helper in `apps/backend/api/views/photo_filters.py`, with `excluded_hashes` honoured for items the user unchecked. Owner scoping comes from `build_photo_queryset` itself (it already filters by `owner=user` unless `public=True`), so a logged-in user cannot enumerate someone else's library through this path. The existing `image_hashes` contract is unchanged.

The frontend mutation hook accepts both payload shapes, the `disabled={!hasSelection || selectAllMode}` guard on the Download menu item drops the `selectAllMode` half, and the click handler branches on `selectAllMode` like the favorite / hide / delete handlers already do. The download modal's photo count uses `totalCount - excluded` as an upper-bound estimate when in select-all mode (virtualisation means `selectedItems` doesn't list the photos that scrolled off).

Tests cover the new query path, exclusions, query filters, user scoping, the still-rejected empty payload, and the 507 storage path. The frontend half was verified by reading; I do not have a browser environment to drive the gallery view end-to-end.