### PR TITLE
fix: scope Select All to the album on surfaces without a server-side query

### DIFF
--- a/apps/frontend/src/components/photolist/SelectionBar.tsx
+++ b/apps/frontend/src/components/photolist/SelectionBar.tsx
@@ -44,30 +44,34 @@ export function SelectionBar(props: Readonly<Props>) {
             onMouseLeave={() => setOpenedAll(false)}
             variant="light"
             onClick={() => {
-              if (selectAllMode) {
-                // Deselect all - exit select all mode
+              if (selectAllMode || (idx2hash.length > 0 && selectedItems.length === idx2hash.length)) {
+                // Already fully selected (server-side or every loaded item) - deselect
                 updateSelectionState({
                   selectMode: false,
                   selectAllMode: false,
                   selectedItems: [],
                   selectAllQuery: undefined,
                 });
-              } else if (selectedItems.length === idx2hash.length) {
-                // All currently loaded items selected - deselect
-                updateSelectionState({
-                  selectMode: false,
-                  selectAllMode: false,
-                  selectedItems: [],
-                  selectAllQuery: undefined,
-                });
-              } else {
-                // Select all - use server-side mode
+              } else if (photosetQuery) {
+                // Surface supplies a server-side query (it may lazily page in items
+                // beyond those loaded, e.g. the timeline / person albums). Select all
+                // via the query; selectedItems here tracks exclusions.
                 updateSelectionState({
                   selectMode: true,
                   selectAllMode: true,
-                  selectedItems: [], // Empty - server handles it, items here are exclusions
+                  selectedItems: [],
                   selectAllQuery: photosetQuery,
                   totalCount,
+                });
+              } else {
+                // No server-side query (thing/place/user albums, search): the full set
+                // is already loaded, so select every loaded item client-side. Avoids the
+                // empty-query fallback that would otherwise match the whole library.
+                updateSelectionState({
+                  selectMode: true,
+                  selectAllMode: false,
+                  selectedItems: idx2hash.filter(item => !item.isTemp),
+                  selectAllQuery: undefined,
                 });
               }
             }}

--- a/apps/frontend/src/routes/_protected/album/folder.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/folder.$id.tsx
@@ -425,6 +425,7 @@ export function FolderDetail() {
       photoset={photosGroupedByDate ?? []}
       updateGroups={getAlbums}
       idx2hash={photosFlat}
+      photosetQuery={{ folder: folderPath }}
       selectable
     />
   );


### PR DESCRIPTION
Choosing "Select All" in a thing, place or user album — or in search results — put the toolbar into server-side select-all mode with no query behind it. Those surfaces never supply a `photosetQuery`, so the bulk actions fell back to an empty query `{}`, which `build_photo_queryset` resolves to the user's entire library. The visible symptoms: "Select All" then Download zipped every photo the user owns rather than the album, the selection counter read "0 photo(s)", and Add-to-album silently added nothing — the modal reads the empty exclusion list that server-side mode keeps in `selectedItems`.

These album-detail and search surfaces load their full photo set in a single response, so there is nothing to page in server-side. "Select All" now selects every loaded item client-side on any surface that supplies no `photosetQuery`, which routes Download, Add-to-album, Favorite, Hide and Delete through the same image-hash path that manual multi-selection already uses. Surfaces that do supply a query — the timeline, `/photos`, `/videos`, favorites, hidden, trashcan and person albums — keep their existing server-side behavior unchanged.

Folders were the one lazily-paged surface also missing its query, so they now pass `photosetQuery={{ folder }}`; the backend `build_photo_queryset` already supports the `folder` filter, so folder select-all is complete rather than falling back to the whole library.

Verified in the browser against a 41-photo user album: the counter reads the real count, Download produces a 41-item zip of the album, and Add-to-album adds the album's photos. A server-side surface (the main timeline) still selects everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
