### PR TITLE
backend: keep emptying the trash when a single photo fails to delete (#873)

### DIFF
--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -580,7 +580,6 @@ class Photo(models.Model):
                     remaining_photo.duplicates.remove(duplicate)
                 duplicate.delete()
 
-        # To-Do: Handle wrong file permissions
         return result
 
     def rotate(self, angle: int = 0, flip_horizontal: bool = False) -> None:

--- a/apps/backend/api/tests/test_delete_photos.py
+++ b/apps/backend/api/tests/test_delete_photos.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -118,3 +119,76 @@ class DeletePhotosTest(TestCase):
         self.assertEqual(0, len(data["results"]))
         self.assertEqual(0, len(data["deleted"]))
         self.assertEqual(5, len(data["not_deleted"]))
+
+    def test_delete_continues_past_photo_whose_file_cannot_be_removed(self):
+        """A photo whose file can't be deleted (e.g. permissions, #873) must not
+        abort the whole request: the remaining photos still get deleted and the
+        failed one is reported in not_deleted."""
+        photos = create_test_photos(
+            number_of_photos=3, owner=self.user1, in_trashcan=True
+        )
+        for photo in photos:
+            photo.files.add(photo.main_file)
+        image_hashes = [p.image_hash for p in photos]
+        failing_path = photos[1].main_file.path
+
+        real_remove = os.remove
+
+        def remove_unless_protected(path, *args, **kwargs):
+            if path == failing_path:
+                raise PermissionError(13, "Permission denied", path)
+            return real_remove(path, *args, **kwargs)
+
+        payload = {"image_hashes": image_hashes}
+        headers = {"Content-Type": "application/json"}
+        with patch("api.models.photo.os.remove", side_effect=remove_unless_protected):
+            response = self.client.delete(
+                "/api/photosedit/delete/", format="json", data=payload, headers=headers
+            )
+        data = response.json()
+
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(data["status"])
+        self.assertEqual([photos[0].image_hash, photos[2].image_hash], data["deleted"])
+        self.assertEqual([photos[1].image_hash], data["not_deleted"])
+
+        for photo in photos:
+            photo.refresh_from_db()
+        self.assertTrue(photos[0].removed)
+        self.assertFalse(photos[1].removed)
+        self.assertTrue(photos[2].removed)
+        # The failed photo stays in the trashcan so the user can retry
+        self.assertTrue(photos[1].in_trashcan)
+
+    def test_delete_select_all_continues_past_photo_whose_file_cannot_be_removed(self):
+        photos = create_test_photos(
+            number_of_photos=3, owner=self.user1, in_trashcan=True
+        )
+        for photo in photos:
+            photo.files.add(photo.main_file)
+        failing_path = photos[1].main_file.path
+
+        real_remove = os.remove
+
+        def remove_unless_protected(path, *args, **kwargs):
+            if path == failing_path:
+                raise PermissionError(13, "Permission denied", path)
+            return real_remove(path, *args, **kwargs)
+
+        payload = {"select_all": True, "query": {}}
+        headers = {"Content-Type": "application/json"}
+        with patch("api.models.photo.os.remove", side_effect=remove_unless_protected):
+            response = self.client.delete(
+                "/api/photosedit/delete/", format="json", data=payload, headers=headers
+            )
+        data = response.json()
+
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(data["status"])
+        self.assertEqual(2, data["count"])
+        self.assertEqual(1, data["failed_count"])
+
+        for photo in photos:
+            photo.refresh_from_db()
+        self.assertEqual(2, sum(p.removed for p in photos))
+        self.assertFalse(photos[1].removed)

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -887,16 +887,26 @@ class DeletePhotos(APIView):
 
             # Need to call manual_delete on each photo for proper cleanup
             deleted_count = 0
+            failed_count = 0
             for photo in photos_qs:
                 if photo.owner == request.user:
-                    photo.manual_delete()
-                    deleted_count += 1
+                    try:
+                        photo.manual_delete()
+                    except Exception:
+                        logger.exception(
+                            f"Could not delete photo {photo.image_hash}, skipping it."
+                        )
+                        failed_count += 1
+                    else:
+                        deleted_count += 1
 
             logger.info(
                 f"{deleted_count} photos were permanently deleted via select_all for user {request.user.id}."
             )
 
-            return Response({"status": True, "count": deleted_count})
+            return Response(
+                {"status": True, "count": deleted_count, "failed_count": failed_count}
+            )
 
         # Existing logic for individual hashes
         # Use filter since image_hash may not be unique after UUID migration
@@ -911,8 +921,15 @@ class DeletePhotos(APIView):
             if photo is None:
                 continue  # Photo not found
             if photo.owner == request.user and photo.in_trashcan:
-                deleted.append(photo.image_hash)
-                photo.manual_delete()
+                try:
+                    photo.manual_delete()
+                except Exception:
+                    logger.exception(
+                        f"Could not delete photo {image_hash}, skipping it."
+                    )
+                    not_deleted.append(photo.image_hash)
+                else:
+                    deleted.append(photo.image_hash)
             else:
                 not_deleted.append(photo.image_hash)
 


### PR DESCRIPTION
Emptying the trash with several photos selected often deletes only one of them per attempt (#873). The cause is in `DeletePhotos`: it loops over the selected photos calling `manual_delete()`, which has no error handling around `os.remove()`. The first photo whose file can't be removed — typically a permission mismatch on the mounted photo volume, which is common in Docker setups — raises out of the loop, aborting the whole request with a 500. Photos earlier in the list were already deleted, everything after was not, so each "select all → delete → refresh" round removes only the photos that happened to sort before the failing one. derneuere suggested handling this gracefully back in the issue thread, and `manual_delete` itself carried a `To-Do: Handle wrong file permissions` comment.

This change catches failures per photo in both the `select_all` and the hash-list branches, logs each with a full traceback, and keeps deleting the rest. A failed photo is reported in `not_deleted` (or in a new `failed_count` for `select_all`) and stays in the trashcan, so the user can retry after fixing permissions instead of the photo silently half-disappearing. The hash branch previously appended to `deleted` *before* calling `manual_delete()`, so even the response lied about what happened; it now records a photo as deleted only after the deletion actually succeeded. Since the frontend's toast uses `deleted.length` / `count`, it now shows the true number without any frontend change, and the response stays compatible with the existing zod schema (extra keys are stripped, all result fields are optional). Surfacing the failures more loudly in the UI would be a frontend follow-up.

The deliberate behavior choice: a photo whose file can't be removed is left fully intact in the trash rather than being marked `removed` with its file still on disk — keeping what the user sees consistent with what's actually on disk. There's no transaction around `manual_delete()`, intentionally: if a multi-file photo fails partway, the database rows for the files that *were* removed from disk must not be rolled back.

Two regression tests drive the endpoint through a photo whose `os.remove` raises `PermissionError` sandwiched between two deletable photos, for both request modes. On the unpatched view both tests error out with the propagated `PermissionError`, reproducing the bug; with the fix they verify the other photos get deleted, the failed one stays in the trash, and the response reports it honestly. Full suite (1351 tests) shows no regressions against the dev baseline; ruff check and format are clean.

Fixes #873.
