### PR TITLE
backend: prefetch known file paths in scan Phase 1 (avoid a query per file)

### DIFF
--- a/apps/backend/api/directory_watcher/scan_jobs.py
+++ b/apps/backend/api/directory_watcher/scan_jobs.py
@@ -50,6 +50,30 @@ def _file_was_modified_after(filepath, time):
     return datetime.datetime.fromtimestamp(modified).replace(tzinfo=pytz.utc) > time
 
 
+def _group_needs_processing(paths, existing_paths, full_scan, last_scan):
+    """Return True if any file in a (directory, basename) group must be processed.
+
+    This mirrors the original per-file decision exactly, but takes a prebuilt
+    set of already-known file paths so the "do we have this file?" test is an
+    in-memory lookup instead of one ``Photo.objects.filter(files__path=path)
+    .exists()`` query per file (a round-trip per file — 100k+ on a large
+    library, the dominant cost of scan start-up).
+
+    The modified-time check (and the sidecar paths it stats) is only reached for
+    a file we already have, on an incremental scan with a baseline — i.e. the
+    only case where "did it change since last scan?" is the deciding question.
+    """
+    for path in paths:
+        if path not in existing_paths or full_scan or not last_scan:
+            return True
+        files_to_check = [path, *get_sidecar_files_in_priority_order(path)]
+        if any(
+            _file_was_modified_after(p, last_scan.finished_at) for p in files_to_check
+        ):
+            return True
+    return False
+
+
 def wait_for_group_and_process_metadata(
     group_id: str,
     metadata_paths: list[str],
@@ -240,32 +264,19 @@ def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=None):
                 group_key = get_file_grouping_key(path)
                 file_groups[group_key].append(path)
 
-        # Determine which groups need processing
+        # Determine which groups need processing.
+        # Load every known file path in ONE query so the per-file existence
+        # check below is an in-memory set lookup rather than a
+        # Photo...exists() round-trip per file (100k+ on a large library).
+        existing_paths = set(
+            Photo.objects.filter(files__path__isnull=False).values_list(
+                "files__path", flat=True
+            )
+        )
+
         groups_to_process: list[tuple[tuple[str, str], list[str]]] = []
-
         for group_key, paths in file_groups.items():
-            # Check if any file in this group needs processing
-            needs_processing = False
-
-            for path in paths:
-                files_to_check = [path]
-                files_to_check.extend(get_sidecar_files_in_priority_order(path))
-
-                if (
-                    not Photo.objects.filter(files__path=path).exists()
-                    or full_scan
-                    or not last_scan
-                    or any(
-                        [
-                            _file_was_modified_after(p, last_scan.finished_at)
-                            for p in files_to_check
-                        ]
-                    )
-                ):
-                    needs_processing = True
-                    break
-
-            if needs_processing:
+            if _group_needs_processing(paths, existing_paths, full_scan, last_scan):
                 groups_to_process.append((group_key, paths))
 
         # Progress target is number of groups (not individual files)

--- a/apps/backend/api/directory_watcher/scan_jobs.py
+++ b/apps/backend/api/directory_watcher/scan_jobs.py
@@ -41,6 +41,14 @@ from api.directory_watcher.utils import (
 )
 
 
+# Number of file groups whose known-paths are resolved in a single DB query
+# during scan Phase 1. Larger batches mean fewer round-trips (faster start-up)
+# but a bigger transient ``known_paths`` set; ~10k groups is the knee where the
+# per-batch query cost stops shrinking, while keeping the transient set tiny
+# (well under 2 MB) regardless of total library size.
+_PATH_PREFETCH_BATCH = 10000
+
+
 def _file_was_modified_after(filepath, time):
     """Check if a file was modified after a given time."""
     try:
