### PR TITLE
fix: Add-to-album / Create-album act on 0 photos under server-side Select All

### DIFF
--- a/apps/backend/api/serializers/album_user.py
+++ b/apps/backend/api/serializers/album_user.py
@@ -5,6 +5,7 @@ from api.serializers.photos import GroupedPhotosSerializer
 from api.serializers.PhotosGroupedByDate import get_photos_ordered_by_date
 from api.serializers.simple import PhotoSuperSimpleSerializer, SimpleUserSerializer
 from api.util import logger
+from api.views.photo_filters import build_photo_queryset
 
 
 class AlbumUserSerializer(serializers.ModelSerializer):
@@ -95,6 +96,19 @@ class AlbumUserEditSerializer(serializers.ModelSerializer):
         write_only=True,
         required=False,
     )
+    # Server-side "Select All" payload, mirroring the other bulk endpoints
+    # (SetPhotosDeleted, ZipListPhotosView_V2, ...): instead of an explicit
+    # `photos` list, `select_all=True` plus a `query` describing the photoset
+    # the user is looking at, with optional `excluded_hashes` for unchecked items.
+    select_all = serializers.BooleanField(
+        write_only=True, required=False, default=False
+    )
+    query = serializers.DictField(write_only=True, required=False)
+    excluded_hashes = serializers.ListField(
+        child=serializers.CharField(max_length=100),
+        write_only=True,
+        required=False,
+    )
 
     class Meta:
         model = AlbumUser
@@ -106,11 +120,26 @@ class AlbumUserEditSerializer(serializers.ModelSerializer):
             "favorited",
             "removedPhotos",
             "cover_photo",
+            "select_all",
+            "query",
+            "excluded_hashes",
         )
+
+    def _resolve_new_photo_pks(self, validated_data):
+        """Resolve the photos to add: the explicit list, or the select-all query."""
+        if validated_data.get("select_all"):
+            request = self.context.get("request")
+            photos = build_photo_queryset(
+                request.user, validated_data.get("query") or {}
+            )
+            excluded_hashes = validated_data.get("excluded_hashes") or []
+            if excluded_hashes:
+                photos = photos.exclude(image_hash__in=excluded_hashes)
+            return list(photos.values_list("id", flat=True))
+        return [photo.id for photo in validated_data.get("photos", [])]
 
     def create(self, validated_data):
         title = validated_data["title"]
-        photos = validated_data["photos"]
 
         user = None
         request = self.context.get("request")
@@ -122,10 +151,11 @@ class AlbumUserEditSerializer(serializers.ModelSerializer):
         if not created:
             return self.update(instance, validated_data)
 
-        for photo in photos:
-            instance.photos.add(photo)
+        photo_pks = self._resolve_new_photo_pks(validated_data)
+        if photo_pks:
+            instance.photos.add(*photo_pks)
         instance.save()
-        logger.info(f"Created user album {instance.id} with {len(photos)} photos")
+        logger.info(f"Created user album {instance.id} with {len(photo_pks)} photos")
         return instance
 
     def update(self, instance, validated_data):
@@ -150,16 +180,14 @@ class AlbumUserEditSerializer(serializers.ModelSerializer):
             instance.cover_photo = cover_photo
             logger.info(f"Changed cover photo to {cover_photo}")
 
-        if "photos" in validated_data.keys():
-            photos = validated_data["photos"]
-            photos_already_in_album = instance.photos.all()
-            cnt = 0
-            for photo in photos:
-                if photo not in photos_already_in_album:
-                    cnt += 1
-                    instance.photos.add(photo)
+        if "photos" in validated_data.keys() or validated_data.get("select_all"):
+            photo_pks = self._resolve_new_photo_pks(validated_data)
+            already_in_album = set(instance.photos.values_list("id", flat=True))
+            new_pks = [pk for pk in photo_pks if pk not in already_in_album]
+            if new_pks:
+                instance.photos.add(*new_pks)
 
-            logger.info(f"Added {cnt} photos to user album {instance.id}")
+            logger.info(f"Added {len(new_pks)} photos to user album {instance.id}")
 
         instance.save()
         return instance

