### PR TITLE
Fix default date rules to prefer original capture time over edit time

### DIFF
--- a/apps/backend/api/date_time_extractor.py
+++ b/apps/backend/api/date_time_extractor.py
@@ -405,16 +405,16 @@ DEFAULT_RULES_PARAMS = [
         "rule_type": RuleTypes.USER_DEFINED,
     },
     {
-        "id": 15,
-        "name": f"Local time from {Tags.DATE_TIME} exif tag",
-        "rule_type": RuleTypes.EXIF,
-        "exif_tag": Tags.DATE_TIME,
-    },
-    {
         "id": 1,
         "name": f"Local time from {Tags.DATE_TIME_ORIGINAL} exif tag",
         "rule_type": RuleTypes.EXIF,
         "exif_tag": Tags.DATE_TIME_ORIGINAL,
+    },
+    {
+        "id": 15,
+        "name": f"Local time from {Tags.DATE_TIME} exif tag",
+        "rule_type": RuleTypes.EXIF,
+        "exif_tag": Tags.DATE_TIME,
     },
     {
         "id": 2,

--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -223,7 +223,7 @@ class Photo(models.Model):
                 tags_to_write[Tags.RATING] = self.rating
             if modified_fields is not None and "timestamp" in modified_fields:
                 # To-Do: Only works for files and not for the sidecar file
-                tags_to_write[Tags.DATE_TIME] = self.timestamp
+                tags_to_write[Tags.DATE_TIME_ORIGINAL] = self.timestamp
 
         if write_face_tags:
             from api.metadata.face_regions import get_face_region_tags

--- a/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
+++ b/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
@@ -3,11 +3,13 @@ import datetime
 from django.test import TestCase
 
 from api.date_time_extractor import (
+    DEFAULT_RULES_PARAMS,
     TimeExtractionRule,
     _extract_no_tz_datetime_from_str,
     as_rules,
     extract_local_date_time,
 )
+from api.metadata.tags import Tags
 
 
 class NumericTagValueTest(TestCase):
@@ -56,6 +58,31 @@ class NumericTagValueTest(TestCase):
             }
         )
         self.assertFalse(rule._check_condition_exif({"EXIF:Rating": 5}))
+
+    def test_default_rules_prefer_original_capture_time_over_file_edit_time(self):
+        rules = as_rules(DEFAULT_RULES_PARAMS)
+        values = {
+            Tags.DATE_TIME: "2024:05:01 10:30:00",
+            Tags.DATE_TIME_ORIGINAL: "2019:08:15 07:45:00",
+        }
+
+        def exif_getter(tags):
+            return [values.get(tag) for tag in tags]
+
+        result = extract_local_date_time(
+            path="/photos/edited-vacation.jpg",
+            rules=rules,
+            exif_getter=exif_getter,
+            gps_lat=None,
+            gps_lon=None,
+            user_default_tz="UTC",
+            user_defined_timestamp=None,
+        )
+
+        self.assertEqual(
+            result,
+            datetime.datetime(2019, 8, 15, 7, 45, 0, tzinfo=datetime.timezone.utc),
+        )
 
     def test_extract_local_date_time_numeric_exif_does_not_crash(self):
         # Full path: an EXIF rule whose tag resolves to a number must not crash

--- a/apps/backend/api/tests/test_face_writeback.py
+++ b/apps/backend/api/tests/test_face_writeback.py
@@ -8,6 +8,7 @@ from api.metadata.face_regions import (
     reverse_orientation_transform,
     thumbnail_coords_to_normalized,
 )
+from api.metadata.tags import Tags
 from api.models.person import Person
 from api.tests.utils import (
     create_test_face,
@@ -534,6 +535,20 @@ class TestSaveMetadataIntegration(TestCase):
         if mock_write_metadata.called:
             tags = mock_write_metadata.call_args[0][1]
             self.assertNotIn("XMP-mwg-rs:RegionInfo", tags)
+
+    @patch("api.models.photo.write_metadata")
+    def test_save_metadata_writes_timestamp_edits_to_date_time_original(
+        self, mock_write_metadata
+    ):
+        photo = create_test_photo(owner=self.user)
+        photo.timestamp = "2019-08-15T07:45:00Z"
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=True)
+
+        mock_write_metadata.assert_called_once()
+        tags = mock_write_metadata.call_args[0][1]
+        self.assertEqual(tags[Tags.DATE_TIME_ORIGINAL], photo.timestamp)
+        self.assertNotIn(Tags.DATE_TIME, tags)
 
     @patch("api.models.photo.write_metadata")
     @patch("api.metadata.face_regions.get_metadata")


### PR DESCRIPTION
Summary:-

  Fixes #1858.

  Fixes the default date extraction rules so `EXIF:DateTimeOriginal` is preferred over `EXIF:DateTime`. This prevents externally edited photos
  from being dated by file edit/save time instead of original capture time.

  Also updates LibrePhotos timestamp write-back to store in `EXIF:DateTimeOriginal`, so in-app timestamp edits can still survive a database
  rebuild.

  Notes:-

  Existing users with stored `datetime_rules` JSON are not migrated by this PR. This changes the default rules used for new/default
  configurations.

  Testing:-

  - Passed: `python -m py_compile apps/backend/api/date_time_extractor.py apps/backend/api/models/photo.py apps/backend/api/tests/
  test_date_time_extractor_numeric_tags.py apps/backend/api/tests/test_face_writeback.py`
  - Passed: `git diff --check`
  - Attempted: `python manage.py test api.tests.test_date_time_extractor_numeric_tags api.tests.test_face_writeback.TestSaveMetadataIntegration
  --settings=librephotos.settings.test_sqlite`
    - Blocked locally because Django is not installed in this Python environment.
  - Attempted: `ruff check apps/backend/api/date_time_extractor.py apps/backend/api/models/photo.py apps/backend/api/tests/
  test_date_time_extractor_numeric_tags.py apps/backend/api/tests/test_face_writeback.py`
    - Blocked locally because Ruff is not installed in this Python environment.