### PR TITLE
chore: apply prettier to WorkerIndicator.tsx

### DIFF
--- a/apps/frontend/src/components/menubars/WorkerIndicator.tsx
+++ b/apps/frontend/src/components/menubars/WorkerIndicator.tsx
@@ -25,7 +25,13 @@ function WorkerRunningJob({ workerRunningJob }: IWorkerIndicator) {
           {t("topmenu.running")} {workerRunningJob.job_type_str} ...
         </Text>
         {!workerRunningJob.finished && !workerRunningJob.cancelled && (
-          <Button onClick={() => cancelJob(workerRunningJob.id)} color="red" variant="outline" size="xs" loading={isPending}>
+          <Button
+            onClick={() => cancelJob(workerRunningJob.id)}
+            color="red"
+            variant="outline"
+            size="xs"
+            loading={isPending}
+          >
             {t("joblist.cancel")}
           </Button>
         )}


### PR DESCRIPTION
`yarn lint:error` has been failing on `dev` since `1d4defaf` (April 2026) because of a prettier nit in `apps/frontend/src/components/menubars/WorkerIndicator.tsx`. None of the PRs merged since then touched `apps/frontend/**`, so the path-filtered `lint-frontend` workflow never ran and the issue stayed latent. #1851 is the first PR after that point to touch the frontend and it inherits this failure.

This is the same pattern as #1833 unblocking #1832 on the backend last week — a one-shot format-only chore so a downstream PR can land. The diff is purely the autoformat output of `yarn prettier --write` on the one offending file. No behaviour change.

After this lands I'll rebase #1851 onto `dev` so its CI sees a green base.
