### PR TITLE
backend: preserve the latest finished job per type in cleanup_old_jobs (scan baseline)

### DIFF
--- a/apps/backend/api/models/long_running_job.py
+++ b/apps/backend/api/models/long_running_job.py
@@ -225,14 +225,51 @@ class LongRunningJob(models.Model):
     @classmethod
     def cleanup_old_jobs(cls, days=30):
         """
-        Delete completed/failed jobs older than specified days.
+        Delete completed/failed jobs older than specified days, but always keep
+        the most recent finished job of each (user, job_type).
+
+        The latest finished job per type is preserved regardless of age because
+        the incremental scan uses it as the "last scan" baseline: it is queried
+        in ``api/directory_watcher/scan_jobs.py`` and ``processing_jobs.py`` to
+        decide which photos can be skipped. Deleting it leaves no baseline, so
+        the next scan reprocesses (and re-enriches) the entire library. Older
+        finished jobs of the same type are still pruned as litter.
 
         Args:
-            days: Number of days after which completed jobs should be deleted
+            days: Number of days after which surplus completed jobs are deleted
 
         Returns:
             Number of jobs deleted
         """
         cutoff = timezone.now() - timedelta(days=days)
-        deleted, _ = cls.objects.filter(finished=True, finished_at__lt=cutoff).delete()
+
+        # Preserve the most recent finished job of each (user, job_type) — the
+        # incremental-scan baseline — at any age. The number of groups is
+        # bounded by users x job types, so this loop is cheap.
+        keep_ids = set()
+        groups = (
+            cls.objects.filter(finished=True, finished_at__isnull=False)
+            .values_list("started_by_id", "job_type")
+            .distinct()
+        )
+        for started_by_id, job_type in groups:
+            latest_id = (
+                cls.objects.filter(
+                    finished=True,
+                    finished_at__isnull=False,
+                    started_by_id=started_by_id,
+                    job_type=job_type,
+                )
+                .order_by("-finished_at", "-id")
+                .values_list("id", flat=True)
+                .first()
+            )
+            if latest_id is not None:
+                keep_ids.add(latest_id)
+
+        deleted, _ = (
+            cls.objects.filter(finished=True, finished_at__lt=cutoff)
+            .exclude(id__in=keep_ids)
+            .delete()
+        )
         return deleted

