### PR TITLE
fix(frontend): make worker-indicator popover click-toggle so Cancel is reachable

### DIFF
--- a/apps/frontend/src/components/menubars/WorkerIndicator.tsx
+++ b/apps/frontend/src/components/menubars/WorkerIndicator.tsx
@@ -43,7 +43,7 @@ function WorkerRunningJob({ workerRunningJob }: IWorkerIndicator) {
 
 export function WorkerIndicator() {
   const { t } = useTranslation();
-  const [opened, { open, close }] = useDisclosure(false);
+  const [opened, { toggle, close }] = useDisclosure(false);
   const [workerColor, setWorkerColor] = useState("red");
   const { workerRunningJob, currentData } = useWorkerStatus();
 
@@ -52,9 +52,11 @@ export function WorkerIndicator() {
   }, [currentData?.queue_can_accept_job]);
 
   return (
-    <Popover opened={opened} width={260} position="bottom" withArrow>
+    // Toggle on click (not hover) so the popover stays open long enough to reach the
+    // Cancel button; click-outside and Escape close it via onChange.
+    <Popover opened={opened} onChange={value => !value && close()} width={260} position="bottom" withArrow>
       <Popover.Target>
-        <Indicator onMouseEnter={open} onMouseLeave={close} color={workerColor}>
+        <Indicator onClick={toggle} style={{ cursor: "pointer" }} color={workerColor}>
           <div />
         </Indicator>
       </Popover.Target>


### PR DESCRIPTION
The worker-status indicator in the top menu shows a popover with a running job's progress and a Cancel button, but the popover opened on hover (`onMouseEnter`) and closed on `onMouseLeave`. Moving the cursor from the dot toward the Cancel button leaves the dot, so the popover dismisses before the button can be clicked. In practice a regular (non-admin) user can see that a job is running but has no way to cancel it — the only reachable job list is the superuser-gated admin page.

This switches the popover to open and close on click (toggle) instead of hover, and wires `onChange` so that clicking outside or pressing Escape still dismisses it. The Cancel button is now reachable. No behavior changes for the running-job progress display itself.
