### PR TITLE
backend: clear 128-dim encodings in migration 0126 with a set-based UPDATE

### DIFF
--- a/apps/backend/api/migrations/0126_clear_128dim_face_encodings.py
+++ b/apps/backend/api/migrations/0126_clear_128dim_face_encodings.py
@@ -7,6 +7,7 @@ face classification run.
 """
 
 from django.db import migrations
+from django.db.models.functions import Length
 
 
 # 128 floats * 8 bytes/float * 2 hex chars/byte = 2048 hex chars
@@ -18,17 +19,19 @@ def clear_128dim_face_encodings(apps, schema_editor):
     Face = apps.get_model("api", "Face")
     Cluster = apps.get_model("api", "Cluster")
 
-    faces_to_clear = [
-        face
-        for face in Face.objects.exclude(encoding="").only("id", "encoding")
-        if len(face.encoding) == ENCODING_128DIM_HEX_LENGTH
-    ]
-    for face in faces_to_clear:
-        face.encoding = ""
-    Face.objects.bulk_update(faces_to_clear, ["encoding"])
+    # Clear in a single set-based UPDATE. The previous implementation loaded every
+    # matching Face into memory and handed them all to bulk_update() with no
+    # batch_size, which emits one
+    #     UPDATE api_face SET encoding = CASE WHEN id=.. THEN '' ... END
+    # with one branch per row. On large libraries (100k+ faces) evaluating that
+    # CASE is roughly O(n^2) and pins a CPU core for hours; the equivalent
+    # set-based UPDATE below runs in seconds.
+    Face.objects.annotate(encoding_length=Length("encoding")).filter(
+        encoding_length=ENCODING_128DIM_HEX_LENGTH
+    ).update(encoding="")
 
     # Delete all clusters; they will be rebuilt on next face classification run
-    deleted, _ = Cluster.objects.all().delete()
+    Cluster.objects.all().delete()
 
 
 def reverse_migration(apps, schema_editor):

--- a/apps/backend/api/tests/test_migration_0126_clear_128dim.py
+++ b/apps/backend/api/tests/test_migration_0126_clear_128dim.py
@@ -1,0 +1,56 @@
+import importlib
+
+import numpy as np
+from django.apps import apps as global_apps
+from django.test import TestCase
+
+from api.models import Cluster, Face
+
+from .utils import create_test_face
+
+# The migration module name starts with a digit, so it can't be imported with a
+# normal `import` statement.
+migration_0126 = importlib.import_module(
+    "api.migrations.0126_clear_128dim_face_encodings"
+)
+
+
+def encoding_of_length(num_floats):
+    """A hex-encoded encoding string for `num_floats` float64 values."""
+    return np.random.rand(num_floats).tobytes().hex()
+
+
+class Clear128DimFaceEncodingsMigrationTest(TestCase):
+    def test_only_128dim_encodings_are_cleared_and_clusters_deleted(self):
+        # 128-dim (2048 hex chars): must be cleared.
+        old_a = create_test_face(encoding=encoding_of_length(128))
+        old_b = create_test_face(encoding=encoding_of_length(128))
+        # 512-dim ArcFace (8192 hex chars): must be left untouched.
+        new = create_test_face(encoding=encoding_of_length(512))
+        # Already-empty: untouched, and not matched by the length filter.
+        empty = create_test_face(encoding="")
+
+        # A face attached to a cluster: the cluster is deleted but the face
+        # survives (Face.cluster is on_delete=SET_NULL).
+        cluster = Cluster.objects.create(mean_face_encoding="")
+        clustered = create_test_face(encoding=encoding_of_length(128), cluster=cluster)
+
+        self.assertEqual(Cluster.objects.count(), 1)
+
+        migration_0126.clear_128dim_face_encodings(global_apps, None)
+
+        for face in (old_a, old_b, clustered):
+            face.refresh_from_db()
+            self.assertEqual(face.encoding, "")
+
+        new.refresh_from_db()
+        self.assertEqual(len(new.encoding), 512 * 8 * 2)
+
+        empty.refresh_from_db()
+        self.assertEqual(empty.encoding, "")
+
+        # All faces still exist; only the cluster link was severed.
+        self.assertEqual(Face.objects.count(), 5)
+        self.assertEqual(Cluster.objects.count(), 0)
+        clustered.refresh_from_db()
+        self.assertIsNone(clustered.cluster)


### PR DESCRIPTION
Migration `0126_clear_128dim_face_encodings` collects every Face whose encoding is still 128-dim and hands the whole list to `bulk_update(..., ["encoding"])` with no `batch_size`. Django turns that into one statement of the form `UPDATE api_face SET encoding = CASE WHEN id=.. THEN '' WHEN id=.. THEN '' ... END WHERE id IN (...)`, with one `CASE` branch per row. Evaluating that `CASE` is roughly O(n²) in the number of faces, so on a large library it doesn't just take a while — it effectively stalls the upgrade.

I hit this on a real install with ~97k faces: Postgres sat at 100% CPU on a single core for well over an hour, the migration never finishing, and because the backend runs `migrate` on startup the whole instance stayed down the entire time. Worse, the query is CPU-bound inside the executor, so it ignores `pg_cancel_backend`/`pg_terminate_backend` and survives a backend container stop — clearing it required restarting Postgres.

This swaps the in-memory loop plus `bulk_update` for an equivalent set-based statement that filters on the encoding length in SQL: `Face.objects.annotate(encoding_length=Length("encoding")).filter(encoding_length=2048).update(encoding="")`. That produces a single `UPDATE api_face SET encoding = '' WHERE length(encoding) = 2048`, which is O(n) and completes in seconds on the same dataset. The end state is identical, and the cluster cleanup is unchanged.

Editing the released migration in place is safe here: the recorded migration name doesn't change, and any install that already applied 0126 is unaffected since the data is already in the target state. The win is entirely for installs that haven't crossed the ArcFace switch yet — which is anyone with a large library upgrading to this release.

The added test creates faces with 128-dim, 512-dim (ArcFace) and empty encodings plus a clustered face, runs the migration function, and asserts that only the 128-dim encodings are cleared, the longer and empty ones are untouched, all faces survive, and clusters are deleted with their `cluster` FK nulled via `SET_NULL`.
