### PR TITLE
docs: replace removed `make rename` with the current procedure

### DIFF
--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -77,13 +77,21 @@ Always include the trailing slash, e.g. `/photos/`, not `/photos`.
 
 ### Changing the container names
 
-Follow the normal instructions as per your chosen build, but after updating the .env file to choose your container names, run
+Container names are set directly in `docker-compose.yml` through the `container_name` keys (`proxy`, `db`, `frontend` and `backend`). Edit those values if you want different names, for example when running more than one LibrePhotos stack on the same host:
 
-```bash
-make rename
+```yaml
+services:
+  backend:
+    container_name: myphotos-backend
 ```
 
-Then you can resume following the normal instructions.
+These are the names you pass to `docker exec`, `docker logs` and similar commands.
+
+They are separate from the **service** names — the `proxy:`, `db:`, `frontend:` and `backend:` keys themselves — which the containers use to reach each other over the Compose network. The bundled proxy resolves `frontend` and `backend` by service name, so leave those keys as they are.
+
+:::note
+Older guides mention a `make rename` helper that rewrote these names from your `.env` file. It was removed together with `deploy/Makefile`; edit `docker-compose.yml` directly instead.
+:::
 
 ### Old environment variables
 

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -36,7 +36,7 @@ dbUser=docker
 # The password used by the database.
 dbPass=AaAa1234
 
-# Database host. Only change this if you want to use your own existing Postgres server. If using your own server, you can remove the 'db' container from docker-compose.yml. If you're changing the name of the DB's container name (DB_CONT_NAME further down), you need to set this variable to match that name too.
+# Database host. Only change this if you want to use your own existing Postgres server. If using your own server, you can remove the 'db' service from docker-compose.yml. If you rename the 'db' service there, set this variable to match the new name.
 dbHost=db
 
 # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
The **Changing the container names** section of the installation docs told users to run:

```bash
make rename
```

That helper no longer exists. It was removed in 52f3644e together with `deploy/Makefile` and the `docker-compose.*.raw` templates, so anyone following this page hits a missing target. Container names are now set directly through the `container_name` keys in `deploy/compose/docker-compose.yml`.

### Changes

- **`apps/docs/docs/installation/environment-variables.md`** — document editing `container_name` in `docker-compose.yml`, with a note explaining that `make rename` was removed so people following older guides aren't stranded. Also spells out that `container_name` is distinct from the Compose **service** name: `deploy/docker/proxy/nginx.conf` resolves `frontend:3000` and `backend:8001` by service name, so those keys must stay put even if the container names change.
- **`deploy/compose/librephotos.env`** — the `dbHost` comment referred to "`DB_CONT_NAME` further down". No such variable exists anywhere in the repo; rewrote it to reference the `db` service instead.

Docs only, no code changes.

### Verification

Grepped for residual `make rename` / `DB_CONT_NAME` references — the only remaining mention is the intentional note explaining the removal.

I did not run a full Docusaurus build (`apps/docs/node_modules` is absent and this machine's system Node is v16). The `:::note` admonition and fenced block mirror the existing `:::warning` already in the same file, which builds today.

Found while triaging #889, which reported the rename mechanism as broken — the mechanism is gone, but the docs still pointed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
