### PR TITLE
fix(backend): restore GPU py3.10 pins for onnxruntime and timezonefinder

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -34,8 +34,11 @@ pyvips==3.1.1
 scikit-learn==1.9.0; python_version >= "3.11"
 scikit-learn==1.7.2; python_version < "3.11"
 sentence_transformers==5.6.0
+# timezonefinder: same py3.10 split as scikit-learn. 8.2.1+ require Python >= 3.11,
+# so the python_version < "3.11" pin must stay at 8.2.0 (last release supporting
+# py3.10) or the GPU build fails. Renovate is disabled for it (see renovate.json).
 timezonefinder==8.2.4; python_version >= "3.11"
-timezonefinder==8.2.4; python_version < "3.11"
+timezonefinder==8.2.0; python_version < "3.11"
 tqdm==4.68.3
 gevent==25.9.1
 python-magic==0.4.27
@@ -56,10 +59,11 @@ llama-cpp-python==0.3.31
 argon2-cffi==25.1.0
 # Dependencies for SigLIP 2 ONNX inference
 # On the GPU image (Python 3.10) the Dockerfile swaps this for
-# onnxruntime-gpu==<same version>. 1.26.0 has no Python 3.10 wheel; 1.23.2 is the
+# onnxruntime-gpu==<same version>. 1.26.0+ has no Python 3.10 wheel; 1.23.2 is the
 # last release with a cp310 wheel for both onnxruntime and onnxruntime-gpu, and is
-# the version the GPU image last built green with (before #1818).
+# the version the GPU image last built green with (before #1818). Keep the
+# python_version < "3.11" pin at 1.23.2. Renovate is disabled for it (see renovate.json).
 onnxruntime==1.27.0; python_version >= "3.11"
-onnxruntime==1.27.0; python_version < "3.11"
+onnxruntime==1.23.2; python_version < "3.11"
 # SentencePiece tokenizer for SigLIP 2
 sentencepiece==0.2.1

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,8 @@
       "enabled": false
     },
     {
-      "description": "Never auto-bump scikit-learn. The backend-gpu image runs Python 3.10, where scikit-learn 1.8.0+ are unavailable, so requirements.txt carries a python_version split (1.9.0 on >=3.11, 1.7.2 on <3.11). Renovate bumps every matching line to one version and collapses the split, breaking the GPU build. Bump manually and keep the <3.11 pin at <=1.7.2.",
-      "matchPackageNames": ["scikit-learn", "scikit_learn"],
+      "description": "Never auto-bump these. The backend-gpu image runs Python 3.10, but newer releases of these packages drop py3.10, so apps/backend/requirements.txt carries a python_version split (newest on >=3.11, last py3.10-compatible on <3.11). Renovate applies one version to every matching line and collapses the split, breaking the GPU build. Bump manually and keep the <3.11 pin on a py3.10-compatible version: scikit-learn<=1.7.2, timezonefinder<=8.2.0, onnxruntime<=1.23.2.",
+      "matchPackageNames": ["scikit-learn", "scikit_learn", "timezonefinder", "onnxruntime", "onnxruntime-gpu"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Problem

`image-backend-gpu` **still fails** after [#1884](https://github.com/LibrePhotos/librephotos/pull/1884), at the same `pip install` step ([run 28234225248](https://github.com/LibrePhotos/librephotos/actions/runs/28234225248/job/83645035989), building merged `dev`). pip only reports one unsatisfiable package at a time, so fixing scikit-learn just let the resolver reach the **next** collapsed split. Renovate had done the same thing to two more packages:

| package | py<3.11 line on `dev` | py3.10? | correct pin |
|---|---|---|---|
| `onnxruntime` | `1.27.0` | ❌ `requires_python >=3.11`, no cp310 wheel | **1.23.2** (`>=3.10`, cp310 ✓) |
| `timezonefinder` | `8.2.4` | ❌ `requires_python >=3.11` | **8.2.0** (8.2.1+ all require ≥3.11) |

The backend-gpu image runs **Python 3.10** (CUDA 12.1.1 / ubuntu22.04). `onnxruntime==1.23.2` is also the last release with a **cp310 wheel for `onnxruntime-gpu`**, which the GPU Dockerfile swaps to after install — verified on PyPI.

## Fix

1. **`requirements.txt`** — restore the `< "3.11"` pins to `onnxruntime==1.23.2` and `timezonefinder==8.2.0` (the `>= "3.11"` lines keep 1.27.0 / 8.2.4 for the py3.12 backend image). Comments updated.
2. **`renovate.json`** — fold `timezonefinder`, `onnxruntime`, `onnxruntime-gpu` into the existing scikit-learn disable rule so Renovate can't collapse these splits again.

## Verification

Audited **all 49 pins** in `apps/backend/requirements.txt` against PyPI `requires_python` and cp310-wheel availability. After this change, these two were the **only** remaining py3.10 breakers — no third surprise behind them.

> Note: `image-backend-gpu` only builds on push to `dev` (not on PRs), so this can only be confirmed green after merge.

## Longer term

This is the 3rd recurrence of Renovate collapsing a py3.10 marker split. The durable alternative is to install **Python 3.12** in `deploy/docker/backend-gpu/base/Dockerfile` (via deadsnakes, keeping CUDA 12.1.1), giving the GPU image parity with the CPU image and retiring every marker split + Renovate-disable workaround. Worth considering if this keeps happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)