--- a/apps/backend/api/tests/test_cleanup_old_jobs_baseline.py
+++ b/apps/backend/api/tests/test_cleanup_old_jobs_baseline.py
@@ -1,0 +1,91 @@
+"""Tests for ``LongRunningJob.cleanup_old_jobs`` baseline preservation.
+
+The incremental scan derives its "last scan" baseline by querying the most
+recent ``finished=True`` job of each type (``api/directory_watcher/scan_jobs.py``
+and ``processing_jobs.py``). The daily cleanup used to delete every finished job
+older than 30 days, including that baseline — which silently forced a full
+re-scan/re-enrichment of the whole library on the next run. Cleanup must now
+keep the latest finished job of each (user, job_type) regardless of age, while
+still pruning older surplus jobs.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from api.models import LongRunningJob
+from api.tests.utils import create_test_user
+
+J = LongRunningJob
+
+
+class CleanupOldJobsBaselineTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    def _job(self, job_type, days_ago, finished=True, user=None):
+        return J.objects.create(
+            started_by=user or self.user,
+            job_id=str(uuid.uuid4()),
+            job_type=job_type,
+            finished=finished,
+            failed=False,
+            finished_at=(
+                timezone.now() - timedelta(days=days_ago) if finished else None
+            ),
+        )
+
+    def test_keeps_latest_finished_job_per_type_even_when_old(self):
+        # The only Scan Photos job is 60 days old — older than the 30d cutoff —
+        # but it is the incremental-scan baseline and must survive.
+        baseline = self._job(J.JOB_SCAN_PHOTOS, days_ago=60)
+        J.cleanup_old_jobs(days=30)
+        self.assertTrue(
+            J.objects.filter(id=baseline.id).exists(),
+            "the latest finished job (scan baseline) must survive cleanup",
+        )
+
+    def test_prunes_older_duplicates_but_keeps_newest(self):
+        older = self._job(J.JOB_SCAN_PHOTOS, days_ago=90)
+        newer = self._job(J.JOB_SCAN_PHOTOS, days_ago=60)
+        J.cleanup_old_jobs(days=30)
+        self.assertFalse(J.objects.filter(id=older.id).exists())
+        self.assertTrue(J.objects.filter(id=newer.id).exists())
+
+    def test_prunes_old_surplus_when_latest_is_recent(self):
+        recent = self._job(J.JOB_SCAN_PHOTOS, days_ago=2)
+        stale = self._job(J.JOB_SCAN_PHOTOS, days_ago=60)
+        J.cleanup_old_jobs(days=30)
+        self.assertTrue(J.objects.filter(id=recent.id).exists())
+        self.assertFalse(J.objects.filter(id=stale.id).exists())
+
+    def test_keeps_latest_of_each_type_independently(self):
+        jobs = [
+            self._job(J.JOB_SCAN_PHOTOS, days_ago=60),
+            self._job(J.JOB_ADD_GEOLOCATION, days_ago=60),
+            self._job(J.JOB_SCAN_FACES, days_ago=60),
+            self._job(J.JOB_GENERATE_TAGS, days_ago=60),
+        ]
+        J.cleanup_old_jobs(days=30)
+        for j in jobs:
+            self.assertTrue(
+                J.objects.filter(id=j.id).exists(),
+                f"baseline for job_type {j.job_type} must survive",
+            )
+
+    def test_keeps_latest_baseline_per_user(self):
+        other = create_test_user()
+        mine = self._job(J.JOB_SCAN_PHOTOS, days_ago=60)
+        theirs = self._job(J.JOB_SCAN_PHOTOS, days_ago=60, user=other)
+        J.cleanup_old_jobs(days=30)
+        self.assertTrue(J.objects.filter(id=mine.id).exists())
+        self.assertTrue(J.objects.filter(id=theirs.id).exists())
+
+    def test_recent_jobs_within_cutoff_are_kept(self):
+        extra = self._job(J.JOB_SCAN_PHOTOS, days_ago=2)
+        latest = self._job(J.JOB_SCAN_PHOTOS, days_ago=1)
+        J.cleanup_old_jobs(days=30)
+        self.assertTrue(J.objects.filter(id=extra.id).exists())
+        self.assertTrue(J.objects.filter(id=latest.id).exists())


### PR DESCRIPTION
Manual addition: this is a small, safe and non-intrusive solution to a much deeper problem. Even after this feature, admins that want a clean job board don't know that their forcing the app to re-scan their library from scratch. The full solution will require more thought.

Original post:
The daily job cleanup and the incremental scan interact in a way that's easy to miss, and it can silently force a full re-scan of an entire library.

How the incremental scan decides what to skip: `scan_photos` and the enrichment jobs (`generate_tags`, `add_geolocation`, `scan_faces`) each look up their "last scan" by querying the most recent `finished=True` job of their own type (`api/directory_watcher/scan_jobs.py`, `api/directory_watcher/processing_jobs.py`) and skip photos that predate it. There is no other persistent record of "last scanned" — that finished `LongRunningJob` row *is* the baseline.

`cleanup_old_jobs(days=30)`, scheduled daily, deletes every finished job older than 30 days — including that baseline row. So if a user goes more than ~30 days between scans, the latest baseline ages out and gets deleted; the next scan then finds `last_scan is None` and reprocesses (and re-enriches) the whole library. Clearing old "finished" jobs from the admin UI triggers the same thing immediately. Users who scan more often are unaffected, because their most recent finished job is always newer than the cutoff — which is also why preserving it is safe.

On a large library the redundant work is significant. On a ~155k-photo library where this surfaced, one full pass measured roughly: Scan Photos 11h47m, Add Geolocation ~6.1h, Scan Faces ~3.4h, Generate Face Embeddings ~6.7h, Generate Tags ~1.5h, Calculate CLIP embeddings ~32m — re-incurred for no functional reason, and the geolocation/face sidecars tend to fail under full-library load on top of it.

This change keeps the most recent finished job of each `(user, job_type)` regardless of age and prunes only the older surplus, so the incremental-scan baseline always survives while accumulated litter is still cleaned up. The added loop is bounded by `users × job_types` (not by number of jobs), so it stays cheap.

It is net-neutral-or-positive for libraries of any size: it only avoids needless reprocessing and never causes anything to scan more than before. A durable per-user "last scanned at" field would be a more complete fix — it would also survive a manual deletion of the latest row — but that is a larger change; this keeps the surface area minimal and resolves the automatic, silent case.

Adds `test_cleanup_old_jobs_baseline.py` covering: the latest finished job of a type survives even when older than the cutoff; older duplicates are still pruned; surplus is removed when the latest is recent; and the latest is preserved independently per type and per user.
