### PR TITLE
fix(backend): stop Renovate re-collapsing the scikit-learn GPU pin

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -27,8 +27,12 @@ pytz==2026.2
 tzdata==2026.2
 PyExifTool==0.4.9  # pinned: 0.5.x changes break metadata extraction; do not bump (see renovate.json)
 pyvips==3.1.1
+# scikit-learn: the backend-gpu image runs Python 3.10 (CUDA/ubuntu22.04), but
+# scikit-learn 1.8.0+ require Python >= 3.11. Keep the python_version < "3.11"
+# pin at <= 1.7.2 or the GPU build fails. Renovate is disabled for this package
+# (see renovate.json) so it can't re-collapse the split; bump it manually.
 scikit-learn==1.9.0; python_version >= "3.11"
-scikit-learn==1.9.0; python_version < "3.11"
+scikit-learn==1.7.2; python_version < "3.11"
 sentence_transformers==5.6.0
 timezonefinder==8.2.4; python_version >= "3.11"
 timezonefinder==8.2.4; python_version < "3.11"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
       "enabled": false
     },
     {
+      "description": "Never auto-bump scikit-learn. The backend-gpu image runs Python 3.10, where scikit-learn 1.8.0+ are unavailable, so requirements.txt carries a python_version split (1.9.0 on >=3.11, 1.7.2 on <3.11). Renovate bumps every matching line to one version and collapses the split, breaking the GPU build. Bump manually and keep the <3.11 pin at <=1.7.2.",
+      "matchPackageNames": ["scikit-learn", "scikit_learn"],
+      "enabled": false
+    },
+    {
       "matchFileNames": ["apps/backend/**"],
       "groupName": "backend dependencies",
       "addLabels": ["backend"]


### PR DESCRIPTION
## Problem

The `image-backend-gpu` build is failing again:

```
ERROR: Could not find a version that satisfies the requirement scikit-learn==1.9.0
ERROR: No matching distribution found for scikit-learn==1.9.0
```

We already fixed this once (commit `ab031f6c`) by splitting scikit-learn with a PEP 508 marker, because the backend-gpu image runs **Python 3.10** (CUDA 12.1.1 / ubuntu22.04) and scikit-learn **1.8.0+ require Python ≥ 3.11**:

```
scikit-learn==1.8.0; python_version >= "3.11"   # backend image (py3.12)
scikit-learn==1.7.2; python_version < "3.11"     # GPU image (py3.10)
```

Renovate then bumped scikit-learn 1.8.0 → 1.9.0 and applied the new version to **both** lines — including the `python_version < "3.11"` line that has to stay ≤ 1.7.2. Renovate treats the two lines as one dependency and has no way to know they're a deliberate version split, so it collapsed them and re-broke the GPU build.

## Fix

1. **`requirements.txt`** — restore the `< "3.11"` pin to `1.7.2` (newest scikit-learn that supports py3.10; the `>= "3.11"` line keeps 1.9.0), plus a comment explaining why.
2. **`renovate.json`** — disable Renovate updates for `scikit-learn`, mirroring the existing `PyExifTool` pin, so it can't collapse the split again. Bumps are now manual and must keep the `< 3.11` line at ≤ 1.7.2.

## Notes

- Renovate can't target only the marked line (both share the package name `scikit-learn`, and the marker isn't a matchable field), so a full disable is the reliable option — same approach already used for PyExifTool.
- ⚠️ `timezonefinder` uses the same marker-split pattern (both lines currently 8.2.4). It isn't broken today, but a future bump to a version that drops py3.10 would hit the identical trap. Happy to extend the same Renovate rule to it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)