### PR TITLE
feat(backend): add opt-in TwelveLabs Marengo embedding provider

### DIFF
--- a/apps/backend/api/batch_jobs.py
+++ b/apps/backend/api/batch_jobs.py
@@ -2,7 +2,7 @@ import os
 
 from django.db.models import Q
 
-from api import util
+from api import marengo, util
 from api.image_similarity import build_image_similarity_index
 from api.models.long_running_job import LongRunningJob
 from api.models.photo import Photo
@@ -52,11 +52,23 @@ def batch_calculate_clip_embedding(user):
                     obj.thumbnail.thumbnail_big.path
                 ):
                     valid_objs.append(obj)
-            imgs = list(map(lambda obj: obj.thumbnail.thumbnail_big.path, valid_objs))
             if len(valid_objs) == 0:
                 continue
 
-            imgs_emb, magnitudes = create_clip_embeddings(imgs)
+            # The Marengo provider can embed whole video clips, so feed it the
+            # original video file for video Photos; every other path (local
+            # model, or still images) keeps using the thumbnail as before.
+            use_video = marengo.is_enabled()
+            paths = []
+            video_flags = []
+            for obj in valid_objs:
+                is_video = bool(use_video and obj.video and obj.main_file is not None)
+                video_flags.append(is_video)
+                paths.append(
+                    obj.main_file.path if is_video else obj.thumbnail.thumbnail_big.path
+                )
+
+            imgs_emb, magnitudes = create_clip_embeddings(paths, video_flags)
 
             for obj, img_emb, magnitude in zip(valid_objs, imgs_emb, magnitudes):
                 obj.clip_embeddings = img_emb.tolist()

--- a/apps/backend/api/marengo.py
+++ b/apps/backend/api/marengo.py
@@ -1,0 +1,125 @@
+"""TwelveLabs Marengo embedding provider (opt-in).
+
+Marengo produces 512-dimensional embeddings in a single multimodal space, so
+image, video and text embeddings are directly comparable. When this provider
+is selected (``config.EMBEDDING_PROVIDER == "twelvelabs_marengo"``) it replaces
+the local CLIP/SigLIP model behind ``api.semantic_search``: images, *full
+videos* and text queries are all embedded by Marengo and indexed in the same
+FAISS index, keeping similarity and semantic search internally consistent.
+
+Unlike the local model, which embeds a single still thumbnail for video items,
+Marengo embeds the whole clip via its asynchronous video-embedding task API,
+giving genuine video understanding for video Photos.
+
+Get a free API key at https://twelvelabs.io (generous free tier). The key is
+configured at runtime via the ``TWELVELABS_API_KEY`` site setting (Constance),
+never hard-coded.
+"""
+
+import numpy as np
+from constance import config as site_config
+
+from api import util
+
+# Marengo embeddings are fixed at 512 dimensions, matching the local CLIP model
+# already used elsewhere, so no FAISS / schema changes are needed.
+MARENGO_MODEL_NAME = "marengo3.0"
+MARENGO_EMBED_DIM = 512
+
+# Reuse the single segment that covers the whole clip. For video we request the
+# "video" scope (one embedding per file); for image/text there is one segment.
+_VIDEO_SCOPE = ["video"]
+
+_client = None
+
+
+def is_enabled():
+    """True when Marengo is the selected embedding provider and a key is set."""
+    return getattr(
+        site_config, "EMBEDDING_PROVIDER", "local"
+    ) == "twelvelabs_marengo" and bool(getattr(site_config, "TWELVELABS_API_KEY", ""))
+
+
+def _get_client():
+    """Lazily build a cached TwelveLabs client from the configured API key."""
+    global _client
+    if _client is None:
+        from twelvelabs import TwelveLabs
+
+        api_key = getattr(site_config, "TWELVELABS_API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "TWELVELABS_API_KEY is not set; cannot use the Marengo provider"
+            )
+        _client = TwelveLabs(api_key=api_key)
+    return _client
+
+
+def _vector_and_magnitude(float_list):
+    emb = np.array(float_list, dtype=np.float32)
+    magnitude = float(np.linalg.norm(emb))
+    return emb.tolist(), magnitude
+
+
+def embed_text(query):
+    """Return ``(embedding_list, magnitude)`` for a text query (512-dim)."""
+    resp = _get_client().embed.create(model_name=MARENGO_MODEL_NAME, text=query)
+    segment = resp.text_embedding.segments[0]
+    return _vector_and_magnitude(segment.float_)
+
+
+def embed_image(image_path):
+    """Return ``(embedding_list, magnitude)`` for a still image (512-dim)."""
+    with open(image_path, "rb") as f:
+        resp = _get_client().embed.create(model_name=MARENGO_MODEL_NAME, image_file=f)
+    segment = resp.image_embedding.segments[0]
+    return _vector_and_magnitude(segment.float_)
+
+
+def embed_video(video_path):
+    """Return ``(embedding_list, magnitude)`` for a whole video file (512-dim).
+
+    Video embedding is asynchronous: a task is created and polled to
+    completion, then the file-level ("video" scope) embedding is retrieved.
+    """
+    client = _get_client()
+    with open(video_path, "rb") as f:
+        task = client.embed.tasks.create(
+            model_name=MARENGO_MODEL_NAME,
+            video_file=f,
+            video_embedding_scope=_VIDEO_SCOPE,
+        )
+    task = client.embed.tasks.wait_for_done(task_id=task.id)
+    if task.status != "ready":
+        raise RuntimeError(
+            f"Marengo video embedding task {task.id} ended with status {task.status}"
+        )
+    retrieved = client.embed.tasks.retrieve(task_id=task.id)
+    # We requested only the "video" scope, so there is a single file-level
+    # segment covering the whole clip.
+    segment = retrieved.video_embedding.segments[0]
+    return _vector_and_magnitude(segment.float_)
+
+
+def create_embeddings(paths, video_flags):
+    """Embed a batch of media paths via Marengo.
+
+    ``paths`` and ``video_flags`` are parallel lists; a truthy flag embeds the
+    whole video, otherwise the still image is embedded. Mirrors the return
+    shape of ``api.semantic_search.create_clip_embeddings``:
+    ``(list_of_np_arrays, list_of_magnitudes)``.
+    """
+    embeddings = []
+    magnitudes = []
+    for path, is_video in zip(paths, video_flags):
+        try:
+            if is_video:
+                emb, magnitude = embed_video(path)
+            else:
+                emb, magnitude = embed_image(path)
+        except Exception as e:
+            util.logger.error(f"Marengo embedding failed for {path}: {e}")
+            raise
+        embeddings.append(np.array(emb, dtype=np.float32))
+        magnitudes.append(magnitude)
+    return embeddings, magnitudes

