### PR TITLE
fix: stop user-list Zod popup for non-admins (#1888)

### DIFF
--- a/apps/backend/api/serializers/user.py
+++ b/apps/backend/api/serializers/user.py
@@ -315,6 +315,11 @@ class PublicUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
+        # Public-safe fields only -- never expose private profile data here
+        # (email, scan_directory, Nextcloud creds, is_superuser, ...). See #1861.
+        # public_sharing is included because it is not private (it is the basis
+        # of the public-user discovery page) and the frontend needs it to list
+        # users who opted into public sharing.
         fields = (
             "id",
             "avatar_url",
@@ -323,6 +328,7 @@ class PublicUserSerializer(serializers.ModelSerializer):
             "last_name",
             "public_photo_count",
             "public_photo_samples",
+            "public_sharing",
         )
 
     def get_public_photo_count(self, obj) -> int:

--- a/apps/backend/api/tests/test_user.py
+++ b/apps/backend/api/tests/test_user.py
@@ -27,6 +27,7 @@ class UserTest(TestCase):
         "last_name",
         "public_photo_count",
         "public_photo_samples",
+        "public_sharing",
     ]
 
     private_user_properties = [

--- a/apps/frontend/src/api_client/user/hooks/useFetchUserListQuery.test.ts
+++ b/apps/frontend/src/api_client/user/hooks/useFetchUserListQuery.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { User } from "../types";
+import { UserListResponse } from "./useFetchUserListQuery";
+
+/**
+ * Regression coverage for https://github.com/LibrePhotos/librephotos/issues/1888
+ *
+ * Since the #1861 authorization fix, GET /api/user/ returns the full
+ * UserSerializer only to admins (and to a user viewing their own record).
+ * Every other authenticated reader gets the public-safe PublicUserSerializer:
+ *   id, avatar_url, username, first_name, last_name,
+ *   public_photo_count, public_photo_samples (+ public_sharing).
+ *
+ * The list query used to validate every row against the *full* `User` schema,
+ * so non-admins got a flood of "Required at results.N.<field>" popups on the
+ * main page. Admins never saw it because they receive the full payload.
+ */
+
+// What an authenticated NON-admin receives for each row (PublicUserSerializer).
+const publicSafeUser = {
+  id: 1,
+  username: "alice",
+  first_name: "Alice",
+  last_name: "Anderson",
+  avatar_url: null,
+  public_photo_count: 3,
+  public_photo_samples: [],
+  public_sharing: true,
+};
+
+// What an admin (or a user viewing their own record) receives (UserSerializer).
+const fullUser = {
+  ...publicSafeUser,
+  email: "alice@example.com",
+  scan_directory: "/data/alice",
+  confidence: 0.5,
+  confidence_person: 0.9,
+  transcode_videos: false,
+  semantic_search_topk: 100,
+  date_joined: "2023-01-01T00:00:00Z",
+  avatar: null,
+  photo_count: 42,
+  nextcloud_server_address: null,
+  nextcloud_username: null,
+  nextcloud_scan_directory: null,
+  favorite_min_rating: 0,
+  image_scale: 1,
+  save_metadata_to_disk: "OFF",
+  datetime_rules: "[]",
+  default_timezone: "UTC",
+  confidence_unknown_face: 0.5,
+  min_cluster_size: 2,
+  min_samples: 1,
+  cluster_selection_epsilon: 0.1,
+  llm_settings: null,
+};
+
+const envelope = (results: unknown[]) => ({ count: results.length, next: null, previous: null, results });
+
+describe("issue #1888 — non-admin user list popup", () => {
+  test("documents the symptom: the full User schema rejects a public-safe row", () => {
+    // This is what produced "Required at results.0.email; ...confidence; ..."
+    const result = User.safeParse(publicSafeUser);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const missing = result.error.issues.map(i => i.path.join("."));
+      // The exact fields from the GitHub report.
+      expect(missing).toEqual(
+        expect.arrayContaining([
+          "email",
+          "confidence",
+          "confidence_person",
+          "transcode_videos",
+          "semantic_search_topk",
+          "date_joined",
+          "photo_count",
+          "favorite_min_rating",
+          "image_scale",
+          "save_metadata_to_disk",
+          "datetime_rules",
+          "default_timezone",
+          "confidence_unknown_face",
+          "min_cluster_size",
+          "min_samples",
+          "cluster_selection_epsilon",
+        ])
+      );
+    }
+  });
+
+  test("the user-list response accepts the public-safe payload non-admins receive", () => {
+    // Before the fix this threw a ZodError (the popup). After the fix it parses.
+    expect(() => UserListResponse.parse(envelope([publicSafeUser]))).not.toThrow();
+    const parsed = UserListResponse.parse(envelope([publicSafeUser]));
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].username).toBe("alice");
+  });
+
+  test("the user-list response still accepts the full admin payload", () => {
+    expect(() => UserListResponse.parse(envelope([fullUser]))).not.toThrow();
+    const parsed = UserListResponse.parse(envelope([fullUser]));
+    expect(parsed.results[0].email).toBe("alice@example.com");
+  });
+});

