### PR TITLE
backend: fix median_value crash on even counts and off-by-one on odd

### DIFF
--- a/apps/backend/api/stats.py
+++ b/apps/backend/api/stats.py
@@ -51,9 +51,9 @@ def median_value(queryset, term):
         return
     values = queryset.values_list(term, flat=True).order_by(term)
     if count % 2 == 1:
-        return values[int(round(count / 2))]
+        return values[count // 2]
     else:
-        return sum(values[count / 2 - 1 : count / 2 + 1]) / Decimal(2.0)
+        return sum(values[count // 2 - 1 : count // 2 + 1]) / Decimal(2.0)
 
 
 def calc_megabytes(bytes):

--- a/apps/backend/api/tests/test_stats_accuracy.py
+++ b/apps/backend/api/tests/test_stats_accuracy.py
@@ -332,6 +332,35 @@ class UtilityFunctionsTestCase(TestCase):
         result = median_value(qs, "size")
         self.assertIsNone(result)
 
+    def test_median_value_odd_count(self):
+        """Median of an odd number of values is the middle element."""
+        user = create_test_user()
+        for size in (10, 20, 30):
+            create_test_photo(owner=user, size=size)
+        qs = Photo.objects.filter(owner=user)
+        self.assertEqual(median_value(qs, "size"), 20)
+
+    def test_median_value_even_count(self):
+        """Median of an even number of values averages the two middle ones.
+
+        Regression test: ``count / 2`` is a float in Python 3, so the old
+        slice ``values[count / 2 - 1 : count / 2 + 1]`` raised TypeError for
+        every even-sized queryset, breaking the whole server-stats endpoint.
+        """
+        user = create_test_user()
+        for size in (10, 20, 30, 40):
+            create_test_photo(owner=user, size=size)
+        qs = Photo.objects.filter(owner=user)
+        self.assertEqual(median_value(qs, "size"), 25)
+
+    def test_median_value_two_values(self):
+        """Smallest even case: average of the two values."""
+        user = create_test_user()
+        for size in (10, 30):
+            create_test_photo(owner=user, size=size)
+        qs = Photo.objects.filter(owner=user)
+        self.assertEqual(median_value(qs, "size"), 20)
+
 
 class CountStatsTestCase(TestCase):
     """Test get_count_stats function."""


### PR DESCRIPTION
`stats.median_value` derived its slice and index bounds with `count / 2`, which is true division in Python 3. For an even number of rows the float slice `values[count / 2 - 1 : count / 2 + 1]` raises `TypeError: slice indices must be integers or None`, so the entire server-stats response blows up whenever a user happens to have an even number of albums, places, things, or events — and those medians feed ten call sites in `get_server_stats`. For odd counts the index `int(round(count / 2))` uses banker's rounding, which returns the element one past the true median (three values return the largest instead of the middle one).

This switches both branches to integer division (`count // 2`) and adds regression tests for the odd, even, and two-element cases. The even and two-element tests both fail on the current code — the first with the `TypeError`, the second by averaging the wrong pair — and the odd test pins down the off-by-one.
