### PR TITLE
docs: update docs for the April–June 2026 release points

### DIFF
--- a/apps/docs/blog/2026-06-21-2026w25.md
+++ b/apps/docs/blog/2026-06-21-2026w25.md
@@ -15,16 +15,13 @@ The backend, frontend, mobile app, documentation, and Docker deployment now all 
 
 🚀 LibrePhotos: New Face Recognition Engine (InsightFace / ArcFace)
 
-Face recognition has been migrated from dlib to an **InsightFace / ArcFace** stack running on **ONNX Runtime**. The new engine produces 512-dimensional ArcFace embeddings (up from the old 128-dim dlib encodings) for more accurate face matching, supports GPU acceleration via `onnxruntime-gpu` in the backend-gpu image, and lets you choose the face recognition model from **Site Settings**. A migration clears the old 128-dim encodings and stale clusters — just re-run a face scan to regenerate them with the new model. The rollout also includes a batch of robustness fixes: RGBA→RGB conversion before recognition, proper JSON error responses from the face service, and several clustering and encoding fixes.
+Face recognition has been migrated from dlib to an **InsightFace / ArcFace** stack running on **ONNX Runtime**. The new engine produces 512-dimensional ArcFace embeddings (up from the old 128-dim dlib encodings) for more accurate face matching, ships `onnxruntime-gpu` in the backend-gpu image for GPU-capable setups, and lets you choose the face recognition model from **Site Settings** (`buffalo_sc` by default). A migration clears the old 128-dim encodings and stale clusters — just re-run a face scan to regenerate them with the new model. The rollout also includes a batch of robustness fixes: RGBA→RGB conversion before recognition, proper JSON error responses from the face service, and several clustering and encoding fixes.
 
 🚀 Frontend: Subdirectory Deployment Support
 
 LibrePhotos can now be hosted under a subpath (e.g. `https://example.com/photos/`) thanks to new `PUBLIC_URL` support in the frontend build. (Implemented by [dashitongzhi](https://github.com/dashitongzhi))
 
-🚀 LibrePhotos: Filter Search by Media Type
-
-Search results can now be filtered to show only photos or only videos. (Implemented by [dotanm](https://github.com/dotanm))
-
+- ✨ LibrePhotos: The search API can now filter results by media type, returning only photos or only videos (Implemented by [dotanm](https://github.com/dotanm))
 - ✨ LibrePhotos: Re-adopt files that reappear after being flagged as missing (Implemented by [dotanm](https://github.com/dotanm))
 - ✨ LibrePhotos: Bump geocode timeout to 10s and rate-limit reverse geocoding per provider (Implemented by [dotanm](https://github.com/dotanm))
 - ✨ LibrePhotos: Add timeouts to sidecar HTTP calls so background jobs can't wedge forever (Implemented by [dotanm](https://github.com/dotanm))

--- a/apps/docs/docs/development/contribution/backend/index.md
+++ b/apps/docs/docs/development/contribution/backend/index.md
@@ -81,7 +81,7 @@ im2txt is an image captioning package which allows us to generate captions on de
 
 #### Face Recognition
 
-We use dlib and face_recognition to detect faces. A very cool feature would be the automatic clustering of unknown faces, which we have not implemented yet.
+We use [InsightFace](https://github.com/deepinsight/insightface) to detect and recognise faces, running on ONNX Runtime: an SCRFD detector finds the faces and an ArcFace model turns each one into a 512-dimension embedding. This replaced the previous dlib / `face_recognition` pipeline (which produced 128-dimension encodings). The model is selectable via the `Face Recognition Model` site setting (`buffalo_sc` by default). Unknown faces are grouped with automatic clustering, and a separate classification step matches faces against already-labelled people.
 
 #### Tagging Models
 

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -56,6 +56,25 @@ To leverage GPU acceleration for neural networks and face detection, follow thes
 The GPU image is only available for x86 architecture. ARM is not supported for the GPU image.
 :::
 
+### Hosting under a sub-path (subdirectory)
+
+By default LibrePhotos is served from the root of a domain (e.g. `https://photos.example.com/`). If you need to host it under a sub-path instead (e.g. `https://example.com/photos/`), the frontend has to know that base path.
+
+The frontend reads it from the `PUBLIC_URL` build-time variable (the alias `VITE_PUBLIC_URL` also works). It sets the base path used for the app's assets and routes and defaults to `/`.
+
+Because it is applied when the frontend is **built**, the prebuilt images are served from `/`. To use a sub-path you need to build the frontend yourself with the variable set, for example:
+
+```bash
+# building the frontend directly
+PUBLIC_URL=/photos/ yarn build
+```
+
+or by passing `PUBLIC_URL` into the frontend image build. Make sure your reverse proxy forwards the same sub-path (`/photos/`) to the frontend container.
+
+:::note
+Always include the trailing slash, e.g. `/photos/`, not `/photos`.
+:::
+
 ### Changing the container names
 
 Follow the normal instructions as per your chosen build, but after updating the .env file to choose your container names, run

--- a/apps/docs/docs/user-guide/face-recognition.md
+++ b/apps/docs/docs/user-guide/face-recognition.md
@@ -32,7 +32,7 @@ After the first scan finished, go to the face dashboard. Label a couple of faces
 
 ### Face Detection
 
-We have two methods on how to extract faces from images. `hog` is fast even on CPUs and does not take up significant RAM, which `cnn` is accurate, but uses a lot of resources.
+Faces are detected with [InsightFace](https://github.com/deepinsight/insightface). Its detector (SCRFD) finds the faces in each photo and returns a bounding box for every face it sees. This replaced the older dlib detectors, so there is no longer a separate `hog` / `cnn` choice — a single detector is used for everyone.
 
 ### Face Quality
 
@@ -40,7 +40,11 @@ At the moment no matter, which detection methods we use, there will be face dete
 
 ### Face Recognition
 
-Creates a 512 dimension embedding for a given face. It makes them comparable with each other. Right now we only have the one method and should be good enough.
+Creates a 512-dimension [ArcFace](https://github.com/deepinsight/insightface) embedding for each detected face, which is what makes faces comparable to one another. You can choose which model is used in **Admin Area → Site Settings → Face Recognition Model**: smaller packs (like the default `buffalo_sc`) are faster and lighter, while larger packs (`buffalo_l`, `antelopev2`) are more accurate but use more memory.
+
+:::note Upgrading from an older version
+Older versions of LibrePhotos used dlib with 128-dimension encodings. When you upgrade to the ArcFace engine, those old encodings and the existing face clusters are cleared automatically because they are not compatible with the new 512-dimension embeddings. Just run **Train faces** / **Re-scan faces** once and your faces will be re-encoded with the new model.
+:::
 
 ### Face Clustering
 

--- a/apps/docs/docs/user-guide/offline-setup.md
+++ b/apps/docs/docs/user-guide/offline-setup.md
@@ -30,6 +30,9 @@ Manually download the necessary models from their respective URLs. Below is a li
     - Vision model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/vision_model.onnx`
     - Text model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/text_model.onnx`
     - Tokenizer: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/tokenizer.model`
+10. **buffalo_sc** (Face recognition — default model)
+    - URL: `https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip`
+    - Only download the model selected in **Site Settings → Face Recognition Model**. The other options use the same release, e.g. `buffalo_s.zip`, `buffalo_m.zip`, `buffalo_l.zip`, `antelopev2.zip`.
 
 ### Step 2: Place the Models in the Correct Location
 
@@ -52,6 +55,7 @@ For example, if your `MEDIA_ROOT` is set to `/var/lib/librephotos`, then the mod
 - **siglip2 vision_model.onnx** -> Place as `<MEDIA_ROOT>/data_models/siglip2/vision_model.onnx`
 - **siglip2 text_model.onnx** -> Place as `<MEDIA_ROOT>/data_models/siglip2/text_model.onnx`
 - **siglip2 tokenizer.model** -> Place as `<MEDIA_ROOT>/data_models/siglip2/tokenizer.model`
+- **buffalo_sc.zip** -> Unpack into `<MEDIA_ROOT>/data_models/face_recognition/models/buffalo_sc/` (the folder should contain the `.onnx` files)
 
 ### Step 3: Verify Model Placement
 
@@ -67,10 +71,13 @@ data_models/
     ├── blip/
     ├── mistral-7b-v0.1.Q5_K_M.gguf
     ├── mistral-7b-instruct-v0.2.Q5_K_M.gguf
-    └── siglip2/
-        ├── vision_model.onnx
-        ├── text_model.onnx
-        └── tokenizer.model
+    ├── siglip2/
+    │   ├── vision_model.onnx
+    │   ├── text_model.onnx
+    │   └── tokenizer.model
+    └── face_recognition/
+        └── models/
+            └── buffalo_sc/
 ```
 
 ### Step 4: Run LibrePhotos

--- a/apps/docs/docs/user-guide/settings/index.md
+++ b/apps/docs/docs/user-guide/settings/index.md
@@ -86,6 +86,12 @@ These are settings that apply to the whole instance.
   - **SigLIP 2** — Google's vision-language model using zero-shot classification against a curated vocabulary of 900+ real-world photo tags. Returns the top 10 most relevant tags.
   
   Switching models does not delete previously generated tags. Each model's tags are stored independently, so you can switch back and forth without rescanning.
+- `Face Recognition Model` Select which [InsightFace](https://github.com/deepinsight/insightface) model is used to detect and recognise faces. Options:
+  - **buffalo_sc** — Lightweight model (default). Fastest and smallest, a good fit for most setups.
+  - **buffalo_s** / **buffalo_m** / **buffalo_l** — Progressively larger and more accurate, at the cost of more memory and compute.
+  - **antelopev2** — High-accuracy model for the best recognition quality.
+
+  Changing the model downloads the corresponding model files on the next run. After switching, run **Train faces** so all faces are re-encoded with the selected model. See [Face recognition](../face-recognition.md).
 
 ## Users
 


### PR DESCRIPTION
Sync the documentation with the changes described in the new blog post:

- Face recognition: replace the stale dlib `hog`/`cnn` description with the new InsightFace (SCRFD) + ArcFace 512-dim engine in the user guide and the backend contribution guide; add an upgrade note about cleared 128-dim encodings.
- Settings: document the new `Face Recognition Model` site setting and its model options (buffalo_sc default, buffalo_s/m/l, antelopev2).
- Offline setup: add the face recognition model download, placement, and directory layout.
- Installation: document hosting under a sub-path via the PUBLIC_URL build-time variable.
- Blog post: soften the media-type search point to reflect that it is currently a backend/API capability (no UI yet), and adjust the GPU wording.