### PR TITLE
backend: retry transient face-service connection drops

### DIFF
--- a/apps/backend/api/face_recognition.py
+++ b/apps/backend/api/face_recognition.py
@@ -1,10 +1,18 @@
 import html
 import re
+import time
 from html.parser import HTMLParser
 
 import numpy as np
 import requests
 from constance import config as site_config
+
+# The face-recognition sidecar can transiently drop the connection while a scan
+# saturates the box (RemoteDisconnected → requests.ConnectionError), or time out.
+# Retry a few times with a short backoff so one blip doesn't fail a face and,
+# accumulated, mark a whole Scan Faces / Generate Face Embeddings job failed.
+FACE_MAX_ATTEMPTS = 3
+FACE_RETRY_BACKOFF = 0.5
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -71,10 +79,26 @@ def _get_error_detail(response):
 
 
 def _post_to_face_service(url, payload):
-    """POST to the face service and raise errors with response details."""
+    """POST to the face service and raise errors with response details.
+
+    Transient transport failures (the service dropping the connection under
+    load, or a timeout) are retried with a short backoff before giving up.
+    Status (HTTP) and body (JSON) errors are not retried — they would fail the
+    same way — and are raised with response details as before.
+    """
     from api.http_timeouts import FACE
 
-    response = requests.post(url, json=payload, timeout=FACE)
+    last_error = None
+    for attempt in range(FACE_MAX_ATTEMPTS):
+        try:
+            response = requests.post(url, json=payload, timeout=FACE)
+            break
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            last_error = exc
+            if attempt + 1 < FACE_MAX_ATTEMPTS:
+                time.sleep(FACE_RETRY_BACKOFF * (attempt + 1))
+    else:
+        raise last_error
 
     try:
         response.raise_for_status()

--- a/apps/backend/api/tests/test_face_service_resilience.py
+++ b/apps/backend/api/tests/test_face_service_resilience.py
@@ -1,0 +1,79 @@
+"""Resilience tests for ``api.face_recognition._post_to_face_service``.
+
+The face-recognition sidecar can transiently drop the connection while a scan
+saturates the box — surfacing as ``requests.ConnectionError`` (the underlying
+``http.client.RemoteDisconnected``) — or time out. A single such blip used to
+fail the whole face, and enough of them tripped the job-failure threshold,
+marking Scan Faces / Generate Face Embeddings as failed despite most faces
+succeeding.
+
+These tests assert the helper retries transient transport failures and gives
+up gracefully, while NOT retrying status/JSON errors (which would fail the
+same way).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.test import SimpleTestCase
+
+from api.face_recognition import FACE_MAX_ATTEMPTS, _post_to_face_service
+
+
+def _ok_response(json_body=None):
+    response = MagicMock()
+    response.status_code = 200
+    response.ok = True
+    response.json.return_value = json_body if json_body is not None else {}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _status_error_response(status_code=400):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = {"error": "bad request"}
+    response.raise_for_status.side_effect = requests.HTTPError("boom")
+    return response
+
+
+class PostToFaceServiceResilienceTest(SimpleTestCase):
+    @patch("api.face_recognition.time.sleep", return_value=None)
+    @patch("api.face_recognition.requests.post")
+    def test_retries_transient_drop_then_succeeds(self, mock_post, _sleep):
+        mock_post.side_effect = [
+            requests.ConnectionError("Remote end closed connection"),
+            _ok_response({"encodings": []}),
+        ]
+
+        result = _post_to_face_service(
+            "http://localhost:8005/face-encodings", {"source": "/tmp/p.jpg"}
+        )
+
+        self.assertEqual(result, {"encodings": []})
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("api.face_recognition.time.sleep", return_value=None)
+    @patch("api.face_recognition.requests.post")
+    def test_gives_up_after_max_attempts(self, mock_post, _sleep):
+        mock_post.side_effect = requests.ConnectionError("Remote end closed connection")
+
+        with self.assertRaises(requests.ConnectionError):
+            _post_to_face_service(
+                "http://localhost:8005/face-encodings", {"source": "/tmp/p.jpg"}
+            )
+
+        self.assertEqual(mock_post.call_count, FACE_MAX_ATTEMPTS)
+
+    @patch("api.face_recognition.time.sleep", return_value=None)
+    @patch("api.face_recognition.requests.post")
+    def test_status_error_is_not_retried(self, mock_post, _sleep):
+        # A non-2xx status is not transient — retrying would fail identically.
+        mock_post.return_value = _status_error_response(400)
+
+        with self.assertRaises(requests.HTTPError):
+            _post_to_face_service(
+                "http://localhost:8005/face-encodings", {"source": "/tmp/p.jpg"}
+            )
+
+        self.assertEqual(mock_post.call_count, 1)


### PR DESCRIPTION
While a large scan saturates the box, the face-recognition sidecar intermittently drops the connection — surfacing as `http.client.RemoteDisconnected` / `requests.ConnectionError`. `_post_to_face_service` (the single helper behind both `get_face_locations` and `get_face_encodings`) had a timeout but no retry, so one transient drop raised straight through. Each such error fails a single face, and once enough accumulate they trip the job-failure threshold from #1844 — marking a whole Scan Faces or Generate Face Embeddings job failed even though almost every face succeeded. This was observed on a 155k-photo library, where Generate Face Embeddings failed partway through on a `RemoteDisconnected`.

`_post_to_face_service` now retries transient transport failures (`ConnectionError`, `Timeout`) a few times with a short backoff before giving up. Status (HTTP) and body (JSON) errors are deliberately not retried — they would fail identically — and are still raised with the same response details as before. Because both face endpoints share this one helper, the change hardens face detection and face-embedding generation together. This mirrors the sidecar hardening in #1842 and #1873.

Adds `test_face_service_resilience.py` covering retry-then-succeed, give-up-after-max-attempts, and not-retrying a status error.
