### PR TITLE
fix(mobile): relax user-list validation for non-admin PublicUserSerializer (#1888)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -114,7 +114,7 @@
       "./jest.setup.js"
     ],
     "timers": "fake",
-    "testEnvironment": "jsdom",
+    "testEnvironment": "node",
     "transformIgnorePatterns": [
       "/node_modules/(?!@react-native|react-native)"
     ]

--- a/apps/mobile/src/api_client/user/hooks/useFetchUserListQuery.test.ts
+++ b/apps/mobile/src/api_client/user/hooks/useFetchUserListQuery.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression coverage for https://github.com/LibrePhotos/librephotos/issues/1888
+ *
+ * Since the #1861 authorization fix, GET /api/user/ returns the full
+ * UserSerializer only to admins (and to a user viewing their own record).
+ * Every other authenticated reader gets the public-safe PublicUserSerializer:
+ *   id, avatar_url, username, first_name, last_name,
+ *   public_photo_count, public_photo_samples (+ public_sharing).
+ *
+ * useFetchUserListQuery used to validate every row against the *full* `User`
+ * schema, so non-admins got a flood of "Required at results.N.<field>" popups.
+ * Admins never saw it because they receive the full payload. The fix validates
+ * each row against the relaxed `ListUser` schema instead.
+ *
+ * This suite asserts directly against the `ListUser` / `ListUserList` schemas
+ * (the source of truth the hook's `UserListResponse` wraps). Importing the hook
+ * itself would drag the native `fetchClient` chain (token storage, navigation,
+ * zustand stores) into jest, which is irrelevant to the parsing regression.
+ */
+import { ListUser, ListUserList, User } from '../types'
+
+// What an authenticated NON-admin receives for each row (PublicUserSerializer).
+const publicSafeUser = {
+  id: 1,
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Anderson',
+  avatar_url: null,
+  public_photo_count: 3,
+  public_photo_samples: [],
+  public_sharing: true,
+}
+
+// What an admin (or a user viewing their own record) receives (UserSerializer).
+const fullUser = {
+  ...publicSafeUser,
+  email: 'alice@example.com',
+  scan_directory: '/data/alice',
+  confidence: 0.5,
+  confidence_person: 0.9,
+  transcode_videos: false,
+  semantic_search_topk: 100,
+  date_joined: '2023-01-01T00:00:00Z',
+  avatar: null,
+  photo_count: 42,
+  nextcloud_server_address: null,
+  nextcloud_username: null,
+  nextcloud_scan_directory: null,
+  favorite_min_rating: 0,
+  image_scale: 1,
+  save_metadata_to_disk: 'OFF',
+  datetime_rules: '[]',
+  default_timezone: 'UTC',
+  face_recognition_model: 'mobilenet',
+  confidence_unknown_face: 0.5,
+  min_cluster_size: 2,
+  min_samples: 1,
+  cluster_selection_epsilon: 0.1,
+  llm_settings: null,
+}
+
+describe('issue #1888 — non-admin user list popup', () => {
+  test('documents the symptom: the full User schema rejects a public-safe row', () => {
+    // This is what produced "Required at results.0.email; ...confidence; ..."
+    const result = User.safeParse(publicSafeUser)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const missing = result.error.issues.map(i => i.path.join('.'))
+      // The exact fields from the GitHub report (plus mobile-only required ones).
+      expect(missing).toEqual(
+        expect.arrayContaining([
+          'email',
+          'confidence',
+          'confidence_person',
+          'transcode_videos',
+          'semantic_search_topk',
+          'date_joined',
+          'photo_count',
+          'favorite_min_rating',
+          'image_scale',
+          'save_metadata_to_disk',
+          'datetime_rules',
+          'default_timezone',
+          'face_recognition_model',
+          'confidence_unknown_face',
+          'min_cluster_size',
+          'min_samples',
+          'cluster_selection_epsilon',
+        ]),
+      )
+    }
+  })
+
+  test('ListUser accepts the public-safe payload non-admins receive', () => {
+    // Before the fix this threw a ZodError (the popup). After the fix it parses.
+    expect(() => ListUser.parse(publicSafeUser)).not.toThrow()
+    const parsed = ListUser.parse(publicSafeUser)
+    expect(parsed.username).toBe('alice')
+    // Private/admin-only fields are absent for non-admins.
+    expect(parsed.email).toBeUndefined()
+    expect(parsed.date_joined).toBeUndefined()
+  })
+
+  test('ListUserList accepts a list of public-safe rows', () => {
+    expect(() => ListUserList.parse([publicSafeUser])).not.toThrow()
+    const parsed = ListUserList.parse([publicSafeUser])
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].username).toBe('alice')
+  })
+
+  test('ListUserList still accepts the full admin payload', () => {
+    expect(() => ListUserList.parse([fullUser])).not.toThrow()
+    const parsed = ListUserList.parse([fullUser])
+    expect(parsed[0].email).toBe('alice@example.com')
+  })
+})

--- a/apps/mobile/src/api_client/user/hooks/useFetchUserListQuery.ts
+++ b/apps/mobile/src/api_client/user/hooks/useFetchUserListQuery.ts
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 import { parseWithNotification } from '../../../util/zodUtils'
 import { fetchClient } from '../../api'
