### PR TITLE
backend: port the exif service to the PyExifTool 0.5.x API

### DIFF
--- a/apps/backend/api/tests/test_iptc_integration.py
+++ b/apps/backend/api/tests/test_iptc_integration.py
@@ -28,6 +28,7 @@ from api.models.photo_metadata import PhotoMetadata
 from api.models.photo_search import PhotoSearch
 from api.models.thumbnail import Thumbnail
 from api.tests.utils import create_test_user
+from service.exif.main import _value_for_tag
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 IPTC_TEST_IMAGE = os.path.join(FIXTURES_DIR, "iptc_test.jpg")
@@ -44,8 +45,9 @@ def _read_tags_with_exiftool(file_path, tags):
     Returns a list of values, one per tag (``None`` when not found).
     Uses a context manager so the exiftool process is always cleaned up.
     """
-    with exiftool.ExifTool() as et:
-        return [et.get_tag(tag, file_path) for tag in tags]
+    with exiftool.ExifToolHelper() as et:
+        result = (et.get_tags([file_path], tags) or [{}])[0]
+    return [_value_for_tag(tag, result) for tag in tags]
 
 
 def _exiftool_get_metadata(media_file, tags, try_sidecar=True, struct=False):
@@ -58,15 +60,18 @@ def _exiftool_get_metadata(media_file, tags, try_sidecar=True, struct=False):
 
     files = _get_existing_metadata_files_reversed(media_file, try_sidecar)
 
-    with exiftool.ExifTool() as et:
-        values = []
-        for tag in tags:
-            value = None
-            for f in files:
-                retrieved = et.get_tag(tag, f)
-                if retrieved is not None:
-                    value = retrieved
-            values.append(value)
+    helper_args = {"common_args": ["-struct"]} if struct else {}
+    with exiftool.ExifToolHelper(**helper_args) as et:
+        results = {f: (et.get_tags([f], tags) or [{}])[0] for f in files}
+
+    values = []
+    for tag in tags:
+        value = None
+        for f in files:
+            retrieved = _value_for_tag(tag, results[f])
+            if retrieved is not None:
+                value = retrieved
+        values.append(value)
 
     return values
 

--- a/apps/backend/service/exif/main.py
+++ b/apps/backend/service/exif/main.py
@@ -3,14 +3,36 @@ import gevent
 from flask import Flask, request
 from gevent.pywsgi import WSGIServer
 
-static_et = exiftool.ExifTool()
-static_struct_et = exiftool.ExifTool(common_args=["-struct"])
+# PyExifTool 0.5.x replaced the ExifTool.start()/get_tag() API used here with
+# ExifToolHelper.get_tags(). ExifToolHelper's default common_args (-G -n) match
+# the group-qualified, numeric output the rest of the backend already expects.
+static_et = exiftool.ExifToolHelper()
+static_struct_et = exiftool.ExifToolHelper(common_args=["-struct"])
 
 app = Flask(__name__)
 
 
 def log(message):
     print(f"exif: {message}")
+
+
+def _value_for_tag(tag, tags_by_key):
+    """Pick *tag*'s value out of a single file's get_tags() result.
+
+    exiftool returns keys either group-qualified (e.g. ``EXIF:DateTimeOriginal``
+    with the default ``-G``) or bare (``DateTimeOriginal`` for the ``-struct``
+    instance, which drops ``-G``), so fall back from an exact match to the bare
+    tag name. Returns ``None`` when the tag is absent.
+    """
+    if tag in tags_by_key:
+        return tags_by_key[tag]
+    bare = tag.rsplit(":", 1)[-1]
+    if bare in tags_by_key:
+        return tags_by_key[bare]
+    for key, value in tags_by_key.items():
+        if key != "SourceFile" and key.rsplit(":", 1)[-1] == bare:
+            return value
+    return None
 
 
 @app.route("/get-tags", methods=["POST"])
@@ -23,20 +45,28 @@ def get_tags():
     except Exception:
         return "", 400
 
-    et = None
-    if struct:
-        et = static_struct_et
-    else:
-        et = static_et
+    et = static_struct_et if struct else static_et
     if not et.running:
-        et.start()
+        et.run()
 
     values = []
     try:
+        # Read every requested tag from each file once. Files are ordered by
+        # reverse priority, so the last file that yields a value for a tag wins
+        # - preserving the previous get_tag()-per-file behaviour.
+        results_by_file = {}
+        for file in files_by_reverse_priority:
+            try:
+                result = et.get_tags([file], tags)
+                results_by_file[file] = result[0] if result else {}
+            except Exception:
+                log(f"An error occurred reading tags from {file}")
+                results_by_file[file] = {}
+
         for tag in tags:
             value = None
             for file in files_by_reverse_priority:
-                retrieved_value = et.get_tag(tag, file)
+                retrieved_value = _value_for_tag(tag, results_by_file.get(file, {}))
                 if retrieved_value is not None:
                     value = retrieved_value
             values.append(value)


### PR DESCRIPTION
The exif sidecar (`service/exif/main.py`) is still written against the PyExifTool 0.4.x API — `ExifTool.running`, `ExifTool.start()` and `ExifTool.get_tag()` — but `#1818` bumped the pin to `PyExifTool==0.5.6`, where that surface was removed. In 0.5.x `ExifTool` has no `start()` or `get_tag()`; tag reads moved to `ExifToolHelper.get_tags()`. As a result every `POST /get-tags` raises an uncaught `AttributeError` and returns HTTP 500, so `api.metadata.reader.get_metadata` gets a non-JSON body back and raises `requests.exceptions.JSONDecodeError`.

The practical impact is that on any backend image built since that dependency bump, **all metadata extraction fails** — timestamps, GPS, image dimensions, IPTC/XMP keywords. Photos still import, but with no dates and no location, and enrichment jobs that read metadata degrade or fail. I found this while standing up a fresh dev stack: every imported photo had `exif_timestamp = None`, and the service returned `500` for every file even though `exiftool` on the command line read the same files fine.

The fix switches both the default and the `-struct` instance to `ExifToolHelper` and reads through `get_tags()`. `ExifToolHelper` defaults to `common_args = ["-G", "-n"]`, which is the same group-qualified, numeric output the previous bare `ExifTool()` produced, so values are unchanged — e.g. `ISO`/`Rating` still come back as numbers, dates as strings. A small `_value_for_tag` helper resolves each requested tag from a file's result dict, handling both the group-qualified keys (`EXIF:DateTimeOriginal`) the default emits and the bare keys (`DateTimeOriginal`) the `-struct` instance returns. The existing per-file "last non-None value wins" priority order across `files_by_reverse_priority` is preserved.

`api/tests/test_iptc_integration.py` hit the identical break: its in-process helpers deliberately mirror the service and also called `get_tag()`, so the whole integration test was erroring with the same `AttributeError`. They're updated to the same `ExifToolHelper.get_tags()` path and now reuse the service's `_value_for_tag`, so the test passes again and actually exercises the fixed code.

This regression shipped unnoticed because the metadata-reader unit tests mock `requests.post` (so they never touch the service), and CI runs `ruff` but not the backend test suite — so the broken `get_tag()` calls in both the service and the integration test went uncaught.

Verified against a running stack on PyExifTool 0.5.6: `POST /get-tags` now returns `201` with correct values (`["2020:03:11 10:21:30", 100]` where it previously 500'd); `get_metadata` returns real values through the service; date-time extraction populates `exif_timestamp` correctly for real and synthetic files; and `python manage.py test api.tests.test_iptc_integration api.tests.test_metadata_reader` passes (11 tests). The full `api.tests` run (1409 tests) shows only pre-existing environment-path failures unrelated to this change.
