### PR TITLE
Add optional XMP face-region scrubbing when deleting facesfeat: scrub face region tags on delete

### DIFF
--- a/apps/backend/api/metadata/face_regions.py
+++ b/apps/backend/api/metadata/face_regions.py
@@ -7,6 +7,30 @@ from api.models.person import Person
 from api.util import logger
 
 
+REGION_TAGS_TO_SCRUB = (
+    Tags.REGION_INFO,
+    Tags.REGION_INFO_WRITE,
+    "XMP-MP:RegionInfo",
+    "XMP-MPRI:Regions",
+)
+
+
+def scrub_face_region_tags(photo, use_sidecar=True):
+    """Remove existing XMP face region containers from a photo file or sidecar.
+
+    ExifTool deletes a tag when it receives an empty assignment. These region
+    containers are used by LibrePhotos, Digikam, Microsoft Photo, and other
+    managers to store face rectangles and names.
+    """
+    from api.metadata.writer import write_metadata
+
+    write_metadata(
+        photo.main_file.path,
+        {tag: "" for tag in REGION_TAGS_TO_SCRUB},
+        use_sidecar=use_sidecar,
+    )
+
+
 def thumbnail_coords_to_normalized(top, right, bottom, left, thumb_width, thumb_height):
     """Convert Face model pixel coords (in big thumbnail space) to MWG-RS
     normalized center-based coords."""
@@ -63,7 +87,7 @@ def reverse_orientation_transform(x, y, w, h, orientation):
         new_y = x
         w, h = h, w
         return new_x, new_y, w, h
-    # Normal orientation or unknown — no transform
+    # Normal orientation or unknown Ã¢â‚¬â€ no transform
     return x, y, w, h
 
 

--- a/apps/backend/api/migrations/0128_user_scrub_face_region_tags_on_delete.py
+++ b/apps/backend/api/migrations/0128_user_scrub_face_region_tags_on_delete.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0127_migrate_photon_provider_robustly"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="scrub_face_region_tags_on_delete",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/backend/api/models/user.py
+++ b/apps/backend/api/models/user.py
@@ -78,6 +78,7 @@ class User(AbstractUser):
         choices=SaveMetadata.choices, default=SaveMetadata.OFF
     )
     save_face_tags_to_disk = models.BooleanField(default=False)