--- a/apps/frontend/src/api_client/user/hooks/useFetchUserListQuery.ts
+++ b/apps/frontend/src/api_client/user/hooks/useFetchUserListQuery.ts
@@ -2,8 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
-import type { UserList } from "../types";
-import { User } from "../types";
+import type { ListUserList } from "../types";
+import { ListUser } from "../types";
 
 export const UserListQueryKeys = ["userList"] as const;
 
@@ -11,14 +11,16 @@ export const UserListResponse = z.object({
   count: z.number(),
   next: z.string().nullable(),
   previous: z.string().nullable(),
-  results: z.array(User),
+  // Non-admins receive the public-safe subset, so validate each row leniently
+  // (see ListUser) instead of against the full User schema (issue #1888).
+  results: z.array(ListUser),
 });
 // User List Query
 export const useFetchUserListQuery = (skip: boolean = false) =>
-  useQuery<UserList>({
+  useQuery<ListUserList>({
     queryKey: UserListQueryKeys,
     queryFn: async () => {
-      const response = await fetchClient.get<UserList>("/user/");
+      const response = await fetchClient.get<ListUserList>("/user/");
       return parseWithNotification(UserListResponse, response, "Failed to parse user list").results;
     },
     enabled: !skip,

--- a/apps/frontend/src/api_client/user/types.ts
+++ b/apps/frontend/src/api_client/user/types.ts
@@ -103,6 +103,28 @@ export type ManageUser = z.infer<typeof ManageUser>;
 export const UserList = User.array();
 export type UserList = z.infer<typeof UserList>;
 
+// Row shape returned by the GET /api/user/ list (and a /user/<id>/ retrieve of
+// someone else's record). Since the #1861 authorization fix the backend only
+// serializes the full UserSerializer for admins and for a user viewing their own
+// record; every other reader receives the public-safe PublicUserSerializer
+// (id, avatar_url, username, first/last name, public_photo_count,
+// public_photo_samples, public_sharing). Validating those rows against the full
+// `User` schema spammed non-admins with "Required at results.N.<field>" popups
+// (issue #1888), so here the private/admin-only fields are optional while the
+// public-safe fields stay required.
+export const ListUser = User.partial().required({
+  id: true,
+  username: true,
+  first_name: true,
+  last_name: true,
+  public_photo_count: true,
+  public_photo_samples: true,
+});
+export type ListUser = z.infer<typeof ListUser>;
+
+export const ListUserList = ListUser.array();
+export type ListUserList = z.infer<typeof ListUserList>;
+
 export type UserState = {
   userSelfDetails: User;
   error: Error | string | null | undefined;

--- a/apps/frontend/src/components/sharing/ModalPhotosShare.tsx
+++ b/apps/frontend/src/components/sharing/ModalPhotosShare.tsx
@@ -116,10 +116,12 @@ export function ModalPhotosShare(props: Props) {
                       <Avatar radius="xl" size={50} src={avatar} />
                       <div>
                         <Title order={4}>{displayName}</Title>
-                        <Text size="sm" c="dimmed">
-                          {t("modalphotosshare.joined")}{" "}
-                          {DateTime.fromISO(item.date_joined).setLocale(i18nResolvedLanguage()).toRelative()}
-                        </Text>
+                        {item.date_joined && (
+                          <Text size="sm" c="dimmed">
+                            {t("modalphotosshare.joined")}{" "}
+                            {DateTime.fromISO(item.date_joined).setLocale(i18nResolvedLanguage()).toRelative()}
+                          </Text>
+                        )}
                       </div>
                     </Group>
                     <Group>

--- a/apps/frontend/src/components/sharing/UserEntry.tsx
+++ b/apps/frontend/src/components/sharing/UserEntry.tsx
@@ -38,10 +38,12 @@ export function UserEntry(props: UserEntryProps) {
         <Avatar radius="xl" size={50} src={getAvatar(user)} />
         <div>
           <Title order={4}>{getDisplayName(user)}</Title>
-          <Text size="sm" c="dimmed">
-            {t("modalphotosshare.joined")}{" "}
-            {DateTime.fromISO(user.date_joined).setLocale(i18nResolvedLanguage()).toRelative()}
-          </Text>
+          {user.date_joined && (
+            <Text size="sm" c="dimmed">
+              {t("modalphotosshare.joined")}{" "}
+              {DateTime.fromISO(user.date_joined).setLocale(i18nResolvedLanguage()).toRelative()}
+            </Text>
+          )}
         </div>
       </Group>
       <Group>


### PR DESCRIPTION
## Problem

Since the #1861 authorization fix (commit `325bd1f5`), `GET /api/user/` returns the full `UserSerializer` only to **admins** and to a user viewing their **own** record. Every other authenticated reader now gets the public-safe `PublicUserSerializer`.

The frontend, however, still validated **every** `/user/` list row against the full `User` Zod schema. `DefaultHeader` runs that query on the main page for every logged-in user, so:

- **Admin** → full payload → validates → no popup.
- **Non-admin** → public-safe payload → ~17 required fields missing → `parseWithNotification` fires the exact popup from the report: `Required at results.0.email; …confidence; …cluster_selection_epsilon. Please report this issue on GitHub.`

That matches the report precisely ("shown to all users except Admin"). Closes #1888.

## Changes

**Frontend**
- New lenient `ListUser` schema (public-safe fields required, private/admin-only fields optional) used to validate the `/user/` list instead of the full `User` schema. Both payload shapes (admin full, non-admin public-safe) now validate.
- Guard the cosmetic `date_joined` display in `ModalPhotosShare` / `UserEntry` so non-admins no longer see "Joined Invalid DateTime".
- Regression test `useFetchUserListQuery.test.ts` reproducing the popup payload (fails before, passes after).

**Backend**
- Expose the non-sensitive `public_sharing` flag in `PublicUserSerializer` so the public-user discovery page keeps working for non-admins. Sensitive fields (email, scan_directory, Nextcloud creds, is_superuser) stay hidden. Updated `test_user.py` property assertions.

## Verification
- Frontend: new test 3/3 pass; `tsc` unchanged (0 new errors); eslint clean on changed files.
- Backend: `test_user` + `test_authz_scoping` = **35/35 pass**, incl. `test_non_admin_list_hides_other_users_private_fields` (confirms `public_sharing` added without leaking any private field); ruff check + format clean.

> Note: the mobile app has the same latent bug (`apps/mobile/.../useFetchUserListQuery.ts` validates against the full `User` schema) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)