--- a/apps/backend/api/tests/test_bulk_operations.py
+++ b/apps/backend/api/tests/test_bulk_operations.py
@@ -437,3 +437,131 @@ class BulkSharePhotosTest(TestCase):
             user_id=self.user2.id, photo_id=photos[0].id
         ).exists()
         self.assertFalse(excluded_shared)
+
+
+class UserAlbumSelectAllTest(TestCase):
+    """Tests for creating / adding to user albums with select_all mode."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user1 = create_test_user()
+        self.user2 = create_test_user()
+        self.client.force_authenticate(user=self.user1)
+
+    def _album_photo_ids(self, album_id):
+        from api.models import AlbumUser
+
+        return set(
+            AlbumUser.objects.get(id=album_id).photos.values_list("id", flat=True)
+        )
+
+    def test_create_album_select_all(self):
+        """Creating an album with select_all adds every photo matching the query."""
+        photos = create_test_photos(number_of_photos=5, owner=self.user1)
+
+        payload = {
+            "title": "everything",
+            "photos": [],
+            "select_all": True,
+            "query": {},
+        }
+        response = self.client.post(
+            "/api/albums/user/edit/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 201)
+
+        album_id = response.json()["id"]
+        self.assertEqual(
+            self._album_photo_ids(album_id), {photo.id for photo in photos}
+        )
+
+    def test_create_album_select_all_respects_media_type(self):
+        """The media-type filter (photo/video) in the query limits the selection."""
+        stills = create_test_photos(number_of_photos=2, owner=self.user1, video=False)
+        videos = create_test_photos(number_of_photos=3, owner=self.user1, video=True)
+
+        payload = {
+            "title": "only videos",
+            "photos": [],
+            "select_all": True,
+            "query": {"video": True},
+        }
+        response = self.client.post(
+            "/api/albums/user/edit/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 201)
+        album_id = response.json()["id"]
+        self.assertEqual(
+            self._album_photo_ids(album_id), {video.id for video in videos}
+        )
+
+        payload = {
+            "title": "only photos",
+            "photos": [],
+            "select_all": True,
+            "query": {"photo": True},
+        }
+        response = self.client.post(
+            "/api/albums/user/edit/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 201)
+        album_id = response.json()["id"]
+        self.assertEqual(
+            self._album_photo_ids(album_id), {still.id for still in stills}
+        )
+
+    def test_add_to_album_select_all_with_exclusions(self):
+        """PATCHing an album with select_all adds the query result minus exclusions."""
+        from api.models import AlbumUser
+
+        photos = create_test_photos(number_of_photos=5, owner=self.user1)
+        album = AlbumUser.objects.create(title="existing", owner=self.user1)
+        album.photos.add(photos[0])
+
+        payload = {
+            "title": "existing",
+            "photos": [],
+            "select_all": True,
+            "query": {},
+            "excluded_hashes": [photos[4].image_hash],
+        }
+        response = self.client.patch(
+            f"/api/albums/user/edit/{album.id}/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self._album_photo_ids(album.id), {photo.id for photo in photos[:4]}
+        )
+
+    def test_select_all_scoped_to_owner(self):
+        """select_all with an empty query only picks up the requesting user's photos."""
+        mine = create_test_photos(number_of_photos=2, owner=self.user1)
+        create_test_photos(number_of_photos=3, owner=self.user2)
+
+        payload = {
+            "title": "mine only",
+            "photos": [],
+            "select_all": True,
+            "query": {},
+        }
+        response = self.client.post(
+            "/api/albums/user/edit/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 201)
+        album_id = response.json()["id"]
+        self.assertEqual(self._album_photo_ids(album_id), {photo.id for photo in mine})
+
+    def test_explicit_photo_list_still_works(self):
+        """The pre-existing explicit `photos` payload keeps working unchanged."""
+        photos = create_test_photos(number_of_photos=3, owner=self.user1)
+
+        payload = {
+            "title": "explicit",
+            "photos": [str(photos[0].id), str(photos[1].id)],
+        }
+        response = self.client.post(
+            "/api/albums/user/edit/", format="json", data=payload
+        )
+        self.assertEqual(response.status_code, 201)
+        album_id = response.json()["id"]
+        self.assertEqual(self._album_photo_ids(album_id), {photos[0].id, photos[1].id})

--- a/apps/frontend/src/api_client/albums/hooks/useAddPhotoToUserAlbumMutation.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useAddPhotoToUserAlbumMutation.ts
@@ -7,9 +7,20 @@ import { UserAlbumsQueryKeys } from "./useFetchUserAlbumsQuery";
 
 export const useAddPhotoToUserAlbumMutation = () =>
   useMutation({
-    mutationFn: async ({ id, title, photos }: AddPhotoFromUserAlbumParams) => {
-      await fetchClient.patch(`/albums/user/edit/${id}/`, { title, photos });
-      notification.addPhotosToAlbum(title, photos.length);
+    mutationFn: async ({
+      id,
+      title,
+      photos,
+      select_all,
+      query,
+      excluded_hashes,
+      photoCount,
+    }: AddPhotoFromUserAlbumParams) => {
+      const body = select_all
+        ? { title, photos: [], select_all: true, query: query ?? {}, excluded_hashes: excluded_hashes ?? [] }
+        : { title, photos };
+      await fetchClient.patch(`/albums/user/edit/${id}/`, body);
+      notification.addPhotosToAlbum(title, photoCount ?? photos.length);
     },
     onSuccess: (_, { id }) => {
       // Invalidate relevant queries

--- a/apps/frontend/src/api_client/albums/hooks/useCreateUserAlbumMutation.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useCreateUserAlbumMutation.ts
@@ -6,9 +6,12 @@ import { UserAlbumsQueryKeys } from "./useFetchUserAlbumsQuery";
 
 export const useCreateUserAlbumMutation = () =>
   useMutation({
-    mutationFn: async ({ title, photos }: CreateUserAlbumParams) => {
-      await fetchClient.post(`/albums/user/edit/`, { title, photos });
-      notification.createAlbum(title, photos.length);
+    mutationFn: async ({ title, photos, select_all, query, excluded_hashes, photoCount }: CreateUserAlbumParams) => {
+      const body = select_all
+        ? { title, photos: [], select_all: true, query: query ?? {}, excluded_hashes: excluded_hashes ?? [] }
+        : { title, photos };
+      await fetchClient.post(`/albums/user/edit/`, body);
+      notification.createAlbum(title, photoCount ?? photos.length);
     },
     onSuccess: () => {
       // Invalidate relevant queries

--- a/apps/frontend/src/api_client/albums/types.ts
+++ b/apps/frontend/src/api_client/albums/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { BulkPhotoQuery } from "../photos/types";
 import { DatePhotosGroup, IncompleteDatePhotosGroup, PhotoHash, SimpleUser } from "../photos/types";
 
 const UserAlbumResponse = z.object({
@@ -32,7 +33,17 @@ export type RenameUserAlbumParams = {
   newTitle: string;
 };
 
-export type CreateUserAlbumParams = {
+// Server-side "Select All": instead of listing every photo id, send the query
+// describing the photoset plus exclusions, mirroring the other bulk mutations.
+// `photoCount` is display-only (the notification), since `photos` is empty then.
+export type SelectAllAlbumFields = {
+  select_all?: boolean;
+  query?: BulkPhotoQuery;
+  excluded_hashes?: string[];
+  photoCount?: number;
+};
+
+export type CreateUserAlbumParams = SelectAllAlbumFields & {
   title: string;
   photos: string[];
 };
@@ -43,7 +54,7 @@ export type RemovePhotoFromUserAlbumParams = {
   photos: string[];
 };
 
-export type AddPhotoFromUserAlbumParams = {
+export type AddPhotoFromUserAlbumParams = SelectAllAlbumFields & {
   id: string;
   title: string;
   photos: string[];

--- a/apps/frontend/src/components/modals/AlbumEdit/AlbumEditModal.tsx
+++ b/apps/frontend/src/components/modals/AlbumEdit/AlbumEditModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Group, Modal, Stack, Text, TextInput, Title, UnstyledButton } from "@mantine/core";
+import { Badge, Button, Divider, Group, Modal, Stack, Text, TextInput, Title, UnstyledButton } from "@mantine/core";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -6,6 +6,8 @@ import {
   useCreateUserAlbumMutation,
   useFetchUserAlbumsQuery,
 } from "../../../api_client/albums/hooks";
+import type { SelectAllAlbumFields } from "../../../api_client/albums/types";
+import type { BulkPhotoQuery } from "../../../api_client/photos/types";
 import { fuzzyMatch } from "../../../util/util";
 import { AlbumListItem } from "../../album/AlbumListItem";
 import { Tile } from "../../Tile";
@@ -14,16 +16,32 @@ import classes from "./AlbumEditModal.module.css";
 type Props = Readonly<{
   isOpen: boolean;
   onRequestClose: () => void;
+  // In select-all mode this holds the EXCLUDED items, not the selection.
   selectedImages: any[];
+  selectAllMode?: boolean;
+  selectAllQuery?: BulkPhotoQuery;
+  totalCount?: number;
 }>;
 
 export function AlbumEditModal(props: Props) {
   const [newAlbumTitle, setNewAlbumTitle] = useState("");
-  const { isOpen, onRequestClose, selectedImages } = props;
+  const { isOpen, onRequestClose, selectedImages, selectAllMode = false, selectAllQuery, totalCount } = props;
   const { t } = useTranslation();
   const { data: albumsUserList = [] } = useFetchUserAlbumsQuery();
   const createUserAlbum = useCreateUserAlbumMutation();
   const addPhotoToUserAlbum = useAddPhotoToUserAlbumMutation();
+
+  const excludedHashes = selectAllMode ? selectedImages.map(i => i.image_hash) : [];
+  const effectiveCount = selectAllMode ? Math.max(0, (totalCount ?? 0) - selectedImages.length) : selectedImages.length;
+
+  // The server resolves select-all through the same query the view uses (incl.
+  // the photos/videos filter), so the payload matches exactly what is on screen.
+  const selectAllFields: SelectAllAlbumFields = {
+    select_all: true,
+    query: selectAllQuery ?? {},
+    excluded_hashes: excludedHashes,
+    photoCount: effectiveCount,
+  };
 
   return (
     <Modal
@@ -36,19 +54,26 @@ export function AlbumEditModal(props: Props) {
       }}
     >
       <Stack>
-        <Text c="dimmed">{t("modalalbum.selectedimages", { count: selectedImages.length })}</Text>
-        <Group>
-          {selectedImages.map(image => (
-            <Tile
-              key={`si-${image.id}`}
-              className={classes.tile}
-              height={40}
-              width={40}
-              image_hash={image.image_hash}
-              video={image.type === "video"}
-            />
-          ))}
-        </Group>
+        <Text c="dimmed">{t("modalalbum.selectedimages", { count: effectiveCount })}</Text>
+        {selectAllMode ? (
+          <Badge color="blue" size="lg" variant="light">
+            {t("selectionbar.all")} {effectiveCount} {t("selectionbar.selected")}
+            {excludedHashes.length > 0 && ` (${excludedHashes.length} ${t("selectionbar.excluded")})`}
+          </Badge>
+        ) : (
+          <Group>
+            {selectedImages.map(image => (
+              <Tile
+                key={`si-${image.id}`}
+                className={classes.tile}
+                height={40}
+                width={40}
+                image_hash={image.image_hash}
+                video={image.type === "video"}
+              />
+            ))}
+          </Group>
+        )}
         <Divider />
         <Title order={4}>{t("modalalbum.newalbum")}</Title>
         <Group>
@@ -67,7 +92,8 @@ export function AlbumEditModal(props: Props) {
             onClick={() => {
               createUserAlbum.mutate({
                 title: newAlbumTitle,
-                photos: selectedImages.map(i => i.id),
+                photos: selectAllMode ? [] : selectedImages.map(i => i.id),
+                ...(selectAllMode ? selectAllFields : {}),
               });
               onRequestClose();
               setNewAlbumTitle("");
@@ -91,7 +117,8 @@ export function AlbumEditModal(props: Props) {
                   addPhotoToUserAlbum.mutate({
                     id: `${item.id}`,
                     title: item.title,
-                    photos: selectedImages.map(i => i.id),
+                    photos: selectAllMode ? [] : selectedImages.map(i => i.id),
+                    ...(selectAllMode ? selectAllFields : {}),
                   });
                   onRequestClose();
                 }}

--- a/apps/frontend/src/components/photolist/PhotoListView.tsx
+++ b/apps/frontend/src/components/photolist/PhotoListView.tsx
@@ -753,9 +753,17 @@ function PhotoListViewComponent({
           isOpen={modalAddToAlbumOpen}
           onRequestClose={() => {
             setModalAddToAlbumOpen(false);
-            updateSelectionState({ selectedItems: [], selectMode: false });
+            updateSelectionState({
+              selectedItems: [],
+              selectMode: false,
+              selectAllMode: false,
+              selectAllQuery: undefined,
+            });
           }}
           selectedImages={selectionState.selectedItems}
+          selectAllMode={selectionState.selectAllMode}
+          selectAllQuery={selectionState.selectAllQuery}
+          totalCount={selectionState.totalCount || numberOfItems || idx2hash.length}
         />
       )}
       {!isPublic && (

--- a/apps/frontend/src/components/photolist/SelectionActions.tsx
+++ b/apps/frontend/src/components/photolist/SelectionActions.tsx
@@ -530,13 +530,6 @@ export function SelectionActions(props: Readonly<Props>) {
           )}
         </Menu.Dropdown>
       </Menu>
-
-      <ModalDownloadOptions
-        isOpen={isDownloadModalOpen}
-        photoCount={getImageHashes().length}
-        onRequestClose={() => setIsDownloadModalOpen(false)}
-        onConfirm={handleDownloadConfirm}
-      />
     </Group>
   );
 }


### PR DESCRIPTION
On surfaces that supply a server-side photoset query (the timeline, favorites, hidden, folders, person albums, `/photos`, `/videos`), Select All stores the query and tracks *exclusions* instead of building an id list, and every bulk action — favorite, hide, make public, delete, share, download (#1851) — sends that `select_all + query + excluded_hashes` payload to the server. The one action that never learned this shape is adding photos to a user album: `AlbumEditModal` kept sending `photos: selectedItems.map(...)`, and in select-all mode `selectedItems` is the (usually empty) exclusion list. So "create album" and "add to existing album" silently act on **0 photos** — and if the user had unticked a few items, exactly those excluded photos would be added instead. #1894 covers the surfaces *without* a server-side query by keeping them client-side; this PR fixes the server-side ones.

The album-edit endpoint now accepts the same payload shape as the other bulk mutations: `AlbumUserEditSerializer` takes optional write-only `select_all` / `query` / `excluded_hashes` fields and resolves them through `build_photo_queryset` — the same helper the other bulk endpoints use, so whatever the view's query filters on (favorites, person, folder, photo/video) is honored exactly, and an empty query can never reach beyond the requesting user's own photos. On the frontend, `AlbumEditModal` receives the select-all state from `PhotoListView`, shows the real count ("All N selected, M excluded") instead of an empty thumbnail strip, and both album mutations send the query payload. Closing the modal now also fully resets the select-all state; it previously left `selectAllMode` set with cleared exclusions.

While there, the serializer's per-photo `photos.add(photo)` loop is replaced with a single bulk `add(*pks)` after one existing-ids query. For small albums this is behaviorally identical (same photos added, same log line); for a select-all add of a large library it avoids one insert round-trip per photo.

This also removes a duplicated `<ModalDownloadOptions>` at the bottom of `SelectionActions`: both copies were bound to the same open state, and the second computed its count with the non-select-all helper, so in select-all mode a dialog claiming "You have selected 0 photo(s)" rendered on top of the correct one. The download payload itself was always right — only the display lied.

Five new tests in `test_bulk_operations.py` cover create and add via `select_all`, media-type-filtered queries, exclusions, owner scoping, and the unchanged explicit-list payload. Verified in the browser on a dev-stack library: select-all add-to-album from the timeline, favorites, folders, and person albums now adds the exact on-screen set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
