### PR TITLE
backend: filter user/place/thing albums by media type (photo / video)

### DIFF
--- a/apps/backend/api/serializers/PhotosGroupedByDate.py
+++ b/apps/backend/api/serializers/PhotosGroupedByDate.py
@@ -11,6 +11,28 @@ class PhotosGroupedByDate:
         self.location = location
 
 
+def filter_photos_by_media_type(photos, request):
+    """Narrow *photos* to videos-only or photos-only per the request's query.
+
+    Mirrors the convention used by the search and album-date endpoints
+    (``api/filters.py``): a truthy ``video`` param keeps only videos, a truthy
+    ``photo`` param keeps only photos, and ``video`` wins if both are present.
+    Returns *photos* unchanged when neither is set (or there is no request).
+
+    Filtering is done in Python so it operates on the photos the caller already
+    resolved - including prefetched relations - without issuing a fresh query
+    that would drop the prefetch's constraints (e.g. hidden/visible) or defer
+    the ``video`` field. Order is preserved.
+    """
+    if request is None:
+        return photos
+    if request.query_params.get("video"):
+        return [photo for photo in photos if photo.video]
+    if request.query_params.get("photo"):
+        return [photo for photo in photos if not photo.video]
+    return photos
+
+
 def get_photos_ordered_by_date(photos):
     """
     Efficiently group photos by date using itertools.groupby.

--- a/apps/backend/api/serializers/album_place.py
+++ b/apps/backend/api/serializers/album_place.py
@@ -2,7 +2,10 @@ from rest_framework import serializers
 
 from api.models import AlbumPlace
 from api.serializers.photos import GroupedPhotosSerializer, PhotoHashListSerializer
-from api.serializers.PhotosGroupedByDate import get_photos_ordered_by_date
+from api.serializers.PhotosGroupedByDate import (
+    filter_photos_by_media_type,
+    get_photos_ordered_by_date,
+)
 from api.serializers.simple import PhotoSuperSimpleSerializer
 
 
@@ -23,7 +26,10 @@ class GroupedPlacePhotosSerializer(serializers.ModelSerializer):
         return str(obj.id)
 
     def get_grouped_photos(self, obj) -> GroupedPhotosSerializer(many=True):
-        grouped_photos = get_photos_ordered_by_date(obj.photos.all())
+        photos = filter_photos_by_media_type(
+            obj.photos.all(), self.context.get("request")
+        )
+        grouped_photos = get_photos_ordered_by_date(photos)
         res = GroupedPhotosSerializer(grouped_photos, many=True).data
         return res
 

--- a/apps/backend/api/serializers/album_thing.py
+++ b/apps/backend/api/serializers/album_thing.py
@@ -2,7 +2,10 @@ from rest_framework import serializers
 
 from api.models import AlbumThing
 from api.serializers.photos import GroupedPhotosSerializer, PhotoHashListSerializer
-from api.serializers.PhotosGroupedByDate import get_photos_ordered_by_date
+from api.serializers.PhotosGroupedByDate import (
+    filter_photos_by_media_type,
+    get_photos_ordered_by_date,
+)
 from api.serializers.simple import PhotoSuperSimpleSerializer
 
 
@@ -22,7 +25,10 @@ class GroupedThingPhotosSerializer(serializers.ModelSerializer):
         return str(obj.id)
 
     def get_grouped_photos(self, obj) -> GroupedPhotosSerializer(many=True):
-        grouped_photos = get_photos_ordered_by_date(obj.photos.all())
+        photos = filter_photos_by_media_type(
+            obj.photos.all(), self.context.get("request")
+        )
+        grouped_photos = get_photos_ordered_by_date(photos)
         res = GroupedPhotosSerializer(grouped_photos, many=True).data
         return res
 

--- a/apps/backend/api/serializers/album_user.py
+++ b/apps/backend/api/serializers/album_user.py
@@ -2,7 +2,10 @@ from rest_framework import serializers
 
 from api.models import AlbumUser, Photo
 from api.serializers.photos import GroupedPhotosSerializer
-from api.serializers.PhotosGroupedByDate import get_photos_ordered_by_date
+from api.serializers.PhotosGroupedByDate import (
+    filter_photos_by_media_type,
+    get_photos_ordered_by_date,
+)
 from api.serializers.simple import PhotoSuperSimpleSerializer, SimpleUserSerializer
 from api.util import logger
 
@@ -40,9 +43,11 @@ class AlbumUserSerializer(serializers.ModelSerializer):
         return str(obj.id)
 
     def get_grouped_photos(self, obj) -> GroupedPhotosSerializer(many=True):
-        grouped_photos = get_photos_ordered_by_date(
-            obj.photos.all().order_by("-exif_timestamp")
+        photos = filter_photos_by_media_type(
+            obj.photos.all().order_by("-exif_timestamp"),
+            self.context.get("request"),
         )
+        grouped_photos = get_photos_ordered_by_date(photos)
         res = GroupedPhotosSerializer(grouped_photos, many=True).data
         return res
 
@@ -263,7 +268,10 @@ class AlbumUserPublicSerializer(serializers.ModelSerializer):
         )
 
     def get_grouped_photos(self, obj) -> GroupedPhotosSerializer(many=True):
-        grouped_photos = get_photos_ordered_by_date(self._filtered_photos(obj))
+        photos = filter_photos_by_media_type(
+            self._filtered_photos(obj), self.context.get("request")
+        )
+        grouped_photos = get_photos_ordered_by_date(photos)
         return GroupedPhotosSerializer(grouped_photos, many=True).data
 
     def get_location(self, obj) -> str:

--- a/apps/backend/api/tests/test_album_media_type_filter.py
+++ b/apps/backend/api/tests/test_album_media_type_filter.py
@@ -1,0 +1,137 @@
+"""Media-type (photo / video) filtering on the album detail endpoints.
+
+The search and album-date endpoints already honor ``?video=true`` / ``?photo=true``
+(PRs #1862 / #1051). These tests cover the same convention extended to the user,
+place and thing album endpoints, plus the shared ``filter_photos_by_media_type``
+helper that backs them.
+"""
+
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.models import AlbumPlace, AlbumThing, AlbumUser
+from api.models.album_user_share import AlbumUserShare
+from api.serializers.PhotosGroupedByDate import filter_photos_by_media_type
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class FilterPhotosByMediaTypeHelperTest(SimpleTestCase):
+    """Unit tests for the pure helper (no DB)."""
+
+    def setUp(self):
+        self.photo_a = SimpleNamespace(video=False)
+        self.photo_b = SimpleNamespace(video=False)
+        self.video_a = SimpleNamespace(video=True)
+        self.items = [self.photo_a, self.video_a, self.photo_b]
+
+    def _request(self, **params):
+        return SimpleNamespace(query_params=params)
+
+    def test_no_request_returns_unchanged(self):
+        self.assertIs(filter_photos_by_media_type(self.items, None), self.items)
+
+    def test_no_params_returns_unchanged(self):
+        result = filter_photos_by_media_type(self.items, self._request())
+        self.assertIs(result, self.items)
+
+    def test_video_keeps_only_videos(self):
+        result = filter_photos_by_media_type(self.items, self._request(video="true"))
+        self.assertEqual(result, [self.video_a])
+
+    def test_photo_keeps_only_photos(self):
+        result = filter_photos_by_media_type(self.items, self._request(photo="true"))
+        self.assertEqual(result, [self.photo_a, self.photo_b])
+
+    def test_video_wins_when_both_present(self):
+        result = filter_photos_by_media_type(
+            self.items, self._request(video="true", photo="true")
+        )
+        self.assertEqual(result, [self.video_a])
+
+    def test_order_is_preserved(self):
+        result = filter_photos_by_media_type(self.items, self._request(photo="true"))
+        self.assertEqual(result, [self.photo_a, self.photo_b])
+
+
+class AlbumMediaTypeFilterEndpointTest(TestCase):
+    """Each album detail endpoint must honor ?video=true / ?photo=true."""
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        now = timezone.now()
+        # two photos, one video
+        self.photo1 = create_test_photo(
+            owner=self.user, video=False, exif_timestamp=now
+        )
+        self.photo2 = create_test_photo(
+            owner=self.user, video=False, exif_timestamp=now
+        )
+        self.video1 = create_test_photo(owner=self.user, video=True, exif_timestamp=now)
+        self.all_hashes = {self.photo1.image_hash, self.photo2.image_hash}
+        self.video_hashes = {self.video1.image_hash}
+
+    @staticmethod
+    def _hashes(response):
+        data = response.json()
+        groups = data.get("grouped_photos")
+        if groups is None:
+            groups = data.get("results", {}).get("grouped_photos", [])
+        return {item["image_hash"] for group in groups for item in group["items"]}
+
+    def _assert_filtering(self, url):
+        # no filter -> everything
+        self.assertEqual(
+            self._hashes(self.client.get(url)),
+            self.all_hashes | self.video_hashes,
+        )
+        # photos only
+        self.assertEqual(
+            self._hashes(self.client.get(url, {"photo": "true"})),
+            self.all_hashes,
+        )
+        # videos only
+        self.assertEqual(
+            self._hashes(self.client.get(url, {"video": "true"})),
+            self.video_hashes,
+        )
+
+    def test_user_album(self):
+        album = AlbumUser.objects.create(title="My Album", owner=self.user)
+        album.photos.add(self.photo1, self.photo2, self.video1)
+        self._assert_filtering(f"/api/albums/user/{album.id}/")
+
+    def test_user_album_public(self):
+        album = AlbumUser.objects.create(title="Shared Album", owner=self.user)
+        album.photos.add(self.photo1, self.photo2, self.video1)
+        AlbumUserShare.objects.create(album=album, enabled=True)
+        anon = APIClient()
+        base = f"/api/albums/user/{album.id}/"
+        self.assertEqual(
+            self._hashes(anon.get(base, {"public": "1"})),
+            self.all_hashes | self.video_hashes,
+        )
+        self.assertEqual(
+            self._hashes(anon.get(base, {"public": "1", "photo": "true"})),
+            self.all_hashes,
+        )
+        self.assertEqual(
+            self._hashes(anon.get(base, {"public": "1", "video": "true"})),
+            self.video_hashes,
+        )
+
+    def test_place_album(self):
+        album = AlbumPlace.objects.create(title="Lisbon", owner=self.user)
+        album.photos.add(self.photo1, self.photo2, self.video1)
+        self._assert_filtering(f"/api/albums/place/{album.id}/")
+
+    def test_thing_album(self):
+        album = AlbumThing.objects.create(
+            title="beach", owner=self.user, thing_type="hashtag_attribute"
+        )
+        album.photos.add(self.photo1, self.photo2, self.video1)
+        self._assert_filtering(f"/api/albums/thing/{album.id}/")

--- a/apps/backend/api/views/albums.py
+++ b/apps/backend/api/views/albums.py
@@ -226,7 +226,14 @@ class AlbumPlaceViewSet(viewsets.ModelViewSet):
                 Prefetch(
                     "photos",
                     queryset=Photo.objects.filter(hidden=False)
-                    .only("image_hash", "public", "rating", "hidden", "exif_timestamp")
+                    .only(
+                        "image_hash",
+                        "public",
+                        "rating",
+                        "hidden",
+                        "exif_timestamp",
+                        "video",
+                    )
                     .order_by("-exif_timestamp"),
                 )
             )


### PR DESCRIPTION
Filtering search results and the timeline by media type already works — the search endpoint (`#1862`) and the album-date endpoints (`#1051`) honor `?video=true` / `?photo=true`. But the user, place and thing album detail endpoints ignored those params and always returned every photo, so a "photos / videos" filter can't be offered on those views. This brings them in line so the same filter can live everywhere a photo grid is shown.

A small shared helper, `filter_photos_by_media_type(photos, request)`, applies the established convention — a truthy `video` keeps only videos, a truthy `photo` keeps only photos, and `video` wins if both are present — and is reused by `AlbumUserSerializer`, `AlbumUserPublicSerializer`, `GroupedPlacePhotosSerializer` and `GroupedThingPhotosSerializer`. (Person albums already work, because the frontend loads them through the album-date list endpoint that already supports this.)

The helper filters in Python rather than issuing a new query, and that's deliberate: the place and thing viewsets `prefetch` their photos with constraints (`hidden=False` for place, `Photo.visible` for thing), so a fresh `.filter(video=...)` on the relation would both drop those constraints and trigger extra queries. Filtering the already-resolved list keeps the prefetch intact and preserves ordering. The place viewset's prefetch `.only(...)` gains `video` so the field is loaded rather than deferred (avoiding an N+1 when filtering).

When neither param is present the endpoints behave exactly as before, so this is a no-op for existing callers.

`api/tests/test_album_media_type_filter.py` unit-tests the helper (precedence, ordering, no-op cases) and asserts `?video=true` / `?photo=true` / no-filter against the user (private and public-share), place and thing album endpoints. This is the backend half of a media-type filter feature; the frontend control is a follow-up.
