### PR TITLE
feat: All / Photos / Videos filter on search, user, place, thing and person albums

### DIFF
--- a/apps/frontend/src/api_client/albums/hooks/useFetchDateAlbumQuery.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useFetchDateAlbumQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient, queryClient } from "../../api";
 import { IncompleteDatePhotosGroup, Photoset } from "../../photos/types";
@@ -12,6 +13,7 @@ type AlbumDateOption = {
   username?: string;
   person_id?: number;
   folder?: string;
+  mediaType?: MediaType;
 };
 
 export const DateAlbumQueryKeys = ["dateAlbum"];
@@ -27,6 +29,7 @@ export const useFetchDateAlbumQuery = (options: AlbumDateOption, queryOptions?: 
       options.person_id,
       options.username,
       options.folder,
+      options.mediaType ?? "all",
     ],
     queryFn: async () => {
       const params = {
@@ -34,8 +37,8 @@ export const useFetchDateAlbumQuery = (options: AlbumDateOption, queryOptions?: 
         public: Photoset.PUBLIC === options.photosetType ? "true" : undefined,
         hidden: Photoset.HIDDEN === options.photosetType ? "true" : undefined,
         in_trashcan: Photoset.IN_TRASHCAN === options.photosetType ? "true" : undefined,
-        photo: Photoset.PHOTOS === options.photosetType ? "true" : undefined,
-        video: Photoset.VIDEOS === options.photosetType ? "true" : undefined,
+        photo: Photoset.PHOTOS === options.photosetType || options.mediaType === "photos" ? "true" : undefined,
+        video: Photoset.VIDEOS === options.photosetType || options.mediaType === "videos" ? "true" : undefined,
         page: options.page.toString(),
         person: options.person_id?.toString(),
         username: options.username?.toLowerCase(),
@@ -58,6 +61,7 @@ export const useFetchDateAlbumQuery = (options: AlbumDateOption, queryOptions?: 
         options.person_id,
         options.username,
         options.folder,
+        options.mediaType ?? "all",
       ];
       const oldData = queryClient.getQueryData(dateAlbumsQueryKey) as IncompleteDatePhotosGroup[] | undefined;
 

--- a/apps/frontend/src/api_client/albums/hooks/useFetchDateAlbumsQuery.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useFetchDateAlbumsQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { addTempElementsToGroups } from "../../../util/util";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
@@ -13,20 +14,30 @@ type AlbumDateListOptions = {
   person_id?: number;
   username?: string;
   folder?: string;
+  // Optional media-type filter, independent of photosetType (e.g. a person
+  // album filtered to videos). Combines with photosetType for photo/video.
+  mediaType?: MediaType;
 };
 
 // Fetch date albums
 export const useFetchDateAlbumsQuery = (options: AlbumDateListOptions) =>
   useQuery({
-    queryKey: [...DateAlbumsQueryKeys, options.photosetType, options.person_id, options.username, options.folder],
+    queryKey: [
+      ...DateAlbumsQueryKeys,
+      options.photosetType,
+      options.person_id,
+      options.username,
+      options.folder,
+      options.mediaType ?? "all",
+    ],
     queryFn: async () => {
       const params = {
         favorite: Photoset.FAVORITES === options.photosetType ? "true" : undefined,
         public: Photoset.PUBLIC === options.photosetType ? "true" : undefined,
         hidden: Photoset.HIDDEN === options.photosetType ? "true" : undefined,
         in_trashcan: Photoset.IN_TRASHCAN === options.photosetType ? "true" : undefined,
-        photo: Photoset.PHOTOS === options.photosetType ? "true" : undefined,
-        video: Photoset.VIDEOS === options.photosetType ? "true" : undefined,
+        photo: Photoset.PHOTOS === options.photosetType || options.mediaType === "photos" ? "true" : undefined,
+        video: Photoset.VIDEOS === options.photosetType || options.mediaType === "videos" ? "true" : undefined,
         person: options.person_id,
         username: options.username?.toLowerCase(),
         folder: options.folder,

--- a/apps/frontend/src/api_client/albums/hooks/useFetchPlaceAlbumQuery.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useFetchPlaceAlbumQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
+import { mediaTypeToParams, type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
 import { DatePhotosGroup } from "../../photos/types";
@@ -16,11 +17,13 @@ export type PlaceAlbum = z.infer<typeof PlaceAlbum>;
 
 const PlaceAlbumResponse = z.object({ results: PlaceAlbum });
 
-export const useFetchPlaceAlbumQuery = (albumId: string) =>
+export const useFetchPlaceAlbumQuery = (albumId: string, mediaType?: MediaType) =>
   useQuery({
-    queryKey: [...PlaceAlbumQueryKeys, albumId],
+    queryKey: [...PlaceAlbumQueryKeys, albumId, mediaType ?? "all"],
     queryFn: async () => {
-      const response = await fetchClient.get(`/albums/place/${albumId}/`);
+      const query = new URLSearchParams(mediaTypeToParams(mediaType));
+      const suffix = query.toString() ? `?${query.toString()}` : "";
+      const response = await fetchClient.get(`/albums/place/${albumId}/${suffix}`);
       return parseWithNotification(PlaceAlbumResponse, response, "Failed to parse place album").results;
     },
     enabled: !!albumId,

--- a/apps/frontend/src/api_client/albums/hooks/useFetchThingsAlbumQuery.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useFetchThingsAlbumQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
+import { mediaTypeToParams, type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
 import { DatePhotosGroup } from "../../photos/types";
@@ -18,11 +19,13 @@ const ThingsAlbumResponse = z.object({
 
 export const ThingsAlbumQueryKeys = ["thingsAlbum"] as const;
 
-export const useFetchThingsAlbumQuery = (id: string) =>
+export const useFetchThingsAlbumQuery = (id: string, mediaType?: MediaType) =>
   useQuery({
-    queryKey: [...ThingsAlbumQueryKeys, id],
+    queryKey: [...ThingsAlbumQueryKeys, id, mediaType ?? "all"],
     queryFn: async () => {
-      const response = await fetchClient.get(`/albums/thing/${id}/`);
+      const query = new URLSearchParams(mediaTypeToParams(mediaType));
+      const suffix = query.toString() ? `?${query.toString()}` : "";
+      const response = await fetchClient.get(`/albums/thing/${id}/${suffix}`);
       return parseWithNotification(ThingsAlbumResponse, response, "Failed to parse things album").results;
     },
     enabled: !!id,

--- a/apps/frontend/src/api_client/albums/hooks/useFetchUserAlbumQuery.ts
+++ b/apps/frontend/src/api_client/albums/hooks/useFetchUserAlbumQuery.ts
@@ -1,16 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
+import { mediaTypeToParams, type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
 import { UserAlbum } from "../types";
 
 export const UserAlbumQueryKeys = ["userAlbum"] as const;
 
-export const useFetchUserAlbumQuery = (id: string, opts?: { public?: boolean; username?: string }) =>
+export const useFetchUserAlbumQuery = (
+  id: string,
+  opts?: { public?: boolean; username?: string; mediaType?: MediaType }
+) =>
   useQuery({
-    queryKey: [...UserAlbumQueryKeys, id, opts?.public ?? false, opts?.username ?? ""],
+    queryKey: [...UserAlbumQueryKeys, id, opts?.public ?? false, opts?.username ?? "", opts?.mediaType ?? "all"],
     enabled: Boolean(id),
     queryFn: async () => {
-      const query = new URLSearchParams();
+      const query = new URLSearchParams(mediaTypeToParams(opts?.mediaType));
       if (opts?.public) query.set("public", "true");
       if (opts?.username) query.set("username", opts.username);
       const suffix = query.toString() ? `?${query.toString()}` : "";

--- a/apps/frontend/src/api_client/search/hooks/useSearchPhotosQuery.ts
+++ b/apps/frontend/src/api_client/search/hooks/useSearchPhotosQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { mediaTypeToParams, type MediaType } from "../../../components/photolist/mediaTypeFilter";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { fetchClient } from "../../api";
 import { useCurrentUserSelfDetailsQuery } from "../../user/hooks/useCurrentUserSelfDetailsQuery";
@@ -6,13 +7,14 @@ import { SearchPhotos, SearchPhotosResult, SemanticSearchPhotos } from "../types
 
 export const SearchPhotosQueryKeys = ["searchPhotos"] as const;
 
-export const useSearchPhotosQuery = (searchTerm: string) => {
+export const useSearchPhotosQuery = (searchTerm: string, mediaType?: MediaType) => {
   const { data: currentUser } = useCurrentUserSelfDetailsQuery();
 
   return useQuery({
-    queryKey: [...SearchPhotosQueryKeys, searchTerm],
+    queryKey: [...SearchPhotosQueryKeys, searchTerm, mediaType ?? "all"],
     queryFn: async () => {
-      const response = await fetchClient.get<typeof SearchPhotos>(`/photos/searchlist/?search=${searchTerm}`);
+      const params = new URLSearchParams({ search: searchTerm, ...mediaTypeToParams(mediaType) });
+      const response = await fetchClient.get<typeof SearchPhotos>(`/photos/searchlist/?${params.toString()}`);
 
       // If semantic_search_topk is set, return a flat list
       if (currentUser?.semantic_search_topk) {

--- a/apps/frontend/src/components/photolist/MediaTypeSelector.tsx
+++ b/apps/frontend/src/components/photolist/MediaTypeSelector.tsx
@@ -1,0 +1,52 @@
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { IconLayoutGrid, IconPhoto, IconVideo } from "@tabler/icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { type MediaType } from "./mediaTypeFilter";
+import { useMediaTypeFilter } from "./useMediaTypeFilter";
+
+const OPTIONS: ReadonlyArray<{ value: MediaType; icon: typeof IconPhoto; labelKey: string }> = [
+  { value: "all", icon: IconLayoutGrid, labelKey: "mediafilter.all" },
+  { value: "photos", icon: IconPhoto, labelKey: "mediafilter.photos" },
+  { value: "videos", icon: IconVideo, labelKey: "mediafilter.videos" },
+];
+
+// A compact All / Photos / Videos toggle. Self-contained: it reads the active
+// value from the current route's `?media` param and writes back via navigate,
+// so a surface only needs to render it (no props) plus read useMediaTypeFilter()
+// to feed its own data hook.
+export function MediaTypeSelector() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const current = useMediaTypeFilter();
+
+  const select = (value: MediaType) => {
+    navigate({
+      // Clear the param for the default so the URL stays clean.
+      search: (prev: Record<string, unknown>) => ({ ...prev, media: value === "all" ? undefined : value }),
+    });
+  };
+
+  return (
+    <ActionIcon.Group>
+      {OPTIONS.map(({ value, icon: Icon, labelKey }) => {
+        const active = current === value;
+        return (
+          <Tooltip key={value} label={t(labelKey)} position="bottom">
+            <ActionIcon
+              variant={active ? "filled" : "subtle"}
+              color="gray"
+              size="lg"
+              aria-label={t(labelKey)}
+              aria-pressed={active}
+              onClick={() => select(value)}
+            >
+              <Icon size={20} />
+            </ActionIcon>
+          </Tooltip>
+        );
+      })}
+    </ActionIcon.Group>
+  );
+}

--- a/apps/frontend/src/components/photolist/PhotoListView.tsx
+++ b/apps/frontend/src/components/photolist/PhotoListView.tsx
@@ -44,6 +44,8 @@ import type { ScrollerData } from "../scrollscrubber/ScrollScrubberTypes.zod";
 import { ModalAlbumShare } from "../sharing/ModalAlbumShare";
 import { ModalPhotosShare } from "../sharing/ModalPhotosShare";
 import { DefaultHeader } from "./DefaultHeader";
+import type { MediaType } from "./mediaTypeFilter";
+import { MediaTypeSelector } from "./MediaTypeSelector";
 import { SelectionActions } from "./SelectionActions";
 import { SelectionBar } from "./SelectionBar";
 import { StackOverlay } from "./StackOverlay";
@@ -94,6 +96,10 @@ type Props = Readonly<{
   emptyStateConfig?: EmptyStateConfig;
   // Query params for server-side select all
   photosetQuery?: BulkPhotoQuery;
+  // When set, an All/Photos/Videos filter is shown in the header. The value is
+  // the current selection (from the route's `?media` param) — passing it keeps
+  // the memoized grid re-rendering when the filter changes.
+  mediaType?: MediaType;
 }>;
 
 // SelectionState is now imported from api_client/photos/types
@@ -119,6 +125,7 @@ function PhotoListViewComponent({
   ownerUsername,
   emptyStateConfig,
   photosetQuery,
+  mediaType,
 }: Props) {
   const { t } = useTranslation();
   const { height } = useViewportSize();
@@ -228,7 +235,6 @@ function PhotoListViewComponent({
               });
             }
           } catch (error) {
-            // eslint-disable-next-line no-console
             console.error("Error scrolling to image:", error);
           }
         }, 100);
@@ -310,6 +316,21 @@ function PhotoListViewComponent({
     selectionStateRef.current = updatedState;
     setSelectionState(updatedState);
   };
+
+  // Clear any active selection when the media-type filter changes: the set of
+  // photos on screen changes, so a carried-over selection (and its "N selected"
+  // count or server-side select-all query) would be stale and misleading.
+  useEffect(() => {
+    const cleared: SelectionState = {
+      selectedItems: [],
+      selectMode: false,
+      selectAllMode: false,
+      selectAllQuery: undefined,
+      totalCount: undefined,
+    };
+    selectionStateRef.current = cleared;
+    setSelectionState(cleared);
+  }, [mediaType]);
 
   const handleSelection = (item: any) => {
     const currentState = selectionStateRef.current;
@@ -465,7 +486,7 @@ function PhotoListViewComponent({
               hasEmptyState={!!emptyStateConfig && !isFirstTimeSetup}
               isPublic={isPublic}
             />
-            {!isLoading && !isPublic && getNumPhotos() > 0 && (
+            {!isLoading && !isPublic && (getNumPhotos() > 0 || mediaType !== undefined) && (
               <Box
                 style={{
                   position: "absolute",
@@ -475,7 +496,10 @@ function PhotoListViewComponent({
                 }}
               >
                 <Group gap="xs">
-                  {isAlbumPubliclyShared && isUserAlbum && (
+                  {/* The media-type filter stays visible even when the current
+                      filter yields no photos, so the user is never trapped. */}
+                  {mediaType !== undefined && <MediaTypeSelector />}
+                  {getNumPhotos() > 0 && isAlbumPubliclyShared && isUserAlbum && (
                     <Tooltip label={t("sidemenu.sharing")} position="bottom">
                       <ActionIcon
                         variant="subtle"
@@ -492,91 +516,95 @@ function PhotoListViewComponent({
                       </ActionIcon>
                     </Tooltip>
                   )}
-                  <Menu shadow="md" width={200} position="bottom-end">
-                    <Menu.Target>
-                      <Tooltip label={t("photodisplay.settings")} position="bottom">
-                        <ActionIcon
-                          variant="subtle"
-                          color="gray"
-                          size="lg"
-                          aria-label={t("photodisplay.settings")}
-                          style={{
-                            backgroundColor: colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
-                            borderRadius: theme.radius.sm,
-                          }}
-                        >
-                          <IconSettings size={20} />
-                        </ActionIcon>
-                      </Tooltip>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                      <Menu.Label>{t("photodisplay.photoSize")}</Menu.Label>
-                      <Box p="xs">
-                        <Stack gap={6}>
-                          <Slider
-                            mb={20}
-                            value={localImageScale}
-                            onChange={handleThumbnailSizeChange}
-                            min={0.25}
-                            max={3}
-                            step={0.05}
-                            marks={[
-                              { value: 0.5, label: "0.5" },
-                              { value: 1, label: "1" },
-                              { value: 2, label: "2" },
-                            ]}
+                  {getNumPhotos() > 0 && (
+                    <Menu shadow="md" width={200} position="bottom-end">
+                      <Menu.Target>
+                        <Tooltip label={t("photodisplay.settings")} position="bottom">
+                          <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="lg"
+                            aria-label={t("photodisplay.settings")}
+                            style={{
+                              backgroundColor: colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
+                              borderRadius: theme.radius.sm,
+                            }}
+                          >
+                            <IconSettings size={20} />
+                          </ActionIcon>
+                        </Tooltip>
+                      </Menu.Target>
+                      <Menu.Dropdown>
+                        <Menu.Label>{t("photodisplay.photoSize")}</Menu.Label>
+                        <Box p="xs">
+                          <Stack gap={6}>
+                            <Slider
+                              mb={20}
+                              value={localImageScale}
+                              onChange={handleThumbnailSizeChange}
+                              min={0.25}
+                              max={3}
+                              step={0.05}
+                              marks={[
+                                { value: 0.5, label: "0.5" },
+                                { value: 1, label: "1" },
+                                { value: 2, label: "2" },
+                              ]}
+                            />
+                            <Text size="xs" c="dimmed">
+                              {t("photodisplay.lowerBigger")}
+                            </Text>
+                            <Text size="xs" fw={500}>
+                              {t("photodisplay.current", { value: localImageScale.toFixed(2) })}
+                            </Text>
+                          </Stack>
+                        </Box>
+
+                        <Menu.Divider />
+
+                        <Menu.Label>{t("photodisplay.textAlignment")}</Menu.Label>
+                        <Box p="xs">
+                          <Switch
+                            label={t("photodisplay.leftAlign")}
+                            checked={localTextAlignment === "left"}
+                            onChange={event =>
+                              handleTextAlignmentChange(event.currentTarget.checked ? "left" : "right")
+                            }
+                            size="sm"
                           />
-                          <Text size="xs" c="dimmed">
-                            {t("photodisplay.lowerBigger")}
-                          </Text>
-                          <Text size="xs" fw={500}>
-                            {t("photodisplay.current", { value: localImageScale.toFixed(2) })}
-                          </Text>
-                        </Stack>
-                      </Box>
+                        </Box>
 
-                      <Menu.Divider />
+                        <Menu.Divider />
 
-                      <Menu.Label>{t("photodisplay.textAlignment")}</Menu.Label>
-                      <Box p="xs">
-                        <Switch
-                          label={t("photodisplay.leftAlign")}
-                          checked={localTextAlignment === "left"}
-                          onChange={event => handleTextAlignmentChange(event.currentTarget.checked ? "left" : "right")}
-                          size="sm"
-                        />
-                      </Box>
-
-                      <Menu.Divider />
-
-                      <Menu.Label>{t("photodisplay.headerSize")}</Menu.Label>
-                      <Box p="xs">
-                        <Group>
-                          <Button
-                            size="xs"
-                            variant={localHeaderSize === "large" ? "filled" : "outline"}
-                            onClick={() => handleHeaderSizeChange("large")}
-                          >
-                            {t("photodisplay.large")}
-                          </Button>
-                          <Button
-                            size="xs"
-                            variant={localHeaderSize === "normal" ? "filled" : "outline"}
-                            onClick={() => handleHeaderSizeChange("normal")}
-                          >
-                            {t("photodisplay.normal")}
-                          </Button>
-                          <Button
-                            size="xs"
-                            variant={localHeaderSize === "small" ? "filled" : "outline"}
-                            onClick={() => handleHeaderSizeChange("small")}
-                          >
-                            {t("photodisplay.small")}
-                          </Button>
-                        </Group>
-                      </Box>
-                    </Menu.Dropdown>
-                  </Menu>
+                        <Menu.Label>{t("photodisplay.headerSize")}</Menu.Label>
+                        <Box p="xs">
+                          <Group>
+                            <Button
+                              size="xs"
+                              variant={localHeaderSize === "large" ? "filled" : "outline"}
+                              onClick={() => handleHeaderSizeChange("large")}
+                            >
+                              {t("photodisplay.large")}
+                            </Button>
+                            <Button
+                              size="xs"
+                              variant={localHeaderSize === "normal" ? "filled" : "outline"}
+                              onClick={() => handleHeaderSizeChange("normal")}
+                            >
+                              {t("photodisplay.normal")}
+                            </Button>
+                            <Button
+                              size="xs"
+                              variant={localHeaderSize === "small" ? "filled" : "outline"}
+                              onClick={() => handleHeaderSizeChange("small")}
+                            >
+                              {t("photodisplay.small")}
+                            </Button>
+                          </Group>
+                        </Box>
+                      </Menu.Dropdown>
+                    </Menu>
+                  )}
                 </Group>
               </Box>
             )}
@@ -809,5 +837,5 @@ function PhotoListViewComponent({
 
 export const PhotoListView = React.memo(
   PhotoListViewComponent,
-  (prev, next) => prev.loading === next.loading && prev.idx2hash === next.idx2hash
+  (prev, next) => prev.loading === next.loading && prev.idx2hash === next.idx2hash && prev.mediaType === next.mediaType
 );

--- a/apps/frontend/src/components/photolist/mediaTypeFilter.ts
+++ b/apps/frontend/src/components/photolist/mediaTypeFilter.ts
@@ -1,0 +1,35 @@
+export type MediaType = "all" | "photos" | "videos";
+
+export const DEFAULT_MEDIA_TYPE: MediaType = "all";
+
+// The three states map to the backend's ?photo=true / ?video=true album filter.
+// "all" sends neither param.
+export function mediaTypeToParams(mediaType: MediaType | undefined): { photo?: "true"; video?: "true" } {
+  if (mediaType === "photos") {
+    return { photo: "true" };
+  }
+  if (mediaType === "videos") {
+    return { video: "true" };
+  }
+  return {};
+}
+
+// Boolean form of the same filter, for the BulkPhotoQuery `photosetQuery`
+// (server-side select-all), which uses booleans rather than URL "true" strings.
+export function mediaTypeToBulkQuery(mediaType: MediaType | undefined): { photo?: boolean; video?: boolean } {
+  if (mediaType === "photos") {
+    return { photo: true };
+  }
+  if (mediaType === "videos") {
+    return { video: true };
+  }
+  return {};
+}
+
+// Route `validateSearch` for surfaces that expose the media-type filter. Only
+// the non-default values are kept in the URL; "all" is represented by the
+// absence of the param.
+export function validateMediaSearch(search: Record<string, unknown>): { media?: MediaType } {
+  const { media } = search;
+  return media === "photos" || media === "videos" ? { media } : {};
+}

--- a/apps/frontend/src/components/photolist/useMediaTypeFilter.ts
+++ b/apps/frontend/src/components/photolist/useMediaTypeFilter.ts
@@ -1,0 +1,10 @@
+import { useSearch } from "@tanstack/react-router";
+import { DEFAULT_MEDIA_TYPE, type MediaType } from "./mediaTypeFilter";
+
+// Reads the per-view media-type filter from the current route's `?media` search
+// param. Reset-per-view by design: the value lives in the URL, so it survives
+// reload / back-forward for a given view but does not leak across surfaces.
+export function useMediaTypeFilter(): MediaType {
+  const search = useSearch({ strict: false }) as { media?: MediaType };
+  return search.media ?? DEFAULT_MEDIA_TYPE;
+}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1183,5 +1183,10 @@
     "scanPhotos": "Scan Photos"
   },
   "skip": "Skip",
-  "continue": "Continue"
+  "continue": "Continue",
+  "mediafilter": {
+    "all": "All",
+    "photos": "Photos only",
+    "videos": "Videos only"
+  }
 }

--- a/apps/frontend/src/routes/_protected/album/persons.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/persons.$id.tsx
@@ -9,14 +9,19 @@ import {
   useFetchPeopleAlbumsQuery,
 } from "../../../api_client/albums/hooks";
 import { Photoset, PigPhoto } from "../../../api_client/photos/types";
+import { mediaTypeToBulkQuery, validateMediaSearch } from "../../../components/photolist/mediaTypeFilter";
 import { PhotoGroup, PhotoListView } from "../../../components/photolist/PhotoListView";
+import { useMediaTypeFilter } from "../../../components/photolist/useMediaTypeFilter";
 import { getPhotosFlatFromGroupedByDate } from "../../../util/util";
 
-export const Route = createFileRoute("/_protected/album/persons/$id")();
+export const Route = createFileRoute("/_protected/album/persons/$id")({
+  validateSearch: validateMediaSearch,
+});
 
 export function AlbumPersonGallery(): JSX.Element {
   const { id } = Route.useParams();
   const { t } = useTranslation();
+  const mediaType = useMediaTypeFilter();
   const [photosFlat, setPhotosFlat] = useState<PigPhoto[]>([]);
   const { data: people } = useFetchPeopleAlbumsQuery();
 
@@ -26,6 +31,7 @@ export function AlbumPersonGallery(): JSX.Element {
   const { data: photosGroupedByDate, isLoading } = useFetchDateAlbumsQuery({
     photosetType: Photoset.PERSON,
     person_id: id ? +id : undefined,
+    mediaType,
   });
 
   useEffect(() => {
@@ -39,6 +45,7 @@ export function AlbumPersonGallery(): JSX.Element {
       page: group.page,
       photosetType: Photoset.PERSON,
       person_id: id ? +id : undefined,
+      mediaType,
     },
     { skip: !group.id }
   );
@@ -64,7 +71,8 @@ export function AlbumPersonGallery(): JSX.Element {
       idx2hash={photosFlat}
       updateGroups={getAlbums}
       selectable
-      photosetQuery={{ person: id ? +id : undefined }}
+      mediaType={mediaType}
+      photosetQuery={{ person: id ? +id : undefined, ...mediaTypeToBulkQuery(mediaType) }}
     />
   );
 }

--- a/apps/frontend/src/routes/_protected/album/places.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/places.$id.tsx
@@ -3,14 +3,19 @@ import { createFileRoute } from "@tanstack/react-router";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFetchPlaceAlbumQuery } from "../../../api_client/albums/hooks";
+import { validateMediaSearch } from "../../../components/photolist/mediaTypeFilter";
 import { PhotoListView } from "../../../components/photolist/PhotoListView";
+import { useMediaTypeFilter } from "../../../components/photolist/useMediaTypeFilter";
 
-export const Route = createFileRoute("/_protected/album/places/$id")();
+export const Route = createFileRoute("/_protected/album/places/$id")({
+  validateSearch: validateMediaSearch,
+});
 
 export function AlbumPlaceGallery() {
   const { t } = useTranslation();
   const { id: albumID } = Route.useParams();
-  const { data: album, isFetching } = useFetchPlaceAlbumQuery(albumID ?? "");
+  const mediaType = useMediaTypeFilter();
+  const { data: album, isFetching } = useFetchPlaceAlbumQuery(albumID ?? "", mediaType);
 
   return (
     <PhotoListView
@@ -19,6 +24,7 @@ export function AlbumPlaceGallery() {
       icon={<Map size={50} />}
       photoset={album?.grouped_photos ?? []}
       idx2hash={album?.grouped_photos.flatMap(el => el.items) ?? []}
+      mediaType={mediaType}
       selectable
     />
   );

--- a/apps/frontend/src/routes/_protected/album/things.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/things.$id.tsx
@@ -3,14 +3,19 @@ import { createFileRoute } from "@tanstack/react-router";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFetchThingsAlbumQuery } from "../../../api_client/albums/hooks";
+import { validateMediaSearch } from "../../../components/photolist/mediaTypeFilter";
 import { PhotoListView } from "../../../components/photolist/PhotoListView";
+import { useMediaTypeFilter } from "../../../components/photolist/useMediaTypeFilter";
 
-export const Route = createFileRoute("/_protected/album/things/$id")();
+export const Route = createFileRoute("/_protected/album/things/$id")({
+  validateSearch: validateMediaSearch,
+});
 
 export function AlbumThingGallery() {
   const { t } = useTranslation();
   const { id: albumID } = Route.useParams();
-  const { data: groupedPhotos, isLoading: fetchingAlbumsThing } = useFetchThingsAlbumQuery(albumID || "");
+  const mediaType = useMediaTypeFilter();
+  const { data: groupedPhotos, isLoading: fetchingAlbumsThing } = useFetchThingsAlbumQuery(albumID || "", mediaType);
 
   return (
     <PhotoListView
@@ -19,6 +24,7 @@ export function AlbumThingGallery() {
       icon={<Tags size={50} />}
       photoset={groupedPhotos ? groupedPhotos.grouped_photos : []}
       idx2hash={groupedPhotos ? groupedPhotos.grouped_photos.flatMap(el => el.items) : []}
+      mediaType={mediaType}
       selectable
     />
   );

--- a/apps/frontend/src/routes/_protected/album/user.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/user.$id.tsx
@@ -5,10 +5,14 @@ import { useTranslation } from "react-i18next";
 import { useFetchUserAlbumQuery } from "../../../api_client/albums/hooks";
 import type { DatePhotosGroup, PigPhoto } from "../../../api_client/photos/types";
 import { useCurrentUserSelfDetailsQuery } from "../../../api_client/user/hooks/useCurrentUserSelfDetailsQuery";
+import { validateMediaSearch } from "../../../components/photolist/mediaTypeFilter";
 import { PhotoListView } from "../../../components/photolist/PhotoListView";
+import { useMediaTypeFilter } from "../../../components/photolist/useMediaTypeFilter";
 import { getPhotosFlatFromGroupedByDate } from "../../../util/util";
 
-export const Route = createFileRoute("/_protected/album/user/$id")();
+export const Route = createFileRoute("/_protected/album/user/$id")({
+  validateSearch: validateMediaSearch,
+});
 
 export function AlbumUserGallery() {
   const [flatPhotos, setFlatPhotos] = useState<PigPhoto[]>([]);
@@ -16,8 +20,9 @@ export function AlbumUserGallery() {
   const [isPublic, setIsPublic] = useState(false);
   const { data: currentUser } = useCurrentUserSelfDetailsQuery();
   const { id: albumID } = Route.useParams();
+  const mediaType = useMediaTypeFilter();
 
-  const { data: album, isFetching } = useFetchUserAlbumQuery(albumID ?? "");
+  const { data: album, isFetching } = useFetchUserAlbumQuery(albumID ?? "", { mediaType });
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -52,6 +57,7 @@ export function AlbumUserGallery() {
       isAlbumPubliclyShared={album?.public ?? false}
       albumID={albumID}
       ownerUsername={album?.owner.username}
+      mediaType={mediaType}
       selectable
     />
   );

--- a/apps/frontend/src/routes/_protected/search.$query.tsx
+++ b/apps/frontend/src/routes/_protected/search.$query.tsx
@@ -3,9 +3,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import React from "react";
 import { useSearchPhotosQuery } from "../../api_client/search/hooks";
 import { useCurrentUserSelfDetailsQuery } from "../../api_client/user/hooks/useCurrentUserSelfDetailsQuery";
+import { validateMediaSearch } from "../../components/photolist/mediaTypeFilter";
 import { PhotoListView } from "../../components/photolist/PhotoListView";
+import { useMediaTypeFilter } from "../../components/photolist/useMediaTypeFilter";
 
-export const Route = createFileRoute("/_protected/search/$query")();
+export const Route = createFileRoute("/_protected/search/$query")({
+  validateSearch: validateMediaSearch,
+});
 const DEFAULTS = {
   photosFlat: [],
   photosGroupedByDate: [],
@@ -14,8 +18,12 @@ const DEFAULTS = {
 export function SearchView() {
   const { query: searchQuery } = Route.useParams();
   const { data: currentUser } = useCurrentUserSelfDetailsQuery();
+  const mediaType = useMediaTypeFilter();
 
-  const { data: { photosGroupedByDate, photosFlat } = DEFAULTS, isFetching } = useSearchPhotosQuery(searchQuery ?? "");
+  const { data: { photosGroupedByDate, photosFlat } = DEFAULTS, isFetching } = useSearchPhotosQuery(
+    searchQuery ?? "",
+    mediaType
+  );
 
   return (
     <PhotoListView
@@ -24,6 +32,7 @@ export function SearchView() {
       icon={<Search size={50} />}
       photoset={currentUser?.semantic_search_topk ? photosFlat : photosGroupedByDate}
       idx2hash={photosFlat}
+      mediaType={mediaType}
       selectable
     />
   );


### PR DESCRIPTION
**Depends on #1885** — the user/place/thing album endpoints only honor `?photo=`/`?video=` after that lands, so it should merge first. Search and the date-album endpoints (person albums) already support the params on `dev`.

This is the frontend for the media-type filter: a compact icon-button group (All / Photos / Videos, with tooltips) in the photo-grid header, on the surfaces that mix both kinds of media — search results, user albums, place albums, thing albums and person albums. It closes the gap left by #1862, which added the filter to the search backend but had no UI for it.

The selected filter lives in the route's `?media` search param, so it survives reload and back/forward within a view but deliberately resets when you navigate to another surface. Each surface's data hook threads the value into the request URL and its React Query key in lockstep, so switching the filter can never serve a stale cached photoset. The selector stays visible even when the current filter yields zero results — otherwise picking "Videos" on an all-photo album would leave no way back.

Person albums needed a bit more: they page lazily through the date-album endpoints, so the filter flows through both `useFetchDateAlbumsQuery` and `useFetchDateAlbumQuery` (params, query keys, and the cache cross-population key kept consistent), and the flag is also merged into the server-side select-all photoset query so bulk actions under "Select All" operate on exactly the filtered set that is on screen. Changing the filter clears any active selection — the set of photos on screen changes, so a carried-over "N selected" (or a select-all query) would be stale and misleading.

No new endpoints or request patterns — the same album/search fetches, with one extra query param. Strings are added to the English translation only, per the Weblate flow. Browser-tested on a dev-stack library with mixed photos/videos across all five surfaces, including filter + Select All + bulk-action combinations on person albums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