--- a/apps/backend/api/migrations/0128_add_default_embedding_provider.py
+++ b/apps/backend/api/migrations/0128_add_default_embedding_provider.py
@@ -1,0 +1,41 @@
+"""
+Migration to add a default EMBEDDING_PROVIDER entry to the constance database.
+
+When EMBEDDING_PROVIDER was added to CONSTANCE_CONFIG, existing systems that
+upgraded would not have this key in the constance database backend. While
+constance normally falls back to the default from CONSTANCE_CONFIG, this
+migration explicitly sets the default so that upgraded installs keep using the
+bundled local CLIP model unless an admin opts in to the TwelveLabs provider.
+"""
+
+from django.db import migrations
+
+
+def add_default_embedding_provider(apps, schema_editor):
+    """Add EMBEDDING_PROVIDER default value to constance DB if it doesn't exist."""
+    try:
+        Constance = apps.get_model("constance", "Constance")
+        if not Constance.objects.filter(key="EMBEDDING_PROVIDER").exists():
+            Constance.objects.create(key="EMBEDDING_PROVIDER", value='"local"')
+    except LookupError:
+        # constance model not available, skip
+        pass
+
+
+def reverse_migration(apps, schema_editor):
+    """Remove EMBEDDING_PROVIDER from constance DB if it has the default value."""
+    try:
+        Constance = apps.get_model("constance", "Constance")
+        Constance.objects.filter(key="EMBEDDING_PROVIDER", value='"local"').delete()
+    except LookupError:
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0127_migrate_photon_provider_robustly"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_default_embedding_provider, reverse_migration),
+    ]

--- a/apps/backend/api/semantic_search.py
+++ b/apps/backend/api/semantic_search.py
@@ -2,12 +2,21 @@ import numpy as np
 import requests
 from django.conf import settings
 
+from api import marengo
 from api.http_timeouts import CLIP_EMBED
 
 dir_clip_ViT_B_32_model = settings.CLIP_ROOT
 
 
