### PR TITLE
fix: repair the three failing CI build pipelines on dev

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -27,7 +27,8 @@ pytz==2026.2
 tzdata==2026.2
 PyExifTool==0.5.6
 pyvips==3.1.1
-scikit-learn==1.8.0
+scikit-learn==1.8.0; python_version >= "3.11"
+scikit-learn==1.7.2; python_version < "3.11"
 sentence_transformers==5.4.1
 timezonefinder==8.2.4
 tqdm==4.67.3

--- a/apps/frontend/src/api_client/apiClient.js
+++ b/apps/frontend/src/api_client/apiClient.js
@@ -1,3 +1,4 @@
 export const serverAddress = import.meta.env.VITE_PUBLIC_URL || import.meta.env.PUBLIC_URL || "";
 // This is used for sharing. URL handling needs to account for subdirectory.
-export const shareAddress = window.location.host + (import.meta.env.VITE_PUBLIC_URL || import.meta.env.PUBLIC_URL || "");
+export const shareAddress =
+  window.location.host + (import.meta.env.VITE_PUBLIC_URL || import.meta.env.PUBLIC_URL || "");

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vitest/config";
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
## Summary

`dev` currently has three CI workflows failing on every push. This PR fixes all three. Each is an independent, self-contained commit.

| Workflow | Status before | Root cause | Introduced |
|---|---|---|---|
| `image-frontend` / `image-unified` | ❌ failing | `vite.config.ts` imported `loadEnv` from `vitest/config`, which doesn't export it | #1853 (28d ago) |
| `lint-frontend` | ❌ failing | `apiClient.js` line exceeded prettier's 120-col `printWidth` | #1853 (28d ago) |
| `image-backend-gpu` | ❌ failing | `scikit-learn==1.8.0` needs Python ≥3.11, but the GPU base image (Ubuntu 22.04) ships Python 3.10 | #1818 (May 11) |

## Details

### 1. Frontend Docker build — `loadEnv` import (`image-frontend`, `image-unified`)
`vitest/config` re-exports only a subset of Vite's helpers (`ConfigEnv`, `Plugin`, `ViteUserConfig`, `mergeConfig`) — **not** `loadEnv`. So `yarn run build` failed while loading the config:

```
SyntaxError: The requested module '.../vitest/dist/config.js' does not provide an export named 'loadEnv'
```

Fix: import `loadEnv` from `vite` (its real source), keep `defineConfig` from `vitest/config` so the `test` block stays typed.

Verified against the pinned versions (vite 7.3.x, vitest 3.2.x): `vite` exports `loadEnv`; `vitest/config` does not.

### 2. Frontend lint — prettier line length (`lint-frontend`)
The `shareAddress` declaration in `apiClient.js` was 121 chars (> `printWidth: 120`), failing `prettier/prettier`. Wrapped after `=` to match prettier's canonical output (`prettier --check` now passes).

### 3. GPU image — scikit-learn / Python mismatch (`image-backend-gpu`)
`scikit-learn==1.8.0` requires Python ≥3.11; the GPU image's CUDA base (`nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`) ships Python 3.10, where only `scikit-learn<=1.7.2` is available:

```
ERROR: No matching distribution found for scikit-learn==1.8.0
```

Bumping the CUDA/Ubuntu base to get a newer Python would drop support for older GPU cards, so instead this uses a PEP 508 environment marker:

```
scikit-learn==1.8.0; python_version >= "3.11"   # ubuntu:noble backend image (py3.12)
scikit-learn==1.7.2; python_version < "3.11"    # CUDA GPU image (py3.10)
```

Each environment resolves exactly one of the two lines (verified the markers evaluate as expected for py3.10 and py3.12).

## Test plan
- [x] `prettier --check apps/frontend/src/api_client/apiClient.js` passes
- [x] Confirmed `loadEnv` is exported by `vite` and absent from `vitest/config` for the pinned versions
- [x] Confirmed the two scikit-learn markers are mutually exclusive (py3.10 → 1.7.2, py3.12 → 1.8.0)
- [ ] CI: `image-frontend`, `image-unified`, `lint-frontend`, `image-backend-gpu` should all go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)