### PR TITLE
Self-service password reset (Closes #596)

### DIFF
--- a/apps/backend/api/tests/test_password_reset.py
+++ b/apps/backend/api/tests/test_password_reset.py
@@ -1,0 +1,138 @@
+"""Tests for the self-service password-reset flow (#596).
+
+Covers the request endpoint (which must never leak whether an email exists),
+the confirm endpoint (token validation, password-strength enforcement,
+single-use tokens), and the anti-email-bombing throttle.
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+REQUEST_URL = "/api/auth/password/reset/"
+CONFIRM_URL = "/api/auth/password/reset/confirm/"
+
+
+def _make_user(email="alice@example.com", password="oldpassword123"):
+    user = User.objects.create(username=email, email=email)
+    user.set_password(password)
+    user.save()
+    return user
+
+
+class PasswordResetRequestTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+        self.user = _make_user()
+
+    def test_known_email_sends_one_reset_email(self):
+        resp = self.client.post(REQUEST_URL, {"email": self.user.email})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["status"])
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("password-reset/confirm/", mail.outbox[0].body)
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
+
+    def test_email_match_is_case_insensitive(self):
+        resp = self.client.post(REQUEST_URL, {"email": "ALICE@EXAMPLE.COM"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_unknown_email_still_returns_200_without_sending(self):
+        resp = self.client.post(REQUEST_URL, {"email": "nobody@example.com"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["status"])
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_missing_email_returns_200_without_sending(self):
+        resp = self.client.post(REQUEST_URL, {})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(FRONTEND_BASE_URL="https://photos.example.org")
+    def test_link_uses_configured_frontend_base_url(self):
+        self.client.post(REQUEST_URL, {"email": self.user.email})
+        self.assertIn(
+            "https://photos.example.org/password-reset/confirm/",
+            mail.outbox[0].body,
+        )
+
+
+class PasswordResetConfirmTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+        self.user = _make_user()
+        self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        self.token = default_token_generator.make_token(self.user)
+
+    def _confirm(self, **overrides):
+        payload = {
+            "uid": self.uid,
+            "token": self.token,
+            "new_password": "a-brand-new-secret-42",
+        }
+        payload.update(overrides)
+        return self.client.post(CONFIRM_URL, payload)
+
+    def test_valid_token_resets_password(self):
+        resp = self._confirm()
+        self.assertEqual(resp.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("a-brand-new-secret-42"))
+
+    def test_invalid_token_rejected(self):
+        resp = self._confirm(token="not-a-real-token")
+        self.assertEqual(resp.status_code, 400)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpassword123"))
+
+    def test_tampered_uid_rejected(self):
+        bogus = urlsafe_base64_encode(force_bytes(999999))
+        resp = self._confirm(uid=bogus)
+        self.assertEqual(resp.status_code, 400)
+
+    def test_weak_password_rejected(self):
+        resp = self._confirm(new_password="123")
+        self.assertEqual(resp.status_code, 400)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpassword123"))
+
+    def test_missing_parameters_rejected(self):
+        resp = self.client.post(CONFIRM_URL, {"uid": self.uid})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_token_is_single_use(self):
+        first = self._confirm()
+        self.assertEqual(first.status_code, 200)
+        # The password hash changed, so the same token no longer validates.
+        second = self._confirm()
+        self.assertEqual(second.status_code, 400)
+
+
+class PasswordResetThrottleTest(TestCase):
+    """The request endpoint must be rate-limited to prevent email bombing.
+
+    Uses the default configured rate (5/hour); firing one request beyond it
+    must be rejected with HTTP 429.
+    """
+
+    def setUp(self):
+        cache.clear()
+        self.client = APIClient()
+
+    def test_request_endpoint_is_throttled(self):
+        statuses = [
+            self.client.post(REQUEST_URL, {"email": "x@example.com"}).status_code
+            for _ in range(6)
+        ]
+        self.assertEqual(statuses[:5], [200, 200, 200, 200, 200])
+        self.assertEqual(statuses[5], 429)

--- a/apps/backend/api/views/password_reset.py
+++ b/apps/backend/api/views/password_reset.py
@@ -1,0 +1,129 @@
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.tokens import default_token_generator
+from django.core.exceptions import ValidationError
+from django.core.mail import send_mail
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+def _frontend_base_url(request):
+    """Where the SPA lives, for building the reset link.
+
+    Prefers the explicitly configured FRONTEND_BASE_URL and otherwise falls
+    back to the origin the request itself arrived on, so a default single-host
+    deployment works without any extra configuration.
+    """
+    configured = (settings.FRONTEND_BASE_URL or "").rstrip("/")
+    if configured:
+        return configured
+    return request.build_absolute_uri("/").rstrip("/")
+
+
+class PasswordResetView(APIView):
+    """Request a password-reset email.
+
+    Always responds 200 regardless of whether the address matches a user, so
+    the endpoint cannot be used to enumerate registered email addresses.
+    """
+
+    permission_classes = (AllowAny,)
+    throttle_classes = (ScopedRateThrottle,)
+    throttle_scope = "password_reset"
+
+    def post(self, request, format=None):
+        email = (request.data.get("email") or "").strip()
+        if email:
+            user = User.objects.filter(email__iexact=email).first()
+            if user is not None and user.email:
+                self._send_reset_email(request, user)
+        return Response(
+            {
+                "status": True,
+                "message": "If an account exists for that email, a reset link "
+                "has been sent.",
+            }
+        )
+
+    def _send_reset_email(self, request, user):
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+        base = _frontend_base_url(request)
+        link = f"{base}/password-reset/confirm/{uid}/{token}"
+
+        subject = "Reset your LibrePhotos password"
+        body = (
+            f"Hello {user.get_username()},\n\n"
+            "We received a request to reset the password for your LibrePhotos "
+            "account. Open the link below to choose a new password:\n\n"
+            f"{link}\n\n"
+            "If you did not request this, you can safely ignore this email; your "
+            "password will not change.\n"
+        )
+        try:
+            from api.models.email_config import EmailConfig
+
+            from_email = EmailConfig.load().effective_from_email
+            send_mail(
+                subject,
+                body,
+                from_email,
+                [user.email],
+                fail_silently=False,
+            )
+        except Exception:
+            # Never surface delivery failures to the caller (that would leak
+            # whether the address exists); log for the administrator instead.
+            logger.exception("Failed to send password-reset email")
+
+
+class PasswordResetConfirmView(APIView):
+    """Complete a password reset using the token from the emailed link."""
+
+    permission_classes = (AllowAny,)
+
+    def post(self, request, format=None):
+        uid = request.data.get("uid")
+        token = request.data.get("token")
+        new_password = request.data.get("new_password")
+
+        if not uid or not token or not new_password:
+            return Response(
+                {"status": False, "message": "Missing parameters"}, status=400
+            )
+
+        user = self._user_from_uid(uid)
+        if user is None or not default_token_generator.check_token(user, token):
+            return Response(
+                {"status": False, "message": "Invalid or expired reset link"},
+                status=400,
+            )
+
+        try:
+            validate_password(new_password, user)
+        except ValidationError as exc:
+            return Response(
+                {"status": False, "message": " ".join(exc.messages)}, status=400
+            )
+
+        user.set_password(new_password)
+        user.save()
+        return Response({"status": True, "message": "Password has been reset"})
+
+    def _user_from_uid(self, uid):
+        try:
+            pk = force_str(urlsafe_base64_decode(uid))
+            return User.objects.get(pk=pk)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            return None

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -226,6 +226,9 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "EXCEPTION_HANDLER": "api.views.views.custom_exception_handler",
     "PAGE_SIZE": 20000,
+    "DEFAULT_THROTTLE_RATES": {
+        "password_reset": os.environ.get("PASSWORD_RESET_THROTTLE_RATE", "5/hour"),
+    },
 }
 
 MIDDLEWARE = [
@@ -343,3 +346,7 @@ EMAIL_BACKEND = "api.mail.DynamicEmailBackend"
 DEFAULT_FROM_EMAIL = os.environ.get(
     "DEFAULT_FROM_EMAIL", "LibrePhotos <no-reply@localhost>"
 )
+
+# Base URL of the frontend, used to build the link in the password-reset email.
+# Falls back to the request's own origin when not set (see PasswordResetView).
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "")

--- a/apps/backend/librephotos/urls.py
+++ b/apps/backend/librephotos/urls.py
@@ -43,6 +43,7 @@ from api.views import (
     faces,
     geocode,
     jobs,
+    password_reset,
     photo_metadata,
     photos,
     public_albums,
@@ -346,6 +347,14 @@ urlpatterns = [
     re_path(r"^api/auth/token/obtain/$", CustomTokenObtainPairView.as_view()),
     re_path(r"^api/auth/token/refresh/$", CustomTokenRefreshView.as_view()),
     re_path(r"^api/auth/token/blacklist/", TokenBlacklistView.as_view()),
+    re_path(
+        r"^api/auth/password/reset/$",
+        password_reset.PasswordResetView.as_view(),
+    ),
+    re_path(
+        r"^api/auth/password/reset/confirm/$",
+        password_reset.PasswordResetConfirmView.as_view(),
+    ),
     re_path(
         r"^media/(?P<path>.*)/(?P<fname>.*)",
         views.UnifiedMediaAccessView.as_view(),

--- a/apps/frontend/src/api_client/api.ts
+++ b/apps/frontend/src/api_client/api.ts
@@ -70,11 +70,14 @@ class FetchClient {
     if (response.status === 401) {
       // Check if we're on a public page or auth pages - don't handle 401 as an error there
       const isPublicPage = window.location.pathname.startsWith("/public");
+      // The password-reset request/confirm pages are reached while logged out, so
+      // background 401s there must not clear cookies or bounce to login.
+      const isPasswordResetPage = window.location.pathname.includes("/password-reset");
       const isLoginPage = window.location.pathname.includes("/login");
       const isSignupPage = window.location.pathname.includes("/signup");
-      const suppressAuthNotifications = isPublicPage || isLoginPage || isSignupPage;
+      const suppressAuthNotifications = isPublicPage || isPasswordResetPage || isLoginPage || isSignupPage;
 
-      if (!isPublicPage) {
+      if (!isPublicPage && !isPasswordResetPage) {
         // Logout the user by blacklisting the refresh token
         const cookies = new Cookies();
         const refreshToken = cookies.get("refresh");

--- a/apps/frontend/src/api_client/auth/hooks/index.ts
+++ b/apps/frontend/src/api_client/auth/hooks/index.ts
@@ -1,5 +1,7 @@
 export * from "./useSignUpMutation";
 export * from "./useLoginMutation";
+export * from "./useRequestPasswordResetMutation";
+export * from "./useConfirmPasswordResetMutation";
 export * from "./useLogoutMutation";
 export * from "./useIsFirstTimeSetupQuery";
 export * from "./useIsAuthenticatedQuery";

--- a/apps/frontend/src/api_client/auth/hooks/useConfirmPasswordResetMutation.ts
+++ b/apps/frontend/src/api_client/auth/hooks/useConfirmPasswordResetMutation.ts
@@ -1,0 +1,31 @@
+import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
+import { parseWithNotification } from "../../../util/zodUtils";
+import { fetchClient } from "../../api";
+
+export const PasswordResetConfirmRequest = z.object({
+  uid: z.string(),
+  token: z.string(),
+  new_password: z.string(),
+});
+
+export type PasswordResetConfirmRequest = z.infer<typeof PasswordResetConfirmRequest>;
+
+export const PasswordResetConfirmResponse = z.object({
+  status: z.boolean(),
+  message: z.string(),
+});
+
+export type PasswordResetConfirmResponse = z.infer<typeof PasswordResetConfirmResponse>;
+
+const confirmPasswordReset = (data: PasswordResetConfirmRequest) =>
+  fetchClient
+    .post<PasswordResetConfirmResponse>("/auth/password/reset/confirm/", data)
+    .then(response =>
+      parseWithNotification(PasswordResetConfirmResponse, response, "Failed to parse password reset response")
+    );
+
+export const useConfirmPasswordResetMutation = () =>
+  useMutation({
+    mutationFn: confirmPasswordReset,
+  });

--- a/apps/frontend/src/api_client/auth/hooks/useRequestPasswordResetMutation.ts
+++ b/apps/frontend/src/api_client/auth/hooks/useRequestPasswordResetMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
+import { parseWithNotification } from "../../../util/zodUtils";
+import { fetchClient } from "../../api";
+
+export const PasswordResetRequest = z.object({
+  email: z.string(),
+});
+
+export type PasswordResetRequest = z.infer<typeof PasswordResetRequest>;
+
+export const PasswordResetResponse = z.object({
+  status: z.boolean(),
+  message: z.string(),
+});
+
+export type PasswordResetResponse = z.infer<typeof PasswordResetResponse>;
+
+const requestPasswordReset = (data: PasswordResetRequest) =>
+  fetchClient
+    .post<PasswordResetResponse>("/auth/password/reset/", data)
+    .then(response =>
+      parseWithNotification(PasswordResetResponse, response, "Failed to parse password reset response")
+    );
+
+export const useRequestPasswordResetMutation = () =>
+  useMutation({
+    mutationFn: requestPasswordReset,
+  });

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -639,9 +639,26 @@
     "firsttimesetup": "First time setup",
     "setupdatadirectory": "Choose your scan directory"
   },
+  "passwordreset": {
+    "forgotpassword": "Forgot your password?",
+    "title": "Reset your password",
+    "instructions": "Enter the email address for your account and we'll send you a link to reset your password.",
+    "emailplaceholder": "Email address",
+    "sendlink": "Send reset link",
+    "checkemail": "If an account exists for that email, a password reset link is on its way. Check your inbox.",
+    "backtologin": "Back to login",
+    "erroremail": "Enter a valid email address.",
+    "choosetitle": "Choose a new password",
+    "newpasswordplaceholder": "New password",
+    "confirmpasswordplaceholder": "Confirm new password",
+    "setpassword": "Set new password",
+    "errormustmatch": "Passwords must match.",
+    "success": "Your password has been reset. You can now log in.",
+    "errorinvalidlink": "This password reset link is invalid or has expired. Please request a new one."
+  },
   "emailsettings": {
     "header": "Email (SMTP)",
-    "description": "Configure outgoing email so the server can send account and notification emails. The credential is encrypted before it is stored.",
+    "description": "Configure outgoing email so the server can send password-reset links and other notifications. The credential is encrypted before it is stored.",
     "provider": "Provider",
     "from_email": "From address",
     "host": "SMTP host",

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as PublicRouteRouteImport } from './routes/public/route'
 import { Route as ProtectedRouteRouteImport } from './routes/_protected/route'
+import { Route as PasswordResetIndexRouteImport } from './routes/password-reset.index'
 import { Route as ProtectedIndexRouteImport } from './routes/_protected/index'
 import { Route as PublicUsersRouteImport } from './routes/public/$users'
 import { Route as ProtectedVideosRouteImport } from './routes/_protected/videos'
@@ -49,6 +50,7 @@ import { Route as ProtectedAlbumPlacesIndexRouteImport } from './routes/_protect
 import { Route as ProtectedAlbumPersonsIndexRouteImport } from './routes/_protected/album/persons.index'
 import { Route as ProtectedAlbumFolderIndexRouteImport } from './routes/_protected/album/folder.index'
 import { Route as ProtectedAlbumEventsIndexRouteImport } from './routes/_protected/album/events.index'
+import { Route as PasswordResetConfirmUidTokenRouteImport } from './routes/password-reset.confirm.$uid.$token'
 import { Route as ProtectedSharingWithmeTabRouteImport } from './routes/_protected/sharing/withme.$tab'
 import { Route as ProtectedSharingBymeTabRouteImport } from './routes/_protected/sharing/byme.$tab'
 import { Route as ProtectedAlbumUserIdRouteImport } from './routes/_protected/album/user.$id'
@@ -76,6 +78,11 @@ const PublicRouteRoute = PublicRouteRouteImport.update({
 } as any)
 const ProtectedRouteRoute = ProtectedRouteRouteImport.update({
   id: '/_protected',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PasswordResetIndexRoute = PasswordResetIndexRouteImport.update({
+  id: '/password-reset/',
+  path: '/password-reset/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProtectedIndexRoute = ProtectedIndexRouteImport.update({
@@ -269,6 +276,12 @@ const ProtectedAlbumEventsIndexRoute =
     path: '/album/events/',
     getParentRoute: () => ProtectedRouteRoute,
   } as any)
+const PasswordResetConfirmUidTokenRoute =
+  PasswordResetConfirmUidTokenRouteImport.update({
+    id: '/password-reset/confirm/$uid/$token',
+    path: '/password-reset/confirm/$uid/$token',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ProtectedSharingWithmeTabRoute =
   ProtectedSharingWithmeTabRouteImport.update({
     id: '/sharing/withme/$tab',
@@ -335,6 +348,7 @@ export interface FileRoutesByFullPath {
   '/stacks': typeof ProtectedStacksRoute
   '/videos': typeof ProtectedVideosRoute
   '/public/$users': typeof PublicUsersRoute
+  '/password-reset/': typeof PasswordResetIndexRoute
   '/organizing/$tab': typeof ProtectedOrganizingTabRoute
   '/photo/$id': typeof ProtectedPhotoIdRoute
   '/search/$query': typeof ProtectedSearchQueryRoute
@@ -359,6 +373,7 @@ export interface FileRoutesByFullPath {
   '/album/user/$id': typeof ProtectedAlbumUserIdRoute
   '/sharing/byme/$tab': typeof ProtectedSharingBymeTabRoute
   '/sharing/withme/$tab': typeof ProtectedSharingWithmeTabRoute
+  '/password-reset/confirm/$uid/$token': typeof PasswordResetConfirmUidTokenRoute
   '/album/events/': typeof ProtectedAlbumEventsIndexRoute
   '/album/folder/': typeof ProtectedAlbumFolderIndexRoute
   '/album/persons/': typeof ProtectedAlbumPersonsIndexRoute
@@ -384,6 +399,7 @@ export interface FileRoutesByTo {
   '/videos': typeof ProtectedVideosRoute
   '/public/$users': typeof PublicUsersRoute
   '/': typeof ProtectedIndexRoute
+  '/password-reset': typeof PasswordResetIndexRoute
   '/organizing/$tab': typeof ProtectedOrganizingTabRoute
   '/photo/$id': typeof ProtectedPhotoIdRoute
   '/search/$query': typeof ProtectedSearchQueryRoute
@@ -408,6 +424,7 @@ export interface FileRoutesByTo {
   '/album/user/$id': typeof ProtectedAlbumUserIdRoute
   '/sharing/byme/$tab': typeof ProtectedSharingBymeTabRoute
   '/sharing/withme/$tab': typeof ProtectedSharingWithmeTabRoute
+  '/password-reset/confirm/$uid/$token': typeof PasswordResetConfirmUidTokenRoute
   '/album/events': typeof ProtectedAlbumEventsIndexRoute
   '/album/folder': typeof ProtectedAlbumFolderIndexRoute
   '/album/persons': typeof ProtectedAlbumPersonsIndexRoute
@@ -436,6 +453,7 @@ export interface FileRoutesById {
   '/_protected/videos': typeof ProtectedVideosRoute
   '/public/$users': typeof PublicUsersRoute
   '/_protected/': typeof ProtectedIndexRoute
+  '/password-reset/': typeof PasswordResetIndexRoute
   '/_protected/organizing/$tab': typeof ProtectedOrganizingTabRoute
   '/_protected/photo/$id': typeof ProtectedPhotoIdRoute
   '/_protected/search/$query': typeof ProtectedSearchQueryRoute
@@ -460,6 +478,7 @@ export interface FileRoutesById {
   '/_protected/album/user/$id': typeof ProtectedAlbumUserIdRoute
   '/_protected/sharing/byme/$tab': typeof ProtectedSharingBymeTabRoute
   '/_protected/sharing/withme/$tab': typeof ProtectedSharingWithmeTabRoute
+  '/password-reset/confirm/$uid/$token': typeof PasswordResetConfirmUidTokenRoute
   '/_protected/album/events/': typeof ProtectedAlbumEventsIndexRoute
   '/_protected/album/folder/': typeof ProtectedAlbumFolderIndexRoute
   '/_protected/album/persons/': typeof ProtectedAlbumPersonsIndexRoute
@@ -488,6 +507,7 @@ export interface FileRouteTypes {
     | '/stacks'
     | '/videos'
     | '/public/$users'
+    | '/password-reset/'
     | '/organizing/$tab'
     | '/photo/$id'
     | '/search/$query'
@@ -512,6 +532,7 @@ export interface FileRouteTypes {
     | '/album/user/$id'
     | '/sharing/byme/$tab'
     | '/sharing/withme/$tab'
+    | '/password-reset/confirm/$uid/$token'
     | '/album/events/'
     | '/album/folder/'
     | '/album/persons/'
@@ -537,6 +558,7 @@ export interface FileRouteTypes {
     | '/videos'
     | '/public/$users'
     | '/'
+    | '/password-reset'
     | '/organizing/$tab'
     | '/photo/$id'
     | '/search/$query'
@@ -561,6 +583,7 @@ export interface FileRouteTypes {
     | '/album/user/$id'
     | '/sharing/byme/$tab'
     | '/sharing/withme/$tab'
+    | '/password-reset/confirm/$uid/$token'
     | '/album/events'
     | '/album/folder'
     | '/album/persons'
@@ -588,6 +611,7 @@ export interface FileRouteTypes {
     | '/_protected/videos'
     | '/public/$users'
     | '/_protected/'
+    | '/password-reset/'
     | '/_protected/organizing/$tab'
     | '/_protected/photo/$id'
     | '/_protected/search/$query'
@@ -612,6 +636,7 @@ export interface FileRouteTypes {
     | '/_protected/album/user/$id'
     | '/_protected/sharing/byme/$tab'
     | '/_protected/sharing/withme/$tab'
+    | '/password-reset/confirm/$uid/$token'
     | '/_protected/album/events/'
     | '/_protected/album/folder/'
     | '/_protected/album/persons/'
@@ -625,6 +650,8 @@ export interface RootRouteChildren {
   PublicRouteRoute: typeof PublicRouteRouteWithChildren
   LoginRoute: typeof LoginRoute
   SignupRoute: typeof SignupRoute
+  PasswordResetIndexRoute: typeof PasswordResetIndexRoute
+  PasswordResetConfirmUidTokenRoute: typeof PasswordResetConfirmUidTokenRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -655,6 +682,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof ProtectedRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/password-reset/': {
+      id: '/password-reset/'
+      path: '/password-reset'
+      fullPath: '/password-reset/'
+      preLoaderRoute: typeof PasswordResetIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_protected/': {
@@ -909,6 +943,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedAlbumEventsIndexRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
+    '/password-reset/confirm/$uid/$token': {
+      id: '/password-reset/confirm/$uid/$token'
+      path: '/password-reset/confirm/$uid/$token'
+      fullPath: '/password-reset/confirm/$uid/$token'
+      preLoaderRoute: typeof PasswordResetConfirmUidTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_protected/sharing/withme/$tab': {
       id: '/_protected/sharing/withme/$tab'
       path: '/sharing/withme/$tab'
@@ -1100,6 +1141,8 @@ const rootRouteChildren: RootRouteChildren = {
   PublicRouteRoute: PublicRouteRouteWithChildren,
   LoginRoute: LoginRoute,
   SignupRoute: SignupRoute,
+  PasswordResetIndexRoute: PasswordResetIndexRoute,
+  PasswordResetConfirmUidTokenRoute: PasswordResetConfirmUidTokenRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/frontend/src/routes/login.tsx
+++ b/apps/frontend/src/routes/login.tsx
@@ -1,4 +1,5 @@
 import {
+  Anchor,
   Button,
   Card,
   Center,
@@ -103,6 +104,11 @@ export function LoginPage(): JSX.Element {
                 <Button variant="gradient" gradient={{ from: "#43cea2", to: "#185a9d" }} type="submit">
                   {t("login.login")}
                 </Button>
+                {siteSettings?.email_configured && (
+                  <Anchor href="/password-reset" size="sm" ta="center">
+                    {t("passwordreset.forgotpassword")}
+                  </Anchor>
+                )}
                 {siteSettings && siteSettings.allow_registration && (
                   <Button
                     disabled={!siteSettings.allow_registration || isLoading}

--- a/apps/frontend/src/routes/password-reset.confirm.$uid.$token.tsx
+++ b/apps/frontend/src/routes/password-reset.confirm.$uid.$token.tsx
@@ -1,0 +1,101 @@
+import { Anchor, Button, Card, Group, Image, PasswordInput, Stack, Title, useComputedColorScheme } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
+import { IconLock as Lock } from "@tabler/icons-react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import React from "react";
+import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { useConfirmPasswordResetMutation } from "../api_client/auth";
+
+export const Route = createFileRoute("/password-reset/confirm/$uid/$token")();
+
+export function PasswordResetConfirmPage(): JSX.Element {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const colorScheme = useComputedColorScheme("dark");
+  const { uid, token } = Route.useParams();
+  const { mutate: confirmReset, isPending } = useConfirmPasswordResetMutation();
+
+  const form = useForm({
+    initialValues: { password: "", passwordConfirm: "" },
+    validate: {
+      passwordConfirm: (value, values) => (value !== values.password ? t("passwordreset.errormustmatch") : null),
+    },
+  });
+
+  function onSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const { hasErrors } = form.validate();
+    if (hasErrors) {
+      return;
+    }
+    confirmReset(
+      { uid, token, new_password: form.values.password },
+      {
+        onSuccess: () => {
+          showNotification({
+            message: t("passwordreset.success"),
+            color: "teal",
+          });
+          navigate({ to: "/login" });
+        },
+        onError: () => {
+          showNotification({
+            message: t("passwordreset.errorinvalidlink"),
+            color: "red",
+          });
+        },
+      }
+    );
+  }
+
+  return (
+    <Stack align="center" justify="flex-end" pt={150}>
+      <Group gap="xs" justify="center">
+        <Image height={80} width={80} fit="contain" src={colorScheme === "dark" ? "/logo-white.png" : "/logo.png"} />
+        <span style={{ fontSize: 18 }}>
+          <b>{t("login.name")}</b>
+        </span>
+      </Group>
+      <div className="login-form">
+        <Card>
+          <Stack>
+            <Title order={3}>{t("passwordreset.choosetitle")}</Title>
+            <form onSubmit={onSubmit}>
+              <Stack>
+                <PasswordInput
+                  required
+                  leftSection={<Lock />}
+                  placeholder={t("passwordreset.newpasswordplaceholder")}
+                  name="password"
+                  {...form.getInputProps("password")}
+                />
+                <PasswordInput
+                  required
+                  leftSection={<Lock />}
+                  placeholder={t("passwordreset.confirmpasswordplaceholder")}
+                  name="passwordConfirm"
+                  {...form.getInputProps("passwordConfirm")}
+                />
+                <Button
+                  loading={isPending}
+                  variant="gradient"
+                  gradient={{ from: "#43cea2", to: "#185a9d" }}
+                  type="submit"
+                >
+                  {t("passwordreset.setpassword")}
+                </Button>
+                <Anchor href="/login" size="sm" ta="center">
+                  {t("passwordreset.backtologin")}
+                </Anchor>
+              </Stack>
+            </form>
+          </Stack>
+        </Card>
+      </div>
+    </Stack>
+  );
+}
+
+Route.update({ component: PasswordResetConfirmPage });

--- a/apps/frontend/src/routes/password-reset.index.tsx
+++ b/apps/frontend/src/routes/password-reset.index.tsx
@@ -1,0 +1,102 @@
+import {
+  Anchor,
+  Button,
+  Card,
+  Group,
+  Image,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  useComputedColorScheme,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { IconMail as Mail } from "@tabler/icons-react";
+import { createFileRoute } from "@tanstack/react-router";
+import React, { useState } from "react";
+import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { useRequestPasswordResetMutation } from "../api_client/auth";
+import { EMAIL_REGEX } from "../util/util";
+
+export const Route = createFileRoute("/password-reset/")();
+
+export function PasswordResetRequestPage(): JSX.Element {
+  const { t } = useTranslation();
+  const colorScheme = useComputedColorScheme("dark");
+  const { mutate: requestReset, isPending } = useRequestPasswordResetMutation();
+  const [submitted, setSubmitted] = useState(false);
+
+  const form = useForm({
+    initialValues: { email: "" },
+    validate: {
+      email: value => (!EMAIL_REGEX.test(value) ? t("passwordreset.erroremail") : null),
+    },
+  });
+
+  function onSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const { hasErrors } = form.validate();
+    if (hasErrors) {
+      return;
+    }
+    requestReset(
+      { email: form.values.email },
+      {
+        // The endpoint always returns 200 (it never reveals whether the address
+        // is registered), so show the same confirmation regardless.
+        onSuccess: () => setSubmitted(true),
+      }
+    );
+  }
+
+  return (
+    <Stack align="center" justify="flex-end" pt={150}>
+      <Group gap="xs" justify="center">
+        <Image height={80} width={80} fit="contain" src={colorScheme === "dark" ? "/logo-white.png" : "/logo.png"} />
+        <span style={{ fontSize: 18 }}>
+          <b>{t("login.name")}</b>
+        </span>
+      </Group>
+      <div className="login-form">
+        <Card>
+          <Stack>
+            <Title order={3}>{t("passwordreset.title")}</Title>
+            {submitted ? (
+              <>
+                <Text>{t("passwordreset.checkemail")}</Text>
+                <Anchor href="/login">{t("passwordreset.backtologin")}</Anchor>
+              </>
+            ) : (
+              <form onSubmit={onSubmit}>
+                <Stack>
+                  <Text size="sm">{t("passwordreset.instructions")}</Text>
+                  <TextInput
+                    required
+                    leftSection={<Mail />}
+                    placeholder={t("passwordreset.emailplaceholder")}
+                    name="email"
+                    {...form.getInputProps("email")}
+                  />
+                  <Button
+                    loading={isPending}
+                    variant="gradient"
+                    gradient={{ from: "#43cea2", to: "#185a9d" }}
+                    type="submit"
+                  >
+                    {t("passwordreset.sendlink")}
+                  </Button>
+                  <Anchor href="/login" size="sm" ta="center">
+                    {t("passwordreset.backtologin")}
+                  </Anchor>
+                </Stack>
+              </form>
+            )}
+          </Stack>
+        </Card>
+      </div>
+    </Stack>
+  );
+}
+
+Route.update({ component: PasswordResetRequestPage });

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - SKIP_PATTERNS=${skipPatterns:-}
       - ALLOW_UPLOAD=${allowUpload:-false}
       - CSRF_TRUSTED_ORIGINS=${csrfTrustedOrigins:-}
+      - FRONTEND_BASE_URL=${frontendBaseUrl:-}
       - DEBUG=0
     depends_on:
       db:

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -41,6 +41,18 @@ dbHost=db
 
 # ---------------------------------------------------------------------------------------------
 
+# Outgoing email (for the self-service "Forgot password" flow) is configured in
+# the app itself: Admin area -> Site Settings -> Email. No SMTP settings are
+# needed here.
+#
+# The one email-related deploy setting is the base URL of your LibrePhotos site,
+# used to build the link in the reset email (e.g. https://photos.example.com).
+# Set it whenever you enable email: behind the bundled proxy the backend cannot
+# infer its own public address, so the link would otherwise be unreachable.
+# frontendBaseUrl=
+
+# ---------------------------------------------------------------------------------------------
+
 # If you are not a developer ignore the following parameters: you will never need them.
 
 # Where shall we store the backend and frontend code files.


### PR DESCRIPTION
Adds a self-service password reset flow, so a user who has forgotten their password can recover access without shell access to the server. Until now the only path was an administrator running the `changepassword` management command; this closes that gap for ordinary users.

This builds directly on the admin-configurable email infrastructure from #1906 (issue #1905). The reset email is sent through the same `DynamicEmailBackend`, so it uses whatever the administrator configured in Site Settings, and the "Forgot your password?" link on the login screen only appears when email is actually configured (the public `email_configured` flag) — an instance with no mail server set up shows no dead-end link.

The backend adds two `AllowAny` endpoints under `/api/auth/password/`. The request endpoint always returns 200 regardless of whether the address matches an account, so it cannot be used to enumerate registered emails, and it is throttled to guard against being used to email-bomb a third party. The confirm endpoint validates Django's `default_token_generator` token together with the configured password validators before setting the new password. A `FRONTEND_BASE_URL` setting lets the backend build a reset link that is reachable through the bundled proxy, which rewrites the `Host` header and does not forward `X-Forwarded-Host`.

On the frontend, an unauthenticated request page and confirm page carry the user through the flow, and the confirm route is added to the public-page whitelist in the API client so the background 401 handler does not bounce an unauthenticated visitor back to login before they can set a new password.

Email verification is intentionally out of scope here; it belongs with the OIDC work (#401), which shares the same email foundation.

Verified with 12 new backend unit tests (enumeration-safe request, throttling, token and password-validator enforcement on confirm, and the end-to-end happy path), ruff check/format clean, frontend tsc and eslint clean, and end-to-end in a running stack: requesting a reset for a real account sends the email through a configured SMTP server, and the emailed link sets a new password that logs in.

Closes #596.