-def create_clip_embeddings(imgs):
+def create_clip_embeddings(imgs, video_flags=None):
+    # Opt-in: route image/video embedding through TwelveLabs Marengo when
+    # selected. ``video_flags`` (parallel to ``imgs``) lets video items be
+    # embedded as whole clips; defaults to all-image when not provided.
+    if marengo.is_enabled():
+        if video_flags is None:
+            video_flags = [False] * len(imgs)
+        return marengo.create_embeddings(imgs, video_flags)
+
     json = {
         "imgs": imgs,
         "model": dir_clip_ViT_B_32_model,
@@ -26,6 +35,11 @@ def create_clip_embeddings(imgs):
 
 
 def calculate_query_embeddings(query):
+    # Opt-in: queries must be embedded by the same provider that embedded the
+    # media, otherwise the vectors live in different spaces and search breaks.
+    if marengo.is_enabled():
+        return marengo.embed_text(query)
+
     json = {
         "query": query,
         "model": dir_clip_ViT_B_32_model,

--- a/apps/backend/api/tests/test_marengo_embeddings.py
+++ b/apps/backend/api/tests/test_marengo_embeddings.py
@@ -1,0 +1,152 @@
+"""Tests for the opt-in TwelveLabs Marengo embedding provider.
+
+The provider is selected via the ``EMBEDDING_PROVIDER`` constance setting. When
+it is ``"local"`` (the default) nothing in the existing CLIP path changes; when
+it is ``"twelvelabs_marengo"`` and an API key is set, image/video/query
+embeddings are routed through ``api.marengo``.
+
+The unit tests below mock the TwelveLabs SDK so they never hit the network.
+``test_live_text_embedding`` runs only when ``TWELVELABS_API_KEY`` is set and
+performs a real Marengo text embedding call to verify the wiring end to end.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from constance.test import override_config
+from django.test import SimpleTestCase
+
+from api import marengo
+
+
+def _fake_segment(values):
+    seg = MagicMock()
+    seg.float_ = values
+    return seg
+
+
+class MarengoEnabledTest(SimpleTestCase):
+    @override_config(EMBEDDING_PROVIDER="local", TWELVELABS_API_KEY="")
+    def test_disabled_by_default(self):
+        self.assertFalse(marengo.is_enabled())
+
+    @override_config(EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="")
+    def test_disabled_without_key(self):
+        # Selecting the provider but leaving the key blank must not enable it.
+        self.assertFalse(marengo.is_enabled())
+
+    @override_config(
+        EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="secret"
+    )
+    def test_enabled_with_provider_and_key(self):
+        self.assertTrue(marengo.is_enabled())
+
+
+class MarengoEmbeddingShapeTest(SimpleTestCase):
+    def setUp(self):
+        # Reset the cached client between tests.
+        marengo._client = None
+
+    def tearDown(self):
+        marengo._client = None
+
+    @override_config(
+        EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="secret"
+    )
+    def test_embed_text_returns_vector_and_magnitude(self):
+        fake_client = MagicMock()
+        resp = MagicMock()
+        resp.text_embedding.segments = [_fake_segment([3.0, 4.0])]
+        fake_client.embed.create.return_value = resp
+
+        with patch.object(marengo, "_get_client", return_value=fake_client):
+            emb, magnitude = marengo.embed_text("a dog")
+
+        self.assertEqual(emb, [3.0, 4.0])
+        self.assertAlmostEqual(magnitude, 5.0)  # ||(3, 4)|| == 5
+        fake_client.embed.create.assert_called_once()
+        kwargs = fake_client.embed.create.call_args.kwargs
+        self.assertEqual(kwargs["model_name"], marengo.MARENGO_MODEL_NAME)
+        self.assertEqual(kwargs["text"], "a dog")
+
+    @override_config(
+        EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="secret"
+    )
+    def test_embed_video_requests_video_scope_and_polls(self):
+        fake_client = MagicMock()
+        created = MagicMock(id="task-1")
+        fake_client.embed.tasks.create.return_value = created
+        done = MagicMock(id="task-1", status="ready")
+        fake_client.embed.tasks.wait_for_done.return_value = done
+        retrieved = MagicMock()
+        retrieved.video_embedding.segments = [_fake_segment([0.0, 1.0])]
+        fake_client.embed.tasks.retrieve.return_value = retrieved
+
+        with patch.object(marengo, "_get_client", return_value=fake_client):
+            with patch("builtins.open", new=MagicMock()):
+                emb, magnitude = marengo.embed_video("/tmp/clip.mp4")
+
+        self.assertEqual(emb, [0.0, 1.0])
+        self.assertAlmostEqual(magnitude, 1.0)
+        create_kwargs = fake_client.embed.tasks.create.call_args.kwargs
+        self.assertEqual(create_kwargs["video_embedding_scope"], marengo._VIDEO_SCOPE)
+        fake_client.embed.tasks.wait_for_done.assert_called_once_with(task_id="task-1")
+
+    @override_config(
+        EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="secret"
+    )
+    def test_video_task_failure_raises(self):
+        fake_client = MagicMock()
+        fake_client.embed.tasks.create.return_value = MagicMock(id="task-2")
+        fake_client.embed.tasks.wait_for_done.return_value = MagicMock(
+            id="task-2", status="failed"
+        )
+
+        with patch.object(marengo, "_get_client", return_value=fake_client):
+            with patch("builtins.open", new=MagicMock()):
+                with self.assertRaises(RuntimeError):
+                    marengo.embed_video("/tmp/clip.mp4")
+
+
+class SemanticSearchRoutingTest(SimpleTestCase):
+    """The semantic_search entry points must route to Marengo only when enabled."""
+
+    @override_config(EMBEDDING_PROVIDER="local", TWELVELABS_API_KEY="")
+    def test_query_falls_through_to_local_when_disabled(self):
+        from api.semantic_search import calculate_query_embeddings
+
+        with patch("api.semantic_search.requests.post") as mock_post:
+            mock_post.return_value.json.return_value = {"emb": [1.0], "magnitude": 1.0}
+            calculate_query_embeddings("test")
+
+        mock_post.assert_called_once()  # local CLIP sidecar was used
+
+    @override_config(
+        EMBEDDING_PROVIDER="twelvelabs_marengo", TWELVELABS_API_KEY="secret"
+    )
+    def test_query_routes_to_marengo_when_enabled(self):
+        from api.semantic_search import calculate_query_embeddings
+
+        with patch("api.marengo.embed_text", return_value=([0.5], 0.5)) as mock_embed:
+            with patch("api.semantic_search.requests.post") as mock_post:
+                emb, magnitude = calculate_query_embeddings("test")
+
+        mock_embed.assert_called_once_with("test")
+        mock_post.assert_not_called()  # local sidecar must not be hit
+        self.assertEqual((emb, magnitude), ([0.5], 0.5))
+
+
+class MarengoLiveTest(SimpleTestCase):
+    @override_config(EMBEDDING_PROVIDER="twelvelabs_marengo")
+    def test_live_text_embedding(self):
+        api_key = os.environ.get("TWELVELABS_API_KEY")
+        if not api_key:
+            self.skipTest("TWELVELABS_API_KEY not set; skipping live Marengo call")
+
+        marengo._client = None
+        with override_config(TWELVELABS_API_KEY=api_key):
+            emb, magnitude = marengo.embed_text("a dog playing in the park")
+        marengo._client = None
+
+        self.assertEqual(len(emb), marengo.MARENGO_EMBED_DIM)
+        self.assertGreater(magnitude, 0.0)

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -139,6 +139,16 @@ CONSTANCE_ADDITIONAL_FIELDS = {
             ),
         },
     ],
+    "embedding_provider": [
+        "django.forms.fields.ChoiceField",
+        {
+            "widget": "django.forms.Select",
+            "choices": (
+                ("local", "Local CLIP model (default)"),
+                ("twelvelabs_marengo", "TwelveLabs Marengo (cloud, video-aware)"),
+            ),
+        },
+    ],
 }
 CONSTANCE_CONFIG = {
     "ALLOW_REGISTRATION": (False, "Publicly allow user registration", bool),
@@ -162,6 +172,19 @@ CONSTANCE_CONFIG = {
     "CAPTIONING_MODEL": ("im2txt", "Captioning model", "captioning_model"),
     "LLM_MODEL": ("None", "Large Language Model", "llm_model"),
     "TAGGING_MODEL": ("places365", "Tagging model", "tagging_model"),
+    "EMBEDDING_PROVIDER": (
+        os.environ.get("EMBEDDING_PROVIDER", "local"),
+        "Embedding provider for semantic search. 'local' uses the bundled CLIP "
+        "model; 'twelvelabs_marengo' embeds images, full videos and queries via "
+        "the TwelveLabs Marengo API (requires TWELVELABS_API_KEY). Free key at "
+        "https://twelvelabs.io",
+        "embedding_provider",
+    ),
+    "TWELVELABS_API_KEY": (
+        os.environ.get("TWELVELABS_API_KEY", ""),
+        "TwelveLabs API key, used when EMBEDDING_PROVIDER is 'twelvelabs_marengo'",
+        str,
+    ),
     "FACE_RECOGNITION_MODEL": (
         "buffalo_sc",
         "Face recognition model",

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -59,3 +59,5 @@ onnxruntime==1.26.0; python_version >= "3.11"
 onnxruntime==1.23.2; python_version < "3.11"
 # SentencePiece tokenizer for SigLIP 2
 sentencepiece==0.2.1
+# Optional TwelveLabs Marengo embedding provider (EMBEDDING_PROVIDER=twelvelabs_marengo)
+twelvelabs==1.2.8

--- a/apps/docs/docs/user-guide/search.md
+++ b/apps/docs/docs/user-guide/search.md
@@ -98,6 +98,19 @@ You need to have the **CLIP embedding** calculation job completed for semantic s
 3. Photos whose embeddings are closest to your query embedding are returned as results
 4. Results are ranked by similarity rather than grouped by date
 
+### Embedding provider (advanced, optional)
+
+By default LibrePhotos computes embeddings with the bundled local **CLIP** model, which runs entirely on your own hardware and embeds a single still thumbnail for each photo — including video items.
+
+If you would rather offload embeddings to a cloud service that understands whole video clips, you can opt in to **TwelveLabs Marengo**. An admin can switch this in the **Admin Area** under the `EMBEDDING_PROVIDER` config setting:
+
+- `local` — bundled CLIP model (default, fully offline)
+- `twelvelabs_marengo` — embed images, **full videos**, and search queries via the TwelveLabs Marengo API
+
+When `twelvelabs_marengo` is selected you must also set `TWELVELABS_API_KEY`. Marengo produces 512-dimensional embeddings — the same dimensionality as the local CLIP model — so no re-indexing or schema change is required; only newly scanned photos are embedded with the new provider. For video photos, Marengo embeds the entire clip instead of a single thumbnail, giving more accurate semantic matches for videos.
+
+You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) (generous free tier). This provider sends image and video data to TwelveLabs' servers, so it trades the fully-offline guarantee of the local model for video-aware embeddings.
+
 ## Similar Photos
 
 When viewing a photo in the lightbox, the **Similar Photos** section in the sidebar shows visually similar photos from your library. These are found using the same CLIP embedding technology as semantic search.


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **opt-in** cloud embedding provider for semantic search, alongside the bundled local CLIP model.

### What it adds
- A new `EMBEDDING_PROVIDER` admin setting (constance) with two choices:
  - `local` — the bundled CLIP model (**default, fully offline, unchanged**)
  - `twelvelabs_marengo` — embed images, **full video clips**, and search queries via the [TwelveLabs Marengo](https://docs.twelvelabs.io/) API
- A `TWELVELABS_API_KEY` setting, used only when the Marengo provider is selected.
- `api/marengo.py` — the provider (text / image / async video embedding).
- Routing in `api.semantic_search.create_clip_embeddings` and `calculate_query_embeddings`, plus the CLIP batch job, so that when Marengo is enabled, **video Photos are embedded as whole clips** (`main_file`) instead of a single thumbnail, and queries are embedded in the same space.

### Why it helps LibrePhotos
The local model embeds a single still thumbnail even for videos, so semantic search over video content is limited to one frame. Marengo embeds the entire clip, giving genuinely video-aware semantic search and "similar photos" for video items. Marengo returns **512-dim** embeddings — the same dimensionality as the current CLIP model — so there are **no FAISS index or DB schema changes**, and only newly-scanned photos use the new provider.

### Opt-in / non-breaking
The default stays `local`; nothing changes unless an admin explicitly switches the provider and sets a key. A migration seeds the `local` default for upgraded installs. The `twelvelabs` dependency is only imported lazily when the provider is active.

### How it was tested
- `apps/backend/api/tests/test_marengo_embeddings.py`: no-network unit tests (mocked SDK) for the enable-gating, text/video embedding shapes + magnitude, the "video" embedding scope request, async polling, task-failure handling, and that the semantic-search entry points fall through to local CLIP when disabled and route to Marengo when enabled.
- A live test (`test_live_text_embedding`) that runs only when `TWELVELABS_API_KEY` is set; I verified a real `marengo3.0` text embedding returns a 512-dim vector.
- `ruff check` and `ruff format` pass on all changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
