### PR TITLE
Filter search results by media type (photos / videos)

### DIFF
--- a/apps/backend/api/filters.py
+++ b/apps/backend/api/filters.py
@@ -12,6 +12,15 @@ from api.semantic_search import calculate_query_embeddings
 
 class SemanticSearchFilter(filters.SearchFilter):
     def filter_queryset(self, request, queryset, view):
+        # Narrow by media type independent of the search term, mirroring the
+        # video/photo params already used by the album-date endpoints. This is
+        # applied before the no-search-term early return so the filter works
+        # whether or not a query is supplied.
+        if request.query_params.get("video"):
+            queryset = queryset.filter(video=True)
+        elif request.query_params.get("photo"):
+            queryset = queryset.filter(video=False)
+
         search_fields = self.get_search_fields(view, request)
         search_terms = self.get_search_terms(request)
 

--- a/apps/backend/api/tests/test_search_media_type_filter.py
+++ b/apps/backend/api/tests/test_search_media_type_filter.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.tests.utils import create_test_photo, create_test_user
+
+SEARCH_URL = "/api/photos/searchlist/"
+
+
+def _hashes_in_grouped_response(response):
+    """Flatten the date-grouped search response into a set of image hashes."""
+    hashes = set()
+    for group in response.data["results"]:
+        for item in group.get("items", []):
+            hashes.add(item["image_hash"])
+    return hashes
+
+
+class SearchMediaTypeFilterTest(TestCase):
+    """The search endpoint should honor the video/photo media-type filters.
+
+    semantic_search_topk defaults to 0 for a fresh user, so these exercise the
+    date-grouped branch of SearchListViewSet.list without needing the CLIP
+    embedding service.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        # exif_timestamp is required: get_photos_ordered_by_date drops photos
+        # without one, so the date-grouped response would otherwise be empty.
+        timestamp = timezone.now()
+        self.photo = create_test_photo(
+            owner=self.user, video=False, exif_timestamp=timestamp
+        )
+        self.video = create_test_photo(
+            owner=self.user, video=True, exif_timestamp=timestamp
+        )
+
+    def test_video_true_returns_only_videos(self):
+        response = self.client.get(SEARCH_URL, {"video": "true"})
+        self.assertEqual(response.status_code, 200)
+        hashes = _hashes_in_grouped_response(response)
+        self.assertIn(self.video.image_hash, hashes)
+        self.assertNotIn(self.photo.image_hash, hashes)
+
+    def test_photo_true_returns_only_photos(self):
+        response = self.client.get(SEARCH_URL, {"photo": "true"})
+        self.assertEqual(response.status_code, 200)
+        hashes = _hashes_in_grouped_response(response)
+        self.assertIn(self.photo.image_hash, hashes)
+        self.assertNotIn(self.video.image_hash, hashes)
+
+    def test_no_media_filter_returns_both(self):
+        response = self.client.get(SEARCH_URL)
+        self.assertEqual(response.status_code, 200)
+        hashes = _hashes_in_grouped_response(response)
+        self.assertIn(self.photo.image_hash, hashes)
+        self.assertIn(self.video.image_hash, hashes)
+
+    def test_video_takes_precedence_over_photo(self):
+        # Mirrors build_photo_queryset: video wins when both are supplied.
+        response = self.client.get(SEARCH_URL, {"video": "true", "photo": "true"})
+        self.assertEqual(response.status_code, 200)
+        hashes = _hashes_in_grouped_response(response)
+        self.assertIn(self.video.image_hash, hashes)
+        self.assertNotIn(self.photo.image_hash, hashes)

--- a/apps/backend/api/views/search.py
+++ b/apps/backend/api/views/search.py
@@ -1,4 +1,5 @@
 from django.db.models import Prefetch, Q
+from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema
 from rest_framework.response import Response
 
 from api.filters import SemanticSearchFilter
@@ -25,6 +26,17 @@ class SearchListViewSet(ListViewSet):
             "-exif_timestamp"
         )
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("search", OpenApiTypes.STR),
+            OpenApiParameter("video", OpenApiTypes.BOOL),
+            OpenApiParameter("photo", OpenApiTypes.BOOL),
+        ],
+        description=(
+            "Search photos and videos. Pass video=true to return only videos "
+            "or photo=true to return only photos."
+        ),
+    )
     def list(self, request):
         if request.user.semantic_search_topk == 0:
             queryset = self.filter_queryset(


### PR DESCRIPTION
Searching currently returns photos and videos mixed together, with no way to narrow the results to one or the other. The dedicated Photos and Videos pages already support this (via the `video`/`photo` params on the album-date endpoints, added in #1051), but that filtering was never wired into the search endpoint, so it doesn't compose with a search query. This was the original framing of #750 and #918 — "photos and videos are mixed together and there is no easy way to filter them" — but those issues were resolved only for the browsing/timeline views, not for search.

This change teaches `SearchListViewSet` to honor the same `video=true` / `photo=true` query params. The filtering lives in `SemanticSearchFilter` and is applied before the no-search-term early return, so it works whether or not a query is supplied, and it composes with both the keyword and the semantic (CLIP) search branches. I deliberately reused the exact convention the album-date endpoints already use — a truthy query param, with `video` winning if both are somehow sent — so behavior stays consistent across the app. The endpoint now also declares these params via `@extend_schema`, matching how `albums.py` documents them.

To be clear about scope: this is backend-only, prep work. It exposes the capability on the API but adds no UI — there is intentionally no search-bar control to toggle it yet. The intent is for someone to follow up with the frontend piece (a "Photos only / Videos only" option in the search bar, along the lines of what was sketched on #750), the same backend-first-then-frontend split that #1051 followed. Until that lands, the filter is reachable only by passing the query param directly.

Tests cover the default date-grouped branch (`semantic_search_topk == 0`): video-only, photo-only, no-filter-returns-both, and the video-takes-precedence case. The semantic branch shares the same `filter_queryset` path, so the type filter applies identically there; it isn't unit-tested only because it requires the CLIP embedding service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
