### PR TITLE
backend: re-adopt files that reappear after being flagged missing

### DIFF
--- a/apps/backend/api/directory_watcher/file_handlers.py
+++ b/apps/backend/api/directory_watcher/file_handlers.py
@@ -104,8 +104,14 @@ def group_files_into_photo(user, files: list[File], job_id) -> Photo | None:
     if not main_file:
         return None
 
-    # Check if a Photo already exists with any of these files
-    existing_photo = Photo.objects.filter(owner=user, files__in=files).first()
+    # Check if a Photo already exists with any of these files. Matching on
+    # main_file as well as the files m2m re-adopts photos whose file went
+    # missing and reappeared: _check_files detaches a missing file from the
+    # m2m but keeps main_file pointing at it, so without that match a
+    # reappearing file would spawn a duplicate Photo with the same image_hash.
+    existing_photo = Photo.objects.filter(
+        Q(owner=user) & (Q(files__in=files) | Q(main_file__in=files))
+    ).first()
 
     if existing_photo:
         # Add any missing files to the existing photo

--- a/apps/backend/api/models/file.py
+++ b/apps/backend/api/models/file.py
@@ -68,6 +68,12 @@ class File(models.Model):
         # Check if a File with this path already exists
         existing = File.objects.filter(path=path).first()
         if existing:
+            # The file was flagged missing at some point but is back on disk
+            # (e.g. a network share or removable drive that was temporarily
+            # unmounted during a scan), so it is not missing anymore.
+            if existing.missing and os.path.exists(path):
+                existing.missing = False
+                existing.save(update_fields=["missing"])
             return existing
 
         # Create new File

--- a/apps/backend/api/tests/test_missing_file_reappearance.py
+++ b/apps/backend/api/tests/test_missing_file_reappearance.py
@@ -1,0 +1,84 @@
+import os
+
+from django.test import TestCase
+
+from api.directory_watcher.file_handlers import group_files_into_photo
+from api.models import File, Photo
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class FileCreateMissingFlagTest(TestCase):
+    """File.create must clear the missing flag when a previously missing
+    file is found on disk again (e.g. a network share or removable drive
+    that was unmounted during a scan)."""
+
+    def setUp(self):
+        self.user = create_test_user()
+
+    def test_clears_missing_flag_when_file_is_back_on_disk(self):
+        photo = create_test_photo(owner=self.user)
+        file = photo.main_file
+        file.missing = True
+        file.save()
+
+        result = File.create(file.path, self.user)
+
+        self.assertEqual(file.hash, result.hash)
+        self.assertFalse(result.missing)
+        file.refresh_from_db()
+        self.assertFalse(file.missing)
+
+    def test_keeps_missing_flag_when_file_is_still_gone(self):
+        photo = create_test_photo(owner=self.user)
+        file = photo.main_file
+        file.missing = True
+        file.save()
+        os.remove(file.path)
+
+        result = File.create(file.path, self.user)
+
+        self.assertEqual(file.hash, result.hash)
+        self.assertTrue(result.missing)
+
+
+class MissingFileReappearanceTest(TestCase):
+    """A file that goes missing and later reappears at the same path must be
+    re-attached to its original Photo by the scan, not spawn a duplicate
+    Photo with the same image_hash."""
+
+    def setUp(self):
+        self.user = create_test_user()
+
+    def test_reappearing_file_is_readopted_by_original_photo(self):
+        photo = create_test_photo(owner=self.user)
+        file = photo.main_file
+        photo.files.add(file)
+        path = file.path
+        with open(path, "rb") as f:
+            content = f.read()
+
+        # The file disappears (unmounted share, removed drive) and a
+        # "scan missing photos" run flags it.
+        os.remove(path)
+        photo._check_files()
+        file.refresh_from_db()
+        self.assertTrue(file.missing)
+        self.assertEqual(0, photo.files.count())
+        photo.refresh_from_db()
+        self.assertEqual(file, photo.main_file)
+
+        # The file comes back at the same path and a scan picks it up again.
+        with open(path, "wb") as f:
+            f.write(content)
+        photo_count_before = Photo.objects.count()
+
+        refound_file = File.create(path, self.user)
+        result_photo = group_files_into_photo(
+            self.user, [refound_file], job_id="test-job"
+        )
+
+        self.assertEqual(photo.pk, result_photo.pk)
+        self.assertEqual(photo_count_before, Photo.objects.count())
+        self.assertTrue(photo.files.filter(hash=file.hash).exists())
+        file.refresh_from_db()
+        self.assertFalse(file.missing)


### PR DESCRIPTION
When a photo's file disappears from disk — an unmounted NFS/SMB share, a removable drive, a flaky mount during a scan — `Photo._check_files` detaches the file from the photo's `files` m2m and sets `File.missing = True`. That flag is never reset anywhere in the codebase, and the detachment has a nasty side effect when the file comes back at the same path: the scan does pick it up again (the `files__path` lookup no longer matches, so the group is queued for processing), but `group_files_into_photo` looks for an existing photo only via the `files` m2m, finds nothing, and creates a brand-new Photo with the same `image_hash` as the original. The user ends up with a duplicate that has none of their albums, favorites, captions or faces, plus an invisible zombie photo holding all of that work, and a `File` row that claims to be missing forever. For anyone whose photo storage lives on a network share or external disk, a single mount hiccup quietly corrupts their library this way.

The fix is two small changes that work together. `File.create` now clears the `missing` flag when it returns an existing record whose path is present on disk again. And `group_files_into_photo` also matches existing photos via `main_file` — which `_check_files` deliberately leaves pointing at the missing file — so the scan re-attaches the reappeared file to its original Photo through the already-existing re-attach loop, instead of creating a duplicate. Recovery needs no new mechanism: the next regular photo scan just works, and all the user's organization comes back with it. Photos deleted through the trash can't be resurrected by this, because `manual_delete` clears `main_file` and deletes the `File` rows outright.

Three tests in a new `test_missing_file_reappearance.py` cover the flag reset, the flag *not* being reset while the file is still absent, and the full disappear-flag-reappear-rescan round trip asserting the original Photo (same pk) re-adopts the file with no duplicate created. On the unpatched code the round-trip test fails by producing two Photos with the same `image_hash`, and the flag test fails with `missing` still `True`. Full suite shows no regressions against the dev baseline; ruff check and format are clean.

Related follow-up, deliberately out of scope: `File.create`'s docstring notes that content changes (same path, different bytes) should be handled "separately during rescan", but nothing does that today — the stored hash goes stale. That's independent of the missing-flag lifecycle and probably warrants its own discussion, since `File.hash` is the primary key.
