### PR TITLE
chore(deps): pin PyExifTool to 0.4.9 and stop Renovate bumps

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -25,7 +25,7 @@ psycopg==3.3.4
 https://github.com/owncloud/pyocclient/archive/master.zip
 pytz==2026.2
 tzdata==2026.2
-PyExifTool==0.5.6
+PyExifTool==0.4.9  # pinned: 0.5.x changes break metadata extraction; do not bump (see renovate.json)
 pyvips==3.1.1
 scikit-learn==1.8.0; python_version >= "3.11"
 scikit-learn==1.7.2; python_version < "3.11"

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "automerge": true
     },
     {
+      "description": "Never bump PyExifTool. Pinned to 0.4.9; 0.5.x breaks metadata extraction.",
+      "matchPackageNames": ["PyExifTool", "pyexiftool"],
+      "enabled": false
+    },
+    {
       "matchFileNames": ["apps/backend/**"],
       "groupName": "backend dependencies",
       "addLabels": ["backend"]


### PR DESCRIPTION
## What

- Pin `PyExifTool` back to `==0.4.9` in `apps/backend/requirements.txt` (reverting the bump to `0.5.6` that Renovate proposed in #1818).
- Add a Renovate `packageRule` with `"enabled": false` for `PyExifTool` so it is **never bumped again**.

## Why

`PyExifTool` 0.5.x is a breaking API rewrite. Two APIs we rely on changed:

- `ExifTool.get_tag()` was moved to `ExifToolHelper` — the base `ExifTool` class no longer has it.
- `ExifTool.start()` was renamed.

`apps/backend/service/exif/main.py` constructs `exiftool.ExifTool(...)` directly and calls `et.get_tag(tag, file)` and `et.start()`. On 0.5.x these raise `AttributeError` at runtime, breaking metadata extraction. Pinning to 0.4.9 keeps the service working.

## Renovate config

```json
{
  "description": "Never bump PyExifTool. Pinned to 0.4.9; 0.5.x breaks metadata extraction.",
  "matchPackageNames": ["PyExifTool", "pyexiftool"],
  "enabled": false
}
```

`enabled: false` stops Renovate from opening any update PR (major/minor/patch) for this package. Both casings are listed so the match holds regardless of how the dependency name is normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)