### PR TITLE
backend: coerce numeric exif tag values to str in date-time extractor

### DIFF
--- a/apps/backend/api/date_time_extractor.py
+++ b/apps/backend/api/date_time_extractor.py
@@ -62,7 +62,10 @@ REGEXP_GROUP_MAPPINGS = {
 
 
 def _extract_no_tz_datetime_from_str(x, regexp=REGEXP_NO_TZ, group_mapping=None):
-    match = re.search(regexp, x)
+    # exiftool can hand back non-string tag values (e.g. a numeric Rating or
+    # ISO), so coerce before matching - otherwise re.search raises TypeError,
+    # which is not the ValueError handled below.
+    match = re.search(regexp, str(x))
     if not match:
         return None
     g = match.groups()
@@ -274,7 +277,8 @@ class TimeExtractionRule:
             tag_value = exif_tags.get(tag)
             if not tag_value:
                 return False
-            return re.search(pattern, tag_value) is not None
+            # tag_value may be numeric (see _extract_no_tz_datetime_from_str).
+            return re.search(pattern, str(tag_value)) is not None
         else:
             return True
 

--- a/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
+++ b/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
@@ -1,0 +1,77 @@
+import datetime
+
+from django.test import TestCase
+
+from api.date_time_extractor import (
+    TimeExtractionRule,
+    _extract_no_tz_datetime_from_str,
+    as_rules,
+    extract_local_date_time,
+)
+
+
+class NumericTagValueTest(TestCase):
+    """exiftool returns some tags (Rating, ISO, image dimensions, ...) as JSON
+    numbers rather than strings. Those values flow into the date-time extractor
+    via user-defined EXIF rules and condition_exif checks, where they used to
+    reach re.search() directly and raise an uncaught TypeError. The extractor
+    must coerce them to str instead.
+    """
+
+    def test_extract_numeric_non_date_returns_none(self):
+        # Would raise TypeError before the fix; a rating of 5 is not a date.
+        self.assertIsNone(_extract_no_tz_datetime_from_str(5))
+        self.assertIsNone(_extract_no_tz_datetime_from_str(3.5))
+
+    def test_extract_numeric_dateish_still_parses(self):
+        # str() coercion keeps a numeric value that does encode a date working.
+        self.assertEqual(
+            _extract_no_tz_datetime_from_str(20200101120000),
+            datetime.datetime(2020, 1, 1, 12, 0, 0),
+        )
+
+    def test_extract_string_value_unchanged(self):
+        self.assertEqual(
+            _extract_no_tz_datetime_from_str("2020:01:01 12:00:00"),
+            datetime.datetime(2020, 1, 1, 12, 0, 0),
+        )
+
+    def test_condition_exif_numeric_value_matches(self):
+        rule = TimeExtractionRule(
+            {
+                "rule_type": "exif",
+                "exif_tag": "EXIF:DateTimeOriginal",
+                "condition_exif": "EXIF:Rating//5",
+            }
+        )
+        # tag_value is the int 5; would raise TypeError before the fix.
+        self.assertTrue(rule._check_condition_exif({"EXIF:Rating": 5}))
+
+    def test_condition_exif_numeric_value_no_match(self):
+        rule = TimeExtractionRule(
+            {
+                "rule_type": "exif",
+                "exif_tag": "EXIF:DateTimeOriginal",
+                "condition_exif": "EXIF:Rating//9",
+            }
+        )
+        self.assertFalse(rule._check_condition_exif({"EXIF:Rating": 5}))
+
+    def test_extract_local_date_time_numeric_exif_does_not_crash(self):
+        # Full path: an EXIF rule whose tag resolves to a number must not crash
+        # the whole extraction; it simply yields no datetime and falls through.
+        rules = as_rules([{"rule_type": "exif", "exif_tag": "EXIF:Rating"}])
+
+        def exif_getter(tags):
+            return [5 for _ in tags]
+
+        result = extract_local_date_time(
+            path="/photos/IMG_0001.jpg",
+            rules=rules,
+            exif_getter=exif_getter,
+            gps_lat=None,
+            gps_lon=None,
+            user_default_tz="UTC",
+            user_defined_timestamp=None,
+        )
+        self.assertIsNone(result)


### PR DESCRIPTION
exiftool returns several common tags as JSON numbers rather than strings — `Rating`, `ISO`, image dimensions, GPS components and others come back as `int`/`float`, and that native type survives the JSON round-trip from the exif microservice into `get_metadata`. The date-time extractor then fed those values straight into `re.search` in two places, both reachable through user-defined datetime rules.

The first is `_extract_no_tz_datetime_from_str`, which every EXIF rule reaches via `_get_no_tz_dt_from_tag`. Its `re.search(regexp, x)` call sits *outside* the surrounding `try/except`, and that handler only catches `ValueError` — so a numeric tag value raised an uncaught `TypeError: expected string or bytes-like object` and aborted date-time extraction for the photo. The second is `_check_condition_exif`: any rule carrying a `condition_exif` that points at a numeric tag hit the same crash before the pattern could be matched.

The fix is to coerce the value with `str()` before matching at both sites. Numeric values that happen to encode a date (e.g. `20200101120000`) still parse exactly as before, numeric non-dates simply produce no match and the rule falls through, and string inputs are completely unaffected — `str()` of a string is itself. There is no behavioural change for any library that wasn't already crashing, so this is net-neutral at every size.

The new `test_date_time_extractor_numeric_tags` module covers both choke points plus the full `extract_local_date_time` path with a numeric-returning exif getter. All five numeric cases raise `TypeError` against the unpatched extractor and pass with the fix; the string case passes on both.