@@ -53,11 +61,12 @@ def _file_was_modified_after(filepath, time):
 def _group_needs_processing(paths, existing_paths, full_scan, last_scan):
     """Return True if any file in a (directory, basename) group must be processed.
 
-    This mirrors the original per-file decision exactly, but takes a prebuilt
-    set of already-known file paths so the "do we have this file?" test is an
-    in-memory lookup instead of one ``Photo.objects.filter(files__path=path)
-    .exists()`` query per file (a round-trip per file — 100k+ on a large
-    library, the dominant cost of scan start-up).
+    This mirrors the original per-file decision exactly, but takes a set of
+    already-known file paths (resolved one batch at a time by the caller) so the
+    "do we have this file?" test is an in-memory lookup instead of one
+    ``Photo.objects.filter(files__path=path).exists()`` query per file (a
+    round-trip per file — 100k+ on a large library, the dominant cost of scan
+    start-up). ``existing_paths`` only needs to cover this group's paths.
 
     The modified-time check (and the sidecar paths it stats) is only reached for
     a file we already have, on an incremental scan with a baseline — i.e. the
@@ -72,6 +81,37 @@ def _group_needs_processing(paths, existing_paths, full_scan, last_scan):
         ):
             return True
     return False
+
+
+def _select_groups_to_process(
+    group_items, known_paths_for, full_scan, last_scan, batch_size=_PATH_PREFETCH_BATCH
+):
+    """Pick the file groups that need processing, resolving known paths in batches.
+
+    ``group_items`` is ``list(file_groups.items())`` — (group_key, paths) pairs.
+    ``known_paths_for(batch_paths)`` returns the subset of those paths already in
+    the DB; the caller injects the actual query. Resolving known paths one batch
+    of groups at a time (instead of loading every known path up front) bounds
+    memory to a single batch — important on very large libraries in
+    constrained-RAM environments — while still replacing the old per-file
+    ``Photo...exists()`` round-trip with one query per ``batch_size`` groups.
+    Whole groups are always kept within a batch, so the per-batch known set
+    covers every path each group needs to check.
+    """
+    if full_scan or last_scan is None:
+        # Every group is processed regardless of what's already known, so the
+        # known-path lookup is never consulted — skip the DB queries entirely.
+        return list(group_items)
+
+    groups_to_process: list[tuple[tuple[str, str], list[str]]] = []
+    for start in range(0, len(group_items), batch_size):
+        batch = group_items[start : start + batch_size]
+        batch_paths = [path for _, paths in batch for path in paths]
+        known_paths = known_paths_for(batch_paths)
+        for group_key, paths in batch:
+            if _group_needs_processing(paths, known_paths, full_scan, last_scan):
+                groups_to_process.append((group_key, paths))
+    return groups_to_process
 
 
 def wait_for_group_and_process_metadata(
@@ -265,19 +305,27 @@ def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=None):
                 file_groups[group_key].append(path)
 
         # Determine which groups need processing.
-        # Load every known file path in ONE query so the per-file existence
-        # check below is an in-memory set lookup rather than a
-        # Photo...exists() round-trip per file (100k+ on a large library).
-        existing_paths = set(
-            Photo.objects.filter(files__path__isnull=False).values_list(
-                "files__path", flat=True
+        #
+        # The "do we already have this file?" test is answered from the DB in
+        # BATCHES rather than one query per file: for each batch of groups we
+        # fetch the known paths among that batch in a single ``files__path__in``
+        # query, decide the batch, then discard the set. This keeps the win of
+        # the original change (one round-trip per ~10k groups instead of a
+        # ``Photo...exists()`` per file — 30-35x faster scan start-up on a large
+        # library) while bounding memory to one batch. Loading every known path
+        # at once would be O(library) and, on top of the already-resident
+        # ``file_groups``, could spike RAM on very large collections in
+        # constrained-RAM environments (e.g. ~725 MB at 5M photos vs <2 MB here).
+        def known_paths_for(batch_paths):
+            return set(
+                Photo.objects.filter(files__path__in=batch_paths).values_list(
+                    "files__path", flat=True
+                )
             )
-        )
 
-        groups_to_process: list[tuple[tuple[str, str], list[str]]] = []
-        for group_key, paths in file_groups.items():
-            if _group_needs_processing(paths, existing_paths, full_scan, last_scan):
-                groups_to_process.append((group_key, paths))
+        groups_to_process = _select_groups_to_process(
+            list(file_groups.items()), known_paths_for, full_scan, last_scan
+        )
 
         # Progress target is number of groups (not individual files)
         # Each group = one Photo with potentially multiple file variants

--- a/apps/backend/api/tests/test_group_needs_processing.py
+++ b/apps/backend/api/tests/test_group_needs_processing.py
@@ -1,0 +1,68 @@
+"""Tests for ``scan_jobs._group_needs_processing``.
+
+This is the per-group decision used in scan Phase 1 to skip already-scanned
+photos. It was refactored to take a prebuilt set of known file paths (one query
+instead of a ``Photo...exists()`` per file) and to only run the modified-time
+check for files we already have on an incremental scan. These tests pin the
+decision semantics so the optimization can't quietly change behavior.
+"""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from api.directory_watcher.scan_jobs import _group_needs_processing
+
+
+class _FakeScan:
+    """Stand-in for a last_scan LongRunningJob — only finished_at is read."""
+
+    finished_at = "2026-01-01T00:00:00Z"
+
+
+MOD = "api.directory_watcher.scan_jobs._file_was_modified_after"
+
+
+class GroupNeedsProcessingTest(SimpleTestCase):
+    def test_new_file_not_in_existing_paths_is_processed(self):
+        self.assertTrue(
+            _group_needs_processing(["/p/a.jpg"], set(), False, _FakeScan())
+        )
+
+    def test_full_scan_always_processes(self):
+        self.assertTrue(
+            _group_needs_processing(["/p/a.jpg"], {"/p/a.jpg"}, True, _FakeScan())
+        )
+
+    def test_no_baseline_always_processes(self):
+        self.assertTrue(
+            _group_needs_processing(["/p/a.jpg"], {"/p/a.jpg"}, False, None)
+        )
+
+    @patch(MOD, return_value=False)
+    def test_known_unchanged_file_is_skipped(self, _mod):
+        self.assertFalse(
+            _group_needs_processing(["/p/a.jpg"], {"/p/a.jpg"}, False, _FakeScan())
+        )
+
+    @patch(MOD, return_value=True)
+    def test_known_but_modified_file_is_processed(self, _mod):
+        self.assertTrue(
+            _group_needs_processing(["/p/a.jpg"], {"/p/a.jpg"}, False, _FakeScan())
+        )
+
+    @patch(MOD, return_value=False)
+    def test_group_with_one_unknown_variant_is_processed(self, _mod):
+        # RAW+JPEG group where the JPEG is known but the RAW is new.
+        self.assertTrue(
+            _group_needs_processing(
+                ["/p/a.jpg", "/p/a.cr2"], {"/p/a.jpg"}, False, _FakeScan()
+            )
+        )
+
+    @patch(MOD, return_value=False)
+    def test_modified_check_not_called_for_unknown_file(self, mod):
+        # An unknown path short-circuits before the (expensive) mtime/sidecar
+        # stats — they must not run.
+        _group_needs_processing(["/p/new.jpg"], set(), False, _FakeScan())
+        mod.assert_not_called()

--- a/apps/backend/api/tests/test_group_needs_processing.py
+++ b/apps/backend/api/tests/test_group_needs_processing.py
@@ -11,7 +11,10 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
-from api.directory_watcher.scan_jobs import _group_needs_processing
+from api.directory_watcher.scan_jobs import (
+    _group_needs_processing,
+    _select_groups_to_process,
+)
 
 
 class _FakeScan:
@@ -66,3 +69,74 @@ class GroupNeedsProcessingTest(SimpleTestCase):
         # stats — they must not run.
         _group_needs_processing(["/p/new.jpg"], set(), False, _FakeScan())
         mod.assert_not_called()
+
+
+class SelectGroupsToProcessTest(SimpleTestCase):
+    """``_select_groups_to_process`` resolves known paths in batches (one query
+    per batch of groups) instead of loading every known path at once, bounding
+    memory on large libraries. These tests pin the batching behavior with an
+    injected lookup so no DB is needed."""
+
+    @patch(MOD, return_value=False)
+    def test_new_groups_kept_known_unchanged_dropped(self, _mod):
+        groups = [
+            (("d", "a"), ["/d/a.jpg"]),  # known + unchanged -> skip
+            (("d", "b"), ["/d/b.jpg"]),  # unknown -> process
+        ]
+        result = _select_groups_to_process(
+            groups, lambda paths: {"/d/a.jpg"}, False, _FakeScan()
+        )
+        self.assertEqual(result, [(("d", "b"), ["/d/b.jpg"])])
+
+    @patch(MOD, return_value=False)
+    def test_batching_matches_single_pass_across_boundary(self, _mod):
+        # 5 groups, batch_size=2 -> 3 batches; the result must be identical to
+        # deciding them all at once. Every odd group is unknown (processed).
+        groups = [((f"d{i}", "x"), [f"/d/{i}.jpg"]) for i in range(5)]
+        known = {"/d/0.jpg", "/d/2.jpg", "/d/4.jpg"}  # evens known+unchanged
+
+        calls = []
+
+        def lookup(batch_paths):
+            calls.append(len(batch_paths))
+            return known & set(batch_paths)
+
+        result = _select_groups_to_process(
+            groups, lookup, False, _FakeScan(), batch_size=2
+        )
+        # odds (1, 3) are unknown -> processed; evens skipped
+        self.assertEqual(
+            result,
+            [(("d1", "x"), ["/d/1.jpg"]), (("d3", "x"), ["/d/3.jpg"])],
+        )
+        # one lookup per batch: ceil(5/2) = 3
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls, [2, 2, 1])
+
+    @patch(MOD, return_value=False)
+    def test_empty_input_makes_no_queries(self, _mod):
+        calls = []
+        result = _select_groups_to_process(
+            [], lambda paths: calls.append(1) or set(), False, _FakeScan()
+        )
+        self.assertEqual(result, [])
+        self.assertEqual(calls, [])
+
+    def test_full_scan_processes_all_without_querying(self):
+        # On a full scan every group is processed, so no known-path lookup runs.
+        groups = [(("d", "a"), ["/d/a.jpg"]), (("d", "b"), ["/d/b.jpg"])]
+        calls = []
+        result = _select_groups_to_process(
+            groups, lambda paths: calls.append(1) or set(), True, _FakeScan()
+        )
+        self.assertEqual(result, groups)
+        self.assertEqual(calls, [])
+
+    def test_no_baseline_processes_all_without_querying(self):
+        groups = [(("d", "a"), ["/d/a.jpg"])]
+        calls = []
+        result = _select_groups_to_process(
+            groups, lambda paths: calls.append(1) or set(), False, None
+        )
+        self.assertEqual(result, groups)
+        self.assertEqual(calls, [])


### PR DESCRIPTION
Before deciding which photos to (re)process, a scan walks the library and, for each file, runs `Photo.objects.filter(files__path=path).exists()` to check whether that file is already known (`api/directory_watcher/scan_jobs.py`, Phase 1). That is one database round-trip per file. On a large library it dominates scan start-up: on a ~155k-photo library this phase took about 23 minutes before the first photo was even queued — the job sits in "waiting" with no progress, because these per-file existence checks (plus the directory walk) run before the progress target is set.

This replaces the per-file existence check with one query per **batch** of file groups: the groups are processed in batches (10k by default), and for each batch a single `files__path__in` query fetches which of that batch's paths are already known. The per-group decision is factored into a small helper, `_group_needs_processing`, that preserves the original semantics exactly: a group is processed if any of its files is new, or it is a full scan, or there is no previous scan, or a file/sidecar was modified since the last scan. The modified-time check (and the sidecar paths it stats) only runs for files we already have on an incremental scan — the only case where "did it change since last time?" is the deciding question — and uses a short-circuiting generator instead of building the whole list, so it stops at the first changed file. As an extra saving over the per-file version, a full scan (or a scan with no baseline) now skips the known-path lookup entirely, since every group is processed regardless.

The batching is deliberate. An earlier revision of this change loaded *every* known path into one set up front; @derneuere rightly flagged that as a possible RAM spike on very large libraries in constrained-RAM environments. Benchmarking on a real 230k-path distribution (extrapolated to 1M/5M) confirmed the concern at the top end — a single full set is ~35 MB at 230k but ~151 MB at 1M and ~725 MB at 5M, and it sits on top of the already-resident `file_groups` map, roughly doubling it. Loading in fixed-size batches and discarding each one keeps the transient set under ~2 MB regardless of library size, while still collapsing ~N per-file round-trips into N/10000 queries (measured ~30–35× faster than the per-file checks at 230k; the full-set and batched variants are both far faster than the old code, and the few seconds between them are negligible against an hours-long scan). One subtlety worth recording: simply fetching 1000 rows at a time into an *accumulating* set does not help — the final set is the same size; only deciding each batch and discarding it bounds memory.

The batch loop is factored into `_select_groups_to_process(group_items, known_paths_for, ...)` with the actual query injected, so it is unit-testable without a database. `test_group_needs_processing.py` pins both the per-group decision (new file, full scan, missing baseline, known-unchanged skipped, known-but-modified, a group with one unknown variant, modified-time check not run for an unknown file) and the batching behaviour (known-unchanged dropped while unknown kept, identical results across a batch boundary, and that full-scan / no-baseline short-circuit without querying).

A smaller follow-up remains: on an incremental scan the per-file `os.path.getmtime` checks (the file plus its sidecar-name candidates) still run for every known file; capturing modification times during the directory walk would remove that too. Kept out of this change to keep it focused and behaviour-preserving.