-import type { UserList } from '../types'
-import { User } from '../types'
+import type { ListUserList } from '../types'
+import { ListUser } from '../types'
 
 export const UserListQueryKeys = ['userList'] as const
 
@@ -11,14 +11,16 @@ export const UserListResponse = z.object({
   count: z.number(),
   next: z.string().nullable(),
   previous: z.string().nullable(),
-  results: z.array(User),
+  // Non-admins receive the public-safe subset, so validate each row leniently
+  // (see ListUser) instead of against the full User schema (issue #1888).
+  results: z.array(ListUser),
 })
 // User List Query
 export const useFetchUserListQuery = (skip: boolean = false) =>
-  useQuery<UserList>({
+  useQuery<ListUserList>({
     queryKey: UserListQueryKeys,
     queryFn: async () => {
-      const response = await fetchClient.get<UserList>('/user/')
+      const response = await fetchClient.get<ListUserList>('/user/')
       return parseWithNotification(
         UserListResponse,
         response,

--- a/apps/mobile/src/api_client/user/types.ts
+++ b/apps/mobile/src/api_client/user/types.ts
@@ -105,6 +105,27 @@ export type ManageUser = z.infer<typeof ManageUser>
 export const UserList = User.array()
 export type UserList = z.infer<typeof UserList>
 
+// GET /api/user/ no longer returns the full UserSerializer to everyone. Since the
+// #1861 authorization fix the backend serializes the full UserSerializer only for
+// admins and for a user viewing their own record; every other authenticated reader
+// receives the public-safe PublicUserSerializer (id, avatar_url, username,
+// first/last name, public_photo_count, public_photo_samples, public_sharing).
+// Validating those rows against the full `User` schema spammed non-admins with
+// "Required at results.N.<field>" popups (issue #1888), so here the private/admin-only
+// fields are optional while the public-safe fields stay required.
+export const ListUser = User.partial().required({
+  id: true,
+  username: true,
+  first_name: true,
+  last_name: true,
+  public_photo_count: true,
+  public_photo_samples: true,
+})
+export type ListUser = z.infer<typeof ListUser>
+
+export const ListUserList = ListUser.array()
+export type ListUserList = z.infer<typeof ListUserList>
+
 export type UserState = {
   userSelfDetails: User
   error: Error | string | null | undefined


### PR DESCRIPTION
## Summary

Mirrors the web frontend fix for [#1888](https://github.com/LibrePhotos/librephotos/issues/1888) into the mobile app.

Since the [#1861](https://github.com/LibrePhotos/librephotos/issues/1861) authorization fix, `GET /api/user/` returns the reduced public-safe `PublicUserSerializer` (`id`, `avatar_url`, `username`, `first_name`, `last_name`, `public_photo_count`, `public_photo_samples`, `public_sharing`) to authenticated **non-admin** users, and the full `UserSerializer` only to admins and to a user viewing their own record.

`useFetchUserListQuery` validated every list row against the full `User` Zod schema, so non-admins were spammed with "Required at results.N.&lt;field&gt;" parse-failure notifications — the identical bug already fixed in `apps/frontend`.

## Changes (`apps/mobile`)

- **`api_client/user/types.ts`** — add a relaxed `ListUser` schema (`User.partial().required({ id, username, first_name, last_name, public_photo_count, public_photo_samples })`) plus `ListUserList`, with a comment referencing #1888/#1861. Private/admin-only fields are optional; public-safe fields stay required.
- **`api_client/user/hooks/useFetchUserListQuery.ts`** — validate the response `results` against `ListUser` and return `ListUserList`.
- **`api_client/user/hooks/useFetchUserListQuery.test.ts`** — jest regression coverage: the full `User` schema rejects a public-safe row (documents the symptom), and `ListUser`/`ListUserList` accept both the non-admin public-safe payload and the full admin payload.
- **`package.json`** — fix the jest `testEnvironment` (`jsdom` → `node`). The React Native preset needs no DOM and `jest-environment-jsdom` was never a dependency, so `yarn test` failed at config validation for any test. `node` is the RN-correct default; this adds no dependency (no `yarn.lock` change).

`useFetchUserSelfDetailsQuery` intentionally keeps the full `User` schema — it is only ever called for the current user / self, which still receives the full serializer.

### Consumer audit
No mobile UI consumes the list query's data; the only external reference is `UserListQueryKeys` (cache invalidation). So no field-access sites needed guarding for the now-optional `date_joined` / `public_sharing`.

## Verification (Node 22)

- `yarn test src/api_client/user/hooks/useFetchUserListQuery.test.ts` — **4/4 passing** under the default config.
- `eslint` on all changed files — clean.
- `tsc --noEmit` — no new errors. The one `TS2769` on the hook is a pre-existing `@tanstack/react-query` quirk shared by every query hook (e.g. the untouched `useFetchUserSelfDetailsQuery`), present on the original file before this change.

> Note: requested as a PR against `develop`; this repo's development branch is `dev`, so the base is set to `dev`.

The backend change (`PublicUserSerializer` now includes `public_sharing`) is already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