+    scrub_face_region_tags_on_delete = models.BooleanField(default=False)
     llm_settings = models.JSONField(default=get_default_llm_settings)
     datetime_rules = models.JSONField(default=get_default_config_datetime_rules)
     burst_detection_rules = models.JSONField(

--- a/apps/backend/api/serializers/user.py
+++ b/apps/backend/api/serializers/user.py
@@ -37,6 +37,7 @@ class UserSerializer(serializers.ModelSerializer):
             "favorite_min_rating": {"required": False},
             "save_metadata_to_disk": {"required": False},
             "save_face_tags_to_disk": {"required": False},
+            "scrub_face_region_tags_on_delete": {"required": False},
             "text_alignment": {"required": False},
             "header_size": {"required": False},
             "skip_raw_files": {"required": False},
@@ -74,6 +75,7 @@ class UserSerializer(serializers.ModelSerializer):
             "header_size",
             "save_metadata_to_disk",
             "save_face_tags_to_disk",
+            "scrub_face_region_tags_on_delete",
             "datetime_rules",
             "burst_detection_rules",
             "llm_settings",
@@ -205,6 +207,14 @@ class UserSerializer(serializers.ModelSerializer):
             instance.save()
             logger.info(
                 f"Updated save_face_tags_to_disk to {instance.save_face_tags_to_disk} for user {instance.username}"
+            )
+        if "scrub_face_region_tags_on_delete" in validated_data:
+            instance.scrub_face_region_tags_on_delete = validated_data.pop(
+                "scrub_face_region_tags_on_delete"
+            )
+            instance.save()
+            logger.info(
+                f"Updated scrub_face_region_tags_on_delete to {instance.scrub_face_region_tags_on_delete} for user {instance.username}"
             )
         if "image_scale" in validated_data:
             new_image_scale = validated_data.pop("image_scale")

--- a/apps/backend/api/tests/test_face_writeback.py
+++ b/apps/backend/api/tests/test_face_writeback.py
@@ -1,11 +1,14 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
+from rest_framework.test import APIClient
 
 from api.metadata.face_regions import (
+    REGION_TAGS_TO_SCRUB,
     build_face_region_exiftool_args,
     get_face_region_tags,
     reverse_orientation_transform,
+    scrub_face_region_tags,
     thumbnail_coords_to_normalized,
 )
 from api.models.person import Person
@@ -571,3 +574,83 @@ class TestSaveMetadataIntegration(TestCase):
         self.assertEqual(tags["Rating"], 5)
         self.assertIn("XMP-mwg-rs:RegionInfo", tags)
         self.assertIn("Alice", tags["XMP-mwg-rs:RegionInfo"])
+
+
+class TestScrubFaceRegionTags(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    @patch("api.metadata.writer.write_metadata")
+    def test_scrub_face_region_tags_clears_known_region_containers(
+        self, mock_write_metadata
+    ):
+        photo = create_test_photo(owner=self.user)
+
+        scrub_face_region_tags(photo, use_sidecar=False)
+
+        mock_write_metadata.assert_called_once_with(
+            photo.main_file.path,
+            {tag: "" for tag in REGION_TAGS_TO_SCRUB},
+            use_sidecar=False,
+        )
+
+
+class TestDeleteFacesScrub(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+        self.photo = create_test_photo(owner=self.user)
+        self.face = create_test_face(photo=self.photo)
+
+    @patch("api.views.faces.scrub_face_region_tags")
+    def test_delete_faces_scrubs_region_tags_when_enabled(self, mock_scrub):
+        self.user.scrub_face_region_tags_on_delete = True
+        self.user.save()
+
+        response = self.client.post(
+            "/api/deletefaces",
+            {"face_ids": [self.face.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertTrue(self.face.deleted)
+        mock_scrub.assert_called_once_with(self.photo, use_sidecar=False)
+
+    @patch("api.views.faces.scrub_face_region_tags")
+    def test_delete_faces_does_not_scrub_region_tags_by_default(self, mock_scrub):
+        response = self.client.post(
+            "/api/deletefaces",
+            {"face_ids": [self.face.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertTrue(self.face.deleted)
+        mock_scrub.assert_not_called()
+
+    @patch("api.models.photo.Photo._save_metadata")
+    @patch("api.views.faces.scrub_face_region_tags")
+    def test_delete_faces_rewrites_remaining_face_tags_when_enabled(
+        self, mock_scrub, mock_save_metadata
+    ):
+        self.user.scrub_face_region_tags_on_delete = True
+        self.user.save_face_tags_to_disk = True
+        self.user.save_metadata_to_disk = "SIDECAR_FILE"
+        self.user.save()
+
+        response = self.client.post(
+            "/api/deletefaces",
+            {"face_ids": [self.face.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_scrub.assert_called_once_with(self.photo, use_sidecar=True)
+        mock_save_metadata.assert_called_once_with(
+            use_sidecar=True,
+            metadata_types=["face_tags"],
+        )

--- a/apps/backend/api/tests/test_user.py
+++ b/apps/backend/api/tests/test_user.py
@@ -71,6 +71,7 @@ class UserTest(TestCase):
         "text_alignment",
         "header_size",
         "save_face_tags_to_disk",
+        "scrub_face_region_tags_on_delete",
         "public_sharing_defaults",
     ]
 

--- a/apps/backend/api/views/faces.py
+++ b/apps/backend/api/views/faces.py
@@ -11,6 +11,7 @@ from rest_framework.views import APIView
 from api.directory_watcher import generate_face_embeddings, scan_faces
 from api.face_classify import cluster_all_faces
 from api.ml_models import do_all_models_exist, download_models
+from api.metadata.face_regions import scrub_face_region_tags
 from api.models import Face, User
 from api.models.person import Person, get_or_create_person
 from api.models.photo_search import PhotoSearch
@@ -315,13 +316,32 @@ class DeleteFaces(APIView):
 
         deleted = []
         not_deleted = []
+        updated_photos = set()
         for face in faces.values():
             if face.photo.owner == request.user:
                 deleted.append(face.image.url)
                 face.deleted = True
                 face.save()
+                updated_photos.add(face.photo)
             else:
                 not_deleted.append(face.image.url)
+
+        if request.user.scrub_face_region_tags_on_delete:
+            use_sidecar = (
+                request.user.save_metadata_to_disk == User.SaveMetadata.SIDECAR_FILE
+            )
+            for photo in updated_photos:
+                try:
+                    scrub_face_region_tags(photo, use_sidecar=use_sidecar)
+                    if request.user.save_face_tags_to_disk:
+                        photo._save_metadata(
+                            use_sidecar=use_sidecar,
+                            metadata_types=["face_tags"],
+                        )
+                except Exception:
+                    logger.exception(
+                        f"Failed to scrub face region tags for photo {photo.image_hash}"
+                    )
 
         return Response(
             {

--- a/apps/frontend/src/api_client/user/types.ts
+++ b/apps/frontend/src/api_client/user/types.ts
@@ -44,6 +44,7 @@ export const User = z.object({
   image_scale: z.number(),
   save_metadata_to_disk: z.string(),
   save_face_tags_to_disk: z.boolean().default(false),
+  scrub_face_region_tags_on_delete: z.boolean().default(false),
   datetime_rules: z.string(),
   burst_detection_rules: z.any().optional(), // JSON array of burst detection rules
   default_timezone: z.string(),

--- a/apps/frontend/src/components/settings/Settings.tsx
+++ b/apps/frontend/src/components/settings/Settings.tsx
@@ -258,6 +258,17 @@ export function Settings() {
               });
             }}
           />
+          <Switch
+            label={t("settings.scrub_face_region_tags_on_delete")}
+            description={t("settings.scrub_face_region_tags_on_delete_help")}
+            checked={editedUserDetails.scrub_face_region_tags_on_delete || false}
+            onChange={event => {
+              setEditedUserDetails({
+                ...editedUserDetails,
+                scrub_face_region_tags_on_delete: event.currentTarget.checked,
+              });
+            }}
+          />
         </Card>
         <Card shadow="md">
           <ConfigDateTime

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -220,6 +220,8 @@
     "cluster_selection_epsilon_help": "Determines which clusters get merged. A higher value means more clusters will be merged.",
     "save_face_tags_to_disk": "Write face tags to image files",
     "save_face_tags_to_disk_help": "When enabled, face labels are written as XMP MWG-RS region tags to your image files (or sidecar files) whenever you label a face. This makes face data portable across photo management software like Lightroom, Digikam, and XnView.",
+    "scrub_face_region_tags_on_delete": "Scrub face regions when deleting faces",
+    "scrub_face_region_tags_on_delete_help": "When enabled, deleting a face also removes existing XMP face region metadata from the image file or sidecar. This can clear incorrect regions imported from tools like Digikam.",
     "llm": "Large Language Model Settings",
     "enablellm": "Enable Large Language Model For Captions",
     "addperson": "Add Persons to the Captions",


### PR DESCRIPTION
Implemented issue #1531.

  What i changed:=

  - Added user setting `scrub_face_region_tags_on_delete`.
  - Added Settings UI switch: “Scrub face regions when deleting faces”.
  - When deleting faces, LibrePhotos now optionally clears known XMP face-region containers from the image file or sidecar.
  - If `save_face_tags_to_disk` is also enabled, it scrubs first, then rewrites remaining LibrePhotos face tags.

  Verification:-

  Passed:

  - `python -m py_compile ...`
  - `python -m json.tool apps/frontend/src/locales/en/translation.json`
  - `git diff --check`

  Blocked locally:

  - Django tests: `No module named 'django'`
  - Ruff: `No module named ruff`
  - Frontend lint/build: `apps/frontend/node_modules` is missing