### PR TITLE
backend: keep zero-valued GPS, rating and burst index in metadata

### DIFF
--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -313,8 +313,14 @@ class Photo(models.Model):
             try_sidecar=True,
         )
         old_album_places = self._find_album_place()
-        # Skip if it hasn't changed or is null
-        if not new_gps_lat or not new_gps_lon:
+        # Skip if coordinates are missing or the (0, 0) "null island" default
+        # that cameras write when there is no fix. A single zero axis (the
+        # equator or the prime meridian) is a valid location and must be kept.
+        if (
+            new_gps_lat is None
+            or new_gps_lon is None
+            or (float(new_gps_lat) == 0.0 and float(new_gps_lon) == 0.0)
+        ):
             return
         if (
             old_gps_lat == float(new_gps_lat)

--- a/apps/backend/api/models/photo_metadata.py
+++ b/apps/backend/api/models/photo_metadata.py
@@ -353,14 +353,14 @@ class PhotoMetadata(models.Model):
             photo.size = size
         if video_length and isinstance(video_length, numbers.Number):
             photo.video_length = video_length
-        if rating and isinstance(rating, numbers.Number):
+        if rating is not None and isinstance(rating, numbers.Number):
             photo.rating = rating
 
         # Burst/sequence detection fields
         if subsec_time_original:
             # SubSecTimeOriginal is typically a string like "123" representing milliseconds
             photo.exif_timestamp_subsec = str(subsec_time_original)[:10]
-        if image_number and isinstance(image_number, numbers.Number):
+        if image_number is not None and isinstance(image_number, numbers.Number):
             photo.image_sequence_number = int(image_number)
 
         if commit:
@@ -393,7 +393,7 @@ class PhotoMetadata(models.Model):
             focalLength35Equivalent, numbers.Number
         ):
             metadata.focal_length_35mm = focalLength35Equivalent
-        if rating and isinstance(rating, numbers.Number):
+        if rating is not None and isinstance(rating, numbers.Number):
             metadata.rating = rating
         if subsec_time_original:
             metadata.date_taken_subsec = str(subsec_time_original)[:10]

--- a/apps/backend/api/tests/test_zero_valued_metadata.py
+++ b/apps/backend/api/tests/test_zero_valued_metadata.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for zero-valued metadata being dropped by truthiness checks.
+
+Several EXIF-derived values are legitimately ``0``: a photo on the equator or
+prime meridian (one GPS axis == 0.0), an explicit 0-star rating, and the first
+frame of a burst (ImageNumber == 0). Guards written as ``if value:`` silently
+discarded all of these. These tests pin the corrected ``is not None`` behaviour
+while keeping the ``(0, 0)`` "null island" coordinate rejected.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from api.models.photo_metadata import PhotoMetadata
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class GeolocateZeroCoordinateTestCase(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user)
+
+    @patch("api.models.photo.reverse_geocode", return_value={})
+    @patch("api.models.photo.get_metadata", return_value=(0.0, 11.5))
+    def test_geolocate_keeps_zero_latitude(self, _get_metadata, reverse_geocode):
+        """A photo on the equator (lat == 0.0) must still be geocoded."""
+        self.photo._geolocate(commit=False)
+
+        reverse_geocode.assert_called_once()
+        self.assertEqual(self.photo.exif_gps_lat, 0.0)
+        self.assertEqual(self.photo.exif_gps_lon, 11.5)
+
+    @patch("api.models.photo.reverse_geocode", return_value={})
+    @patch("api.models.photo.get_metadata", return_value=(51.48, 0.0))
+    def test_geolocate_keeps_zero_longitude(self, _get_metadata, reverse_geocode):
+        """A photo on the prime meridian (lon == 0.0) must still be geocoded."""
+        self.photo._geolocate(commit=False)
+
+        reverse_geocode.assert_called_once()
+        self.assertEqual(self.photo.exif_gps_lat, 51.48)
+        self.assertEqual(self.photo.exif_gps_lon, 0.0)
+
+    @patch("api.models.photo.reverse_geocode", return_value={})
+    @patch("api.models.photo.get_metadata", return_value=(0.0, 0.0))
+    def test_geolocate_skips_null_island(self, _get_metadata, reverse_geocode):
+        """The (0, 0) default written when there is no GPS fix is rejected."""
+        self.photo._geolocate(commit=False)
+
+        reverse_geocode.assert_not_called()
+        self.assertIsNone(self.photo.exif_gps_lat)
+        self.assertIsNone(self.photo.exif_gps_lon)
+
+
+class ZeroRatingAndImageNumberTestCase(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user)
+
+    def test_zero_rating_and_image_number_are_kept(self):
+        """rating == 0 and ImageNumber == 0 must be recorded, not dropped."""
+        # 18-element tuple matching the tags requested in extract_exif_data.
+        mock_values = [None] * 18
+        mock_values[13] = 0  # RATING (explicit 0 stars)
+        mock_values[15] = 0  # IMAGE_NUMBER (first frame of a burst)
+
+        with patch("api.models.photo_metadata.get_metadata", return_value=mock_values):
+            metadata = PhotoMetadata.extract_exif_data(self.photo, commit=True)
+
+        self.photo.refresh_from_db()
+        self.assertEqual(self.photo.image_sequence_number, 0)
+        self.assertEqual(self.photo.rating, 0)
+        self.assertEqual(metadata.rating, 0)


### PR DESCRIPTION
Several EXIF-derived values are legitimately `0`, but guards written as `if value:` silently discarded them.

`_geolocate` skipped any coordinate with a zero axis (`if not new_gps_lat or not new_gps_lon: return`), so a photo taken on the equator or the prime meridian was never geocoded — its coordinates were dropped and no place album was assigned. The guard now skips only genuinely missing coordinates and the `(0, 0)` "null island" default that cameras write when there is no GPS fix, while keeping a single zero axis. This mirrors the existing `date_time_extractor._check_gps_ok` helper, which already treats one zero axis as valid and `(0, 0)` as invalid.

An explicit 0-star `rating` was dropped on both `Photo` and `PhotoMetadata`, erasing the difference between "unrated" and "rated zero". And `ImageNumber == 0` — the first frame of a burst — was dropped, leaving `image_sequence_number` null and corrupting burst/sequence ordering.

All three guards switch to `is not None`. The regression tests fail on the current code (the GPS ones never call `reverse_geocode`; the rating/burst one leaves both fields null) and pass with the fix; a fourth test pins down that `(0, 0)` is still rejected so the GPS change doesn't over-correct into geocoding the null-island default.
