### PR TITLE
backend: harden get_metadata against transient exif-service failures

### DIFF
--- a/apps/backend/api/metadata/reader.py
+++ b/apps/backend/api/metadata/reader.py
@@ -1,7 +1,19 @@
 import os
 import os.path
+import time
 
 import requests
+
+from api import util
+
+EXIF_SERVICE_URL = "http://localhost:8010/get-tags"
+# The exif sidecar can transiently fail while a scan saturates the box —
+# returning an empty body (so ``.json()`` raises ``JSONDecodeError``), a non-2xx
+# status, or dropping the connection. Retry a few times with a short backoff
+# before giving up, so a single blip does not become a per-photo error that
+# accumulates past the failure threshold and marks a whole job "failed".
+EXIF_MAX_ATTEMPTS = 3
+EXIF_RETRY_BACKOFF = 0.5
 
 
 def get_sidecar_files_in_priority_order(media_file):
@@ -37,24 +49,47 @@ def get_metadata(media_file, tags, try_sidecar=True, struct=False):
     If *struct* is `True`, use the exiftool instance which returns structured data
 
     Returns a list with the value of each tag in *tags* or `None` if the
-    tag was not found.
+    tag was not found. If the exif service cannot be reached or returns an
+    unusable response after retries, returns a list of `None` (one per tag)
+    rather than raising, so a transient service hiccup does not abort the
+    caller's whole photo-processing pipeline.
 
     """
     files_by_reverse_priority = _get_existing_metadata_files_reversed(
         media_file, try_sidecar
     )
 
-    json = {
+    payload = {
         "tags": tags,
         "files_by_reverse_priority": files_by_reverse_priority,
         "struct": struct,
     }
     from api.http_timeouts import EXIF
 
-    response = requests.post(
-        "http://localhost:8010/get-tags", json=json, timeout=EXIF
-    ).json()
-    values = response["values"]
+    values = None
+    last_error = None
+    for attempt in range(EXIF_MAX_ATTEMPTS):
+        try:
+            response = requests.post(EXIF_SERVICE_URL, json=payload, timeout=EXIF)
+            response.raise_for_status()
+            values = response.json()["values"]
+            break
+        except (requests.RequestException, ValueError, KeyError) as error:
+            # ValueError covers JSONDecodeError (empty/non-JSON body); KeyError a
+            # response missing "values"; RequestException covers timeouts,
+            # dropped connections and non-2xx statuses.
+            last_error = error
+            if attempt + 1 < EXIF_MAX_ATTEMPTS:
+                time.sleep(EXIF_RETRY_BACKOFF * (attempt + 1))
+
+    if values is None:
+        util.logger.warning(
+            f"exif service returned no usable metadata for {media_file} after "
+            f"{EXIF_MAX_ATTEMPTS} attempt(s): {last_error}. "
+            f"Falling back to empty metadata."
+        )
+        return [None] * len(tags)
+
     # The exif service can return fewer values than requested if exiftool
     # errors mid-loop. Callers unpack the result positionally, so pad with
     # None to honor the documented one-value-per-tag contract.

--- a/apps/backend/api/models/thumbnail.py
+++ b/apps/backend/api/models/thumbnail.py
@@ -148,14 +148,22 @@ class Thumbnail(models.Model):
                 tags=[Tags.IMAGE_HEIGHT, Tags.IMAGE_WIDTH],
                 try_sidecar=False,
             )
+            if not height or not width:
+                # Dimensions unavailable (e.g. the exif sidecar was unreachable).
+                # Skip rather than abort the whole photo pipeline — a missing
+                # aspect ratio is backfilled by a later scan.
+                logger.warning(
+                    f"missing dimensions for image {self.thumbnail_big.path}; "
+                    "skipping aspect ratio"
+                )
+                return
             self.aspect_ratio = round(width / height, 2)
 
             self.save()
-        except Exception as e:
+        except Exception:
             logger.exception(
                 f"could not calculate aspect ratio for image {self.thumbnail_big.path}"
             )
-            raise e
 
     def _get_dominant_color(self, palette_size=16):
         # Skip if it's already calculated

--- a/apps/backend/api/tests/test_metadata_reader.py
+++ b/apps/backend/api/tests/test_metadata_reader.py
@@ -12,9 +12,10 @@ docstring: one value per tag, ``None`` when the tag was not found.
 
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import SimpleTestCase
 
-from api.metadata.reader import get_metadata
+from api.metadata.reader import EXIF_MAX_ATTEMPTS, get_metadata
 
 
 class GetMetadataPaddingTest(SimpleTestCase):
@@ -52,3 +53,59 @@ class GetMetadataPaddingTest(SimpleTestCase):
         )
 
         self.assertEqual(result, [12.34, None, None])
+
+
+class GetMetadataResilienceTest(SimpleTestCase):
+    """The exif sidecar can transiently fail under scan load — empty body,
+    non-2xx status, or dropped connection. ``get_metadata`` must retry and then
+    degrade to ``None``-per-tag rather than raising, so one blip doesn't fail a
+    whole enrichment job (Add Geolocation / Scan Faces) via the error threshold.
+    """
+
+    def _values_response(self, values):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"values": values}
+        return response
+
+    def _empty_body_response(self):
+        # Mirrors requests' behaviour on an empty body: .json() raises.
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.side_effect = requests.exceptions.JSONDecodeError(
+            "Expecting value", "", 0
+        )
+        return response
+
+    @patch("api.metadata.reader.time.sleep", return_value=None)
+    @patch("api.metadata.reader.requests.post")
+    def test_empty_body_falls_back_to_none(self, mock_post, _sleep):
+        mock_post.return_value = self._empty_body_response()
+
+        result = get_metadata("/tmp/photo.jpg", tags=["EXIF:Make", "EXIF:Model"])
+
+        self.assertEqual(result, [None, None])
+        self.assertEqual(mock_post.call_count, EXIF_MAX_ATTEMPTS)
+
+    @patch("api.metadata.reader.time.sleep", return_value=None)
+    @patch("api.metadata.reader.requests.post")
+    def test_connection_error_falls_back_to_none(self, mock_post, _sleep):
+        mock_post.side_effect = requests.exceptions.ConnectionError("closed")
+
+        result = get_metadata("/tmp/photo.jpg", tags=["GPS:Latitude", "GPS:Longitude"])
+
+        self.assertEqual(result, [None, None])
+        self.assertEqual(mock_post.call_count, EXIF_MAX_ATTEMPTS)
+
+    @patch("api.metadata.reader.time.sleep", return_value=None)
+    @patch("api.metadata.reader.requests.post")
+    def test_retries_then_succeeds(self, mock_post, _sleep):
+        mock_post.side_effect = [
+            requests.exceptions.ConnectionError("transient"),
+            self._values_response([1.0, 2.0]),
+        ]
+
+        result = get_metadata("/tmp/photo.jpg", tags=["GPS:Latitude", "GPS:Longitude"])
+
+        self.assertEqual(result, [1.0, 2.0])
+        self.assertEqual(mock_post.call_count, 2)


### PR DESCRIPTION
On a large scan (≈155k photos, CPU-only host) both the Add Geolocation and Scan Faces jobs ran to completion but were marked **failed**, because more than 5% of their per-photo work raised `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. The traceback bottoms out in `get_metadata`, which calls `requests.post(".../get-tags").json()` unconditionally: when the exif sidecar is saturated and returns an empty (or non-JSON) body — or drops the connection — `.json()` raises and the exception propagates all the way up. So a single transient sidecar blip becomes a hard per-photo failure, and enough of them trip the job-failure threshold added in #1844, branding the whole job failed even though ~95% of photos succeeded.

The same crash also aborts `_process_photo` partway through `Thumbnail._calculate_aspect_ratio`, which re-raised the exception — leaving the photo with a row but without EXIF/date/search-captions, and (because the row now exists) it is skipped on the next incremental scan rather than retried.

This makes `get_metadata` tolerant of a struggling sidecar. It retries the request a few times with a short backoff — covering empty/non-JSON bodies, non-2xx statuses, timeouts and dropped connections uniformly — and if it still can't get a usable response it returns the documented `None`-per-tag list instead of raising. That degradation already matches the function's contract: the short-return padding from #1840 produces the same shape, so the existing callers that guard their values (`_geolocate`, `face_extractor`, the bulk EXIF unpack, the date extractor) simply skip gracefully. `_calculate_aspect_ratio` was the one caller doing arithmetic on the result, so it now skips when dimensions are missing and no longer re-raises, so one metadata hiccup can't abort the rest of a photo's processing — the missing aspect ratio is backfilled by a later scan.

Extends `test_metadata_reader.py` with cases for an empty body, a dropped connection, and recovery on a retry. This is a sequel to the `get_metadata` hardening in #1840 and #1842.
