### PR TITLE
backend: fix cross-user authorization issues and server-stats parse failure

### DIFF
--- a/apps/backend/api/stats.py
+++ b/apps/backend/api/stats.py
@@ -62,11 +62,65 @@ def calc_megabytes(bytes):
     return round((bytes / 1024) / 1024)
 
 
+def _coerce_cache_size(value):
+    """Normalize a py-cpuinfo cache-size field to an int (bytes), or None.
+
+    py-cpuinfo returns these as ints on most CPUs, but ``_friendly_bytes_to_int``
+    falls back to the raw string (e.g. "1.3 MiB", "32 KiB") when the value can't be
+    parsed as a plain int -- seen on hardware like the Xeon Gold 6148 via newer
+    lscpu. The frontend stats schema requires a number, so coerce here to keep the
+    API contract numeric. See issue #1864.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        import re
+
+        match = re.match(
+            r"^\s*([0-9]*\.?[0-9]+)\s*([KMGT]?i?B)?\s*$", value, re.IGNORECASE
+        )
+        if not match:
+            return None
+        number = float(match.group(1))
+        unit = (match.group(2) or "B").upper()
+        multipliers = {
+            "B": 1,
+            "KB": 1000,
+            "KIB": 1024,
+            "MB": 1000**2,
+            "MIB": 1024**2,
+            "GB": 1000**3,
+            "GIB": 1024**3,
+            "TB": 1000**4,
+            "TIB": 1024**4,
+        }
+        return int(round(number * multipliers.get(unit, 1)))
+    return None
+
+
 def get_server_stats():
     # CPU architecture, Speed, Number of Cores, 64bit / 32 Bits
     import cpuinfo
 
     cpu_info = cpuinfo.get_cpu_info()
+    # py-cpuinfo may report cache sizes as non-numeric strings on some CPUs; keep
+    # the API numeric so the frontend's number schema doesn't reject them (#1864).
+    for cache_field in (
+        "l1_data_cache_size",
+        "l1_instruction_cache_size",
+        "l2_cache_size",
+        "l3_cache_size",
+    ):
+        if cache_field in cpu_info:
+            coerced = _coerce_cache_size(cpu_info[cache_field])
+            if coerced is None:
+                del cpu_info[cache_field]
+            else:
+                cpu_info[cache_field] = coerced
     # Available RAM
     import psutil
 

--- a/apps/backend/api/tests/test_authz_scoping.py
+++ b/apps/backend/api/tests/test_authz_scoping.py
@@ -1,0 +1,145 @@
+"""Authorization regression tests for the findings in issue #1861.
+
+1. AlbumUserViewSet ?public must be read-only (no anonymous/cross-user writes).
+2. LongRunningJobViewSet must scope jobs to their owner.
+3. UserViewSet must not leak other users' private profile fields.
+"""
+
+import logging
+import uuid
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.models import AlbumUser, LongRunningJob
+from api.models.album_user_share import AlbumUserShare
+from api.tests.utils import create_test_user
+
+logger = logging.getLogger(__name__)
+
+
+def _results(response):
+    data = response.json()
+    if isinstance(data, dict) and "results" in data:
+        return data["results"]
+    return data
+
+
+class PublicAlbumWriteProtectionTest(TestCase):
+    """Finding 1: ?public grants read-only access, never write/destroy."""
+
+    def setUp(self):
+        self.owner = create_test_user()
+        self.attacker = create_test_user()
+        self.album = AlbumUser.objects.create(title="Holiday", owner=self.owner)
+        AlbumUserShare.objects.create(album=self.album, enabled=True)
+        self.url = f"/api/albums/user/{self.album.id}/?public=1"
+
+    def test_public_album_still_readable_anonymously(self):
+        # The legitimate read path must keep working.
+        resp = APIClient().get(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_anonymous_cannot_delete_public_album(self):
+        resp = APIClient().delete(self.url)
+        self.assertIn(resp.status_code, (401, 403))
+        self.assertTrue(AlbumUser.objects.filter(id=self.album.id).exists())
+
+    def test_other_authenticated_user_cannot_delete_public_album(self):
+        client = APIClient()
+        client.force_authenticate(user=self.attacker)
+        resp = client.delete(self.url)
+        self.assertIn(resp.status_code, (403, 404))
+        self.assertTrue(AlbumUser.objects.filter(id=self.album.id).exists())
+
+
+class JobScopingTest(TestCase):
+    """Finding 2: a user may only see/act on their own jobs (admins excepted)."""
+
+    def setUp(self):
+        self.alice = create_test_user()
+        self.bob = create_test_user()
+        self.admin = create_test_user(is_admin=True)
+        self.alice_job = LongRunningJob.objects.create(
+            started_by=self.alice,
+            job_id=str(uuid.uuid4()),
+            job_type=LongRunningJob.JOB_SCAN_PHOTOS,
+        )
+        self.bob_job = LongRunningJob.objects.create(
+            started_by=self.bob,
+            job_id=str(uuid.uuid4()),
+            job_type=LongRunningJob.JOB_SCAN_PHOTOS,
+        )
+
+    def test_user_only_lists_own_jobs(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        ids = {row["id"] for row in _results(client.get("/api/jobs/"))}
+        self.assertIn(self.bob_job.id, ids)
+        self.assertNotIn(self.alice_job.id, ids)
+
+    def test_user_cannot_retrieve_others_job(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        resp = client.get(f"/api/jobs/{self.alice_job.id}/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_user_cannot_cancel_others_job(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        resp = client.post(f"/api/jobs/{self.alice_job.id}/cancel/")
+        self.assertEqual(resp.status_code, 404)
+        self.alice_job.refresh_from_db()
+        self.assertFalse(self.alice_job.cancelled)
+
+    def test_admin_sees_all_jobs(self):
+        client = APIClient()
+        client.force_authenticate(user=self.admin)
+        ids = {row["id"] for row in _results(client.get("/api/jobs/"))}
+        self.assertIn(self.alice_job.id, ids)
+        self.assertIn(self.bob_job.id, ids)
+
+
+class UserProfileExposureTest(TestCase):
+    """Finding 3: non-admins must not see other users' private profile fields."""
+
+    SENSITIVE = ("email", "scan_directory", "nextcloud_server_address", "is_superuser")
+
+    def setUp(self):
+        self.alice = create_test_user(
+            scan_directory="/data/alice-private",
+            nextcloud_server_address="https://nc.alice.example",
+        )
+        self.alice.email = "alice@example.com"
+        self.alice.save()
+        self.bob = create_test_user()
+        self.bob.email = "bob@example.com"
+        self.bob.save()
+        self.admin = create_test_user(is_admin=True)
+
+    def test_non_admin_list_hides_other_users_private_fields(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        rows = {row["id"]: row for row in _results(client.get("/api/user/"))}
+        alice_row = rows[self.alice.id]
+        for field in self.SENSITIVE:
+            self.assertNotIn(field, alice_row)
+
+    def test_non_admin_retrieve_other_user_hides_private_fields(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        row = client.get(f"/api/user/{self.alice.id}/").json()
+        for field in self.SENSITIVE:
+            self.assertNotIn(field, row)
+
+    def test_user_can_see_own_full_profile(self):
+        client = APIClient()
+        client.force_authenticate(user=self.bob)
+        row = client.get(f"/api/user/{self.bob.id}/").json()
+        self.assertEqual(row.get("email"), "bob@example.com")
+
+    def test_admin_sees_full_profiles(self):
+        client = APIClient()
+        client.force_authenticate(user=self.admin)
+        rows = {row["id"]: row for row in _results(client.get("/api/user/"))}
+        self.assertEqual(rows[self.alice.id].get("email"), "alice@example.com")

--- a/apps/backend/api/tests/test_server_stats_cpu_info.py
+++ b/apps/backend/api/tests/test_server_stats_cpu_info.py
@@ -1,0 +1,67 @@
+"""Regression tests for issue #1864.
+
+py-cpuinfo can report cache sizes as non-numeric strings (e.g. "1.3 MiB") on some
+CPUs, which broke the frontend's numeric stats schema. The backend must normalize
+those fields to ints (or drop them) before returning cpu_info.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from api.stats import _coerce_cache_size, get_server_stats
+
+
+class CoerceCacheSizeTest(TestCase):
+    def test_int_passthrough(self):
+        self.assertEqual(_coerce_cache_size(32768), 32768)
+
+    def test_zero_passthrough(self):
+        self.assertEqual(_coerce_cache_size(0), 0)
+
+    def test_binary_unit_strings(self):
+        self.assertEqual(_coerce_cache_size("32 KiB"), 32768)
+        self.assertEqual(_coerce_cache_size("6 MiB"), 6291456)
+
+    def test_fractional_string(self):
+        # The exact value py-cpuinfo fails to parse and returns as a string.
+        self.assertEqual(_coerce_cache_size("1.3 MiB"), round(1.3 * 1024 * 1024))
+
+    def test_unparseable_returns_none(self):
+        self.assertIsNone(_coerce_cache_size("not a size"))
+        self.assertIsNone(_coerce_cache_size(None))
+
+
+class ServerStatsCpuInfoTest(TestCase):
+    @patch("cpuinfo.get_cpu_info")
+    def test_string_cache_sizes_are_coerced_to_int(self, mock_get_cpu_info):
+        mock_get_cpu_info.return_value = {
+            "brand_raw": "Intel(R) Xeon(R) Gold 6148",
+            "l1_data_cache_size": "1.3 MiB",  # the value the issue reported as a string
+            "l1_instruction_cache_size": "32 KiB",
+            "l2_cache_size": 1048576,  # already an int
+            "l3_cache_size": "27.5 MiB",
+        }
+        stats = get_server_stats()
+        cpu_info = stats["cpu_info"]
+        for field in (
+            "l1_data_cache_size",
+            "l1_instruction_cache_size",
+            "l2_cache_size",
+            "l3_cache_size",
+        ):
+            self.assertIsInstance(
+                cpu_info[field],
+                int,
+                f"{field} should be numeric, got {cpu_info[field]!r}",
+            )
+
+    @patch("cpuinfo.get_cpu_info")
+    def test_unparseable_cache_size_is_dropped(self, mock_get_cpu_info):
+        mock_get_cpu_info.return_value = {
+            "brand_raw": "Weird CPU",
+            "l1_data_cache_size": "unknown",
+        }
+        stats = get_server_stats()
+        # Dropped rather than emitted as a non-numeric string.
+        self.assertNotIn("l1_data_cache_size", stats["cpu_info"])

--- a/apps/backend/api/tests/test_share_photos.py
+++ b/apps/backend/api/tests/test_share_photos.py
@@ -1,5 +1,4 @@
 import logging
-from unittest import skip
 
 from django.test import TestCase
 from rest_framework.test import APIClient
@@ -70,10 +69,12 @@ class SharePhotosTest(TestCase):
         )
         self.assertEqual(0, len(shared_photos))
 
-    @skip("BUG!!! scenario not implemented")
     def test_share_other_user_photos(self):
+        # IDOR guard (#1860): user1 (authenticated) must NOT be able to share
+        # user2's photos -- to themselves or anyone -- since they don't own them.
         photos = create_test_photos(number_of_photos=2, owner=self.user2)
         image_hashes = [p.image_hash for p in photos]
+        photo_ids = [p.id for p in photos]
 
         payload = {
             "image_hashes": image_hashes,
@@ -90,7 +91,43 @@ class SharePhotosTest(TestCase):
         self.assertEqual(0, data["count"])
         shared_photos = list(
             Photo.shared_to.through.objects.filter(
-                user_id=self.user1.id, photo_id__in=image_hashes
+                user_id=self.user1.id, photo_id__in=photo_ids
             )
         )
         self.assertEqual(0, len(shared_photos))
+
+    def test_unshare_other_user_photos(self):
+        # The unshare branch is the same defect in reverse: user1 must not be able
+        # to strip a legitimate share on a photo owned by user2 (#1860).
+        photos = create_test_photos(number_of_photos=2, owner=self.user2)
+        image_hashes = [p.image_hash for p in photos]
+        photo_ids = [p.id for p in photos]
+        # user2 legitimately shares their photos to user1.
+        share_test_photos(image_hashes, self.user1)
+        self.assertEqual(
+            2,
+            Photo.shared_to.through.objects.filter(
+                user_id=self.user1.id, photo_id__in=photo_ids
+            ).count(),
+        )
+
+        payload = {
+            "image_hashes": image_hashes,
+            "val_shared": False,
+            "target_user_id": self.user1.id,
+        }
+        headers = {"Content-Type": "application/json"}
+        response = self.client.post(
+            "/api/photosedit/share/", format="json", data=payload, headers=headers
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        # The existing legitimate shares must be untouched.
+        self.assertEqual(
+            2,
+            Photo.shared_to.through.objects.filter(
+                user_id=self.user1.id, photo_id__in=photo_ids
+            ).count(),
+        )

--- a/apps/backend/api/tests/test_user.py
+++ b/apps/backend/api/tests/test_user.py
@@ -102,10 +102,25 @@ class UserTest(TestCase):
         self.assertEqual(len(User.objects.all()), len(data["results"]))
 
     def test_authenticated_user_list_properties(self):
+        # Security (#1861): a regular authenticated user must NOT be able to
+        # enumerate other users' private profile fields (email, scan_directory,
+        # Nextcloud creds, is_superuser, ...). The list exposes only the
+        # public-safe properties for everyone except admins.
         self.client.force_authenticate(user=self.user1)
         response = self.client.get("/api/user/")
         data = response.json()
         logger.debug(data)
+
+        for user in data["results"]:
+            self.assertEqual(len(self.public_user_properties), len(user.keys()))
+            for key in self.public_user_properties:
+                self.assertTrue(key in user, f"user does not have key: {key}")
+
+    def test_admin_user_list_properties(self):
+        # Admins retain the full view of every user.
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get("/api/user/")
+        data = response.json()
 
         for user in data["results"]:
             for key in self.private_user_properties:
@@ -115,7 +130,6 @@ class UserTest(TestCase):
                     key in self.private_user_properties,
                     f"user has superfluous key: {key}",
                 )
-
             self.assertEqual(len(self.private_user_properties), len(user.keys()))
 
     def test_user_update_self(self):

--- a/apps/backend/api/views/albums.py
+++ b/apps/backend/api/views/albums.py
@@ -282,8 +282,14 @@ class AlbumUserViewSet(viewsets.ModelViewSet):
         serializer.save(owner=self.request.user)
 
     def get_queryset(self):
-        # Support public access when explicitly requested
-        if self.request.query_params.get("public"):
+        # Support public access when explicitly requested. Public access is
+        # READ-ONLY: only honor ?public for the safe list/retrieve actions, so a
+        # public album id can't be mutated or deleted through this unscoped
+        # queryset. See issue #1861.
+        if self.request.query_params.get("public") and self.action in (
+            "list",
+            "retrieve",
+        ):
             # Anyone can view a public album if the album itself is marked public and active (not expired)
             username = self.request.query_params.get("username")
             from django.utils import timezone
@@ -311,14 +317,23 @@ class AlbumUserViewSet(viewsets.ModelViewSet):
         )
 
     def get_permissions(self):
-        if self.request.query_params.get("public"):
+        # Anonymous public access is allowed only for read actions. Write actions
+        # (create/update/partial_update/destroy) always require authentication,
+        # even when ?public is present. See issue #1861.
+        if self.request.query_params.get("public") and self.action in (
+            "list",
+            "retrieve",
+        ):
             permission_classes = [AllowAny]
         else:
             permission_classes = [IsAuthenticated]
         return [permission() for permission in permission_classes]
 
     def get_serializer_class(self):
-        if self.request.query_params.get("public"):
+        if self.request.query_params.get("public") and self.action in (
+            "list",
+            "retrieve",
+        ):
             return AlbumUserPublicSerializer
         return super().get_serializer_class()
 

--- a/apps/backend/api/views/jobs.py
+++ b/apps/backend/api/views/jobs.py
@@ -10,18 +10,27 @@ from api.views.pagination import TinyResultsSetPagination
 
 
 class LongRunningJobViewSet(viewsets.ModelViewSet):
-    queryset = (
-        LongRunningJob.objects.prefetch_related(
+    # Declared for router basename inference only; real access is scoped per-user
+    # in get_queryset() below.
+    queryset = LongRunningJob.objects.all()
+    serializer_class = LongRunningJobSerializer
+    pagination_class = TinyResultsSetPagination
+
+    def get_queryset(self):
+        # Scope jobs to the requesting user so one user cannot list, retrieve,
+        # update, delete or cancel another user's jobs. Staff/superusers retain
+        # the global view. See issue #1861. Object-level actions (cancel/destroy)
+        # inherit this via get_object().
+        qs = LongRunningJob.objects.prefetch_related(
             Prefetch(
                 "started_by",
                 queryset=User.objects.only("id", "username", "first_name", "last_name"),
             ),
-        )
-        .all()
-        .order_by("-started_at")
-    )
-    serializer_class = LongRunningJobSerializer
-    pagination_class = TinyResultsSetPagination
+        ).order_by("-started_at")
+        user = self.request.user
+        if user.is_authenticated and (user.is_staff or user.is_superuser):
+            return qs
+        return qs.filter(started_by=user)
 
     @action(detail=True, methods=["post"])
     def cancel(self, request, pk=None):

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -694,10 +694,14 @@ class SetPhotosShared(APIView):
         ])
         """
 
-        # Look up photo UUIDs from image_hashes (image_hash is no longer the primary key)
-        photos = Photo.objects.filter(image_hash__in=image_hashes).only(
-            "id", "image_hash"
-        )
+        # Look up photo UUIDs from image_hashes (image_hash is no longer the primary key).
+        # Scope to owner=request.user so a user can only (un)share photos they actually
+        # own, matching the sibling SetPhotos* endpoints. Without this, an authenticated
+        # user could add an arbitrary target_user_id to the shared_to of someone else's
+        # private photos (cross-user IDOR). See issue #1860.
+        photos = Photo.objects.filter(
+            image_hash__in=image_hashes, owner=request.user
+        ).only("id", "image_hash")
         photo_ids = [photo.id for photo in photos]
 
         if shared:

--- a/apps/backend/api/views/user.py
+++ b/apps/backend/api/views/user.py
@@ -127,8 +127,28 @@ class UserViewSet(viewsets.ModelViewSet):
             if self.request.user.is_authenticated and self.request.user.is_superuser:
                 return UserSerializer
             return SignupUserSerializer
-        if not self.request.user.is_authenticated:
+
+        user = self.request.user
+        # list / retrieve are the enumeration surface. The full UserSerializer
+        # exposes sensitive fields (email, scan_directory, Nextcloud server/
+        # username, is_superuser, ...), so restrict it to admins and to a user
+        # viewing their OWN record; every other reader (anonymous or another
+        # authenticated user) gets the public-safe serializer. A user's own
+        # settings come from /api/manage/user and the JWT token claims.
+        # See issue #1861.
+        if self.action in ("list", "retrieve"):
+            if user.is_authenticated and (user.is_staff or user.is_superuser):
+                return UserSerializer
+            if (
+                self.action == "retrieve"
+                and user.is_authenticated
+                and str(self.kwargs.get("pk")) == str(user.id)
+            ):
+                return UserSerializer
             return PublicUserSerializer
+
+        # update / partial_update / destroy are already restricted to self-or-admin
+        # by get_permissions (IsAdminOrSelf) and need the full serializer.
         return UserSerializer
 
     def get_permissions(self):


### PR DESCRIPTION
Fixes the authorization issues from #1861 and #1860, plus the server-stats parse failure #1864. Each was independently reproduced against `dev` before fixing; this PR adds the corresponding regression tests.

Closes #1860
Closes #1861
Closes #1864

## Authorization fixes

**Cross-user photo-share IDOR (#1860)** — `SetPhotosShared` resolved photos by `image_hash` with no owner filter, so an authenticated user could add any `target_user_id` to the `shared_to` of photos they don't own (and then read them via the media views), or strip a victim's shares via the unshare branch. Now scoped to `owner=request.user` on both branches, matching the sibling `SetPhotosFavorite/Hidden/Public` endpoints.

**Public-album write bypass (#1861-1)** — `AlbumUserViewSet.get_permissions` returned `AllowAny` for *every* action when `?public` was present, so an anonymous `DELETE /api/albums/user/<id>/?public=1` deleted the album. `?public` is now honored only for the safe `list`/`retrieve` actions across `get_permissions`, `get_queryset`, and `get_serializer_class`; writes always require auth and owner scoping.

**Job IDOR (#1861-2)** — `LongRunningJobViewSet` queried all jobs, so any user could list/retrieve/cancel/delete others' jobs. `get_queryset` now scopes to `started_by=request.user` (staff/superusers still see all); object-level actions inherit this via `get_object()`.

**User enumeration (#1861-3)** — `UserViewSet` returned the full `UserSerializer` (email, scan_directory, Nextcloud credentials, `is_superuser`, ...) to any authenticated user. The full serializer is now restricted to admins and to a user viewing their **own** record; everyone else gets `PublicUserSerializer` for `list`/`retrieve`. Self-edit keeps the full serializer (a user's own settings already come from `/api/manage/user` and the JWT token claims).

## Bug fix

**Server stats parse failure (#1864)** — py-cpuinfo can report cache sizes as non-numeric strings (e.g. `"1.3 MiB"` on a Xeon Gold 6148 via newer `lscpu`), which the frontend's `z.number()` stats schema rejected (`Expected number, received string at cpu_info.l1_data_cache_size`). The backend now coerces `l1_data_cache_size`/`l1_instruction_cache_size`/`l2_cache_size`/`l3_cache_size` to int bytes (dropping any truly unparseable value) so the API contract stays numeric.

## Tests

- `test_share_photos.py`: un-skipped and hardened `test_share_other_user_photos` (the pre-existing `@skip("BUG!!! ...")` case) + added `test_unshare_other_user_photos`.
- `test_authz_scoping.py` (new): public-album write protection, job scoping (incl. admin-sees-all), and user-profile field exposure.
- `test_server_stats_cpu_info.py` (new): unit tests for the coercion helper + end-to-end coercion through `get_server_stats`.
- `test_user.py`: updated `test_authenticated_user_list_properties` to assert the public-safe fields for a non-admin, and added `test_admin_user_list_properties`.

Full backend suite run locally: the only failures are pre-existing, environment-specific ones (Windows case-insensitive filesystem, exiftool/mock scaffolding, timestamp-tie ordering flakes) unrelated to these changes. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
