### PR TITLE
fix(backend): unblock image-backend-gpu — pin timezonefinder & onnxruntime for Python 3.10

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -30,7 +30,8 @@ pyvips==3.1.1
 scikit-learn==1.8.0; python_version >= "3.11"
 scikit-learn==1.7.2; python_version < "3.11"
 sentence_transformers==5.4.1
-timezonefinder==8.2.4
+timezonefinder==8.2.4; python_version >= "3.11"
+timezonefinder==8.2.0; python_version < "3.11"
 tqdm==4.67.3
 gevent==25.9.1
 python-magic==0.4.27
@@ -50,6 +51,11 @@ transformers==4.56.2
 llama-cpp-python==0.3.23
 argon2-cffi==25.1.0
 # Dependencies for SigLIP 2 ONNX inference
-onnxruntime==1.26.0
+# On the GPU image (Python 3.10) the Dockerfile swaps this for
+# onnxruntime-gpu==<same version>. 1.26.0 has no Python 3.10 wheel; 1.23.2 is the
+# last release with a cp310 wheel for both onnxruntime and onnxruntime-gpu, and is
+# the version the GPU image last built green with (before #1818).
+onnxruntime==1.26.0; python_version >= "3.11"
+onnxruntime==1.23.2; python_version < "3.11"
 # SentencePiece tokenizer for SigLIP 2
 sentencepiece==0.2.1


### PR DESCRIPTION
## Summary

Follow-up to #1867. That PR fixed 4 of the 5 failing pipelines; `image-backend-gpu` still failed because the GPU image is built on **Python 3.10** (`nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`) and **PR #1818** bumped three packages to versions that require Python ≥3.11:

| Package | Pre-#1818 (py3.10 OK) | After #1818 | Requires |
|---|---|---|---|
| `scikit-learn` | 1.7.2 | 1.8.0 | ≥3.11 — *fixed in #1867* |
| `timezonefinder` | 8.2.0 | 8.2.4 | ≥3.11 — **this PR** |
| `onnxruntime` | 1.23.2 | 1.26.0 | ≥3.11 — **this PR** |

The build was failing at pip resolution:
```
ERROR: No matching distribution found for timezonefinder==8.2.4
```
(and `onnxruntime==1.26.0` would have failed next).

## Why these exact fallback versions

The `image-backend-gpu` run **immediately before #1818 was the last green build** (a full ~7‑min build, i.e. it ran the whole Dockerfile including the `onnxruntime → onnxruntime-gpu` swap and the `CUDAExecutionProvider` check). So the pre-#1818 versions are *proven-good* on this exact image:

- `timezonefinder==8.2.0` — last release with a Python 3.10 wheel.
- `onnxruntime==1.23.2` — last release with a **cp310 wheel for both `onnxruntime` and `onnxruntime-gpu`**. This matters because the GPU Dockerfile reads the installed `onnxruntime` version and installs `onnxruntime-gpu==<that version>`; 1.26.0 has no cp310 wheel at all.

## Approach

Per the maintainer's decision (keep CUDA 12.1.1 — bumping CUDA drops support for older GPU cards), this stays in `requirements.txt` using PEP 508 environment markers, matching the `scikit-learn` fix from #1867:

```
timezonefinder==8.2.4; python_version >= "3.11"   # ubuntu:noble backend image (py3.12)
timezonefinder==8.2.0; python_version < "3.11"    # CUDA GPU image (py3.10)

onnxruntime==1.26.0; python_version >= "3.11"
onnxruntime==1.23.2; python_version < "3.11"
```

Each environment resolves exactly one line per package (verified: py3.12 → 1.26.0/8.2.4, py3.10 → 1.23.2/8.2.0).

## Note for the future

This is the same class of breakage as #1867 — the GPU image is the only target still on Python 3.10, so every dependency that drops 3.10 needs a marker. If this recurs often, the durable alternative (which still **keeps CUDA 12.1.1**) is to install Python 3.12 in the GPU base image (`deploy/docker/backend-gpu/base/Dockerfile`) via the deadsnakes PPA, giving the GPU image version parity with the CPU image. Out of scope here; flagging for consideration.

## Test plan
- [x] Markers parse and are mutually exclusive (py3.10 → 1.23.2/8.2.0, py3.12 → 1.26.0/8.2.4)
- [x] Confirmed cp310 wheels exist for `timezonefinder==8.2.0`, `onnxruntime==1.23.2`, and `onnxruntime-gpu==1.23.2`
- [x] These are the versions of the last green `image-backend-gpu` build (pre-#1818)
- [ ] CI: `image-backend-gpu` goes green on merge (only runs on push to `dev`, not on PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)