### PR TITLE
fix(backend): write date edits as XMP:DateCreated, fix dead EXIF:DateTime tag

### DIFF
--- a/apps/backend/api/date_time_extractor.py
+++ b/apps/backend/api/date_time_extractor.py
@@ -405,16 +405,22 @@ DEFAULT_RULES_PARAMS = [
         "rule_type": RuleTypes.USER_DEFINED,
     },
     {
-        "id": 15,
-        "name": f"Local time from {Tags.DATE_TIME} exif tag",
+        "id": 16,
+        "name": f"Local time from {Tags.DATE_CREATED} tag (set by LibrePhotos or other photo managers)",
         "rule_type": RuleTypes.EXIF,
-        "exif_tag": Tags.DATE_TIME,
+        "exif_tag": Tags.DATE_CREATED,
     },
     {
         "id": 1,
         "name": f"Local time from {Tags.DATE_TIME_ORIGINAL} exif tag",
         "rule_type": RuleTypes.EXIF,
         "exif_tag": Tags.DATE_TIME_ORIGINAL,
+    },
+    {
+        "id": 15,
+        "name": f"Local time from {Tags.DATE_TIME} exif tag",
+        "rule_type": RuleTypes.EXIF,
+        "exif_tag": Tags.DATE_TIME,
     },
     {
         "id": 2,

--- a/apps/backend/api/metadata/tags.py
+++ b/apps/backend/api/metadata/tags.py
@@ -3,7 +3,13 @@ class Tags:
     IMAGE_HEIGHT = "ImageHeight"
     IMAGE_WIDTH = "ImageWidth"
     DATE_TIME_ORIGINAL = "EXIF:DateTimeOriginal"
-    DATE_TIME = "EXIF:DateTime"
+    # ExifTool names EXIF tag 0x0132 "ModifyDate" - "EXIF:DateTime" is not a
+    # valid ExifTool tag and silently reads/writes nothing.
+    DATE_TIME = "EXIF:ModifyDate"
+    # XMP-photoshop:DateCreated. Unlike the EXIF date tags this one can be
+    # written into an XMP sidecar, and writing it leaves the camera's
+    # EXIF:DateTimeOriginal untouched.
+    DATE_CREATED = "XMP:DateCreated"
     QUICKTIME_CREATE_DATE = "QuickTime:CreateDate"
     QUICKTIME_DURATION = "QuickTime:Duration"
     LATITUDE = "Composite:GPSLatitude"

--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -222,8 +222,18 @@ class Photo(models.Model):
             if modified_fields is None or "rating" in modified_fields:
                 tags_to_write[Tags.RATING] = self.rating
             if modified_fields is not None and "timestamp" in modified_fields:
-                # To-Do: Only works for files and not for the sidecar file
-                tags_to_write[Tags.DATE_TIME] = self.timestamp
+                # XMP:DateCreated is used rather than an EXIF date tag because
+                # EXIF tags cannot be written into an XMP sidecar (exiftool
+                # silently leaves the sidecar unchanged), and because writing it
+                # preserves the camera's original EXIF:DateTimeOriginal.
+                # Serialized in exiftool's canonical form; ``self.timestamp`` is
+                # local time carrying a UTC tzinfo, so the offset is dropped
+                # rather than written out as a misleading "+00:00".
+                tags_to_write[Tags.DATE_CREATED] = (
+                    self.timestamp.strftime("%Y:%m:%d %H:%M:%S")
+                    if self.timestamp
+                    else ""
+                )
 
         if write_face_tags:
             from api.metadata.face_regions import get_face_region_tags

--- a/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
+++ b/apps/backend/api/tests/test_date_time_extractor_numeric_tags.py
@@ -1,13 +1,16 @@
 import datetime
 
+import pytz
 from django.test import TestCase
 
 from api.date_time_extractor import (
+    DEFAULT_RULES_PARAMS,
     TimeExtractionRule,
     _extract_no_tz_datetime_from_str,
     as_rules,
     extract_local_date_time,
 )
+from api.metadata.tags import Tags
 
 
 class NumericTagValueTest(TestCase):
@@ -75,3 +78,75 @@ class NumericTagValueTest(TestCase):
             user_defined_timestamp=None,
         )
         self.assertIsNone(result)
+
+
+class DefaultRulesOrderTest(TestCase):
+    """The default rules must be able to read back what LibrePhotos writes.
+
+    A date edit is persisted as ``XMP:DateCreated`` (an EXIF date tag cannot be
+    written into a sidecar, and overwriting ``EXIF:DateTimeOriginal`` would
+    destroy the capture time). A plain ``EXIF:DateTimeOriginal`` read wins over
+    XMP when the two disagree, so the ``XMP:DateCreated`` rule has to be ranked
+    above it or the next scan reverts the user's edit.
+    """
+
+    @staticmethod
+    def _extract(exif_values):
+        def exif_getter(tags):
+            return [exif_values.get(tag) for tag in tags]
+
+        return extract_local_date_time(
+            path="/photos/IMG_0001.jpg",
+            rules=as_rules(DEFAULT_RULES_PARAMS),
+            exif_getter=exif_getter,
+            gps_lat=None,
+            gps_lon=None,
+            user_default_tz="UTC",
+            user_defined_timestamp=None,
+        )
+
+    def test_date_created_wins_over_the_exif_date_tags(self):
+        result = self._extract(
+            {
+                Tags.DATE_CREATED: "2019:08:15 07:45:00",
+                Tags.DATE_TIME_ORIGINAL: "2005:01:02 03:04:05",
+                Tags.DATE_TIME: "2001:02:03 04:05:06",
+            }
+        )
+        self.assertEqual(
+            datetime.datetime(2019, 8, 15, 7, 45, 0, tzinfo=pytz.utc), result
+        )
+
+    def test_date_time_original_wins_when_there_is_no_date_created(self):
+        result = self._extract(
+            {
+                Tags.DATE_TIME_ORIGINAL: "2005:01:02 03:04:05",
+                Tags.DATE_TIME: "2001:02:03 04:05:06",
+            }
+        )
+        self.assertEqual(
+            datetime.datetime(2005, 1, 2, 3, 4, 5, tzinfo=pytz.utc), result
+        )
+
+    def test_modify_date_is_still_used_as_a_last_resort(self):
+        result = self._extract({Tags.DATE_TIME: "2001:02:03 04:05:06"})
+        self.assertEqual(
+            datetime.datetime(2001, 2, 3, 4, 5, 6, tzinfo=pytz.utc), result
+        )
+
+    def test_user_defined_timestamp_still_outranks_every_exif_rule(self):
+        user_timestamp = datetime.datetime(1999, 12, 31, 23, 59, 59, tzinfo=pytz.utc)
+
+        def exif_getter(tags):
+            return [{Tags.DATE_CREATED: "2019:08:15 07:45:00"}.get(tag) for tag in tags]
+
+        result = extract_local_date_time(
+            path="/photos/IMG_0001.jpg",
+            rules=as_rules(DEFAULT_RULES_PARAMS),
+            exif_getter=exif_getter,
+            gps_lat=None,
+            gps_lon=None,
+            user_default_tz="UTC",
+            user_defined_timestamp=user_timestamp,
+        )
+        self.assertEqual(user_timestamp, result)

--- a/apps/backend/api/tests/test_exiftool_tag_names.py
+++ b/apps/backend/api/tests/test_exiftool_tag_names.py
@@ -1,0 +1,206 @@
+"""Non-mocked exiftool tests.
+
+The rest of the suite patches :func:`api.metadata.writer.write_metadata` away, so
+a tag name ExifTool does not recognise ships green. ``Tags.DATE_TIME`` was
+``"EXIF:DateTime"`` for years - a name ExifTool has never accepted, since it
+calls EXIF tag 0x0132 ``ModifyDate`` - which meant both the datetime rule using
+it and the timestamp write-back silently did nothing. These tests run the real
+binary so that class of bug fails loudly.
+"""
+
+import datetime
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import PIL.Image
+from django.test import SimpleTestCase, TestCase
+
+from api.metadata.reader import get_sidecar_files_in_priority_order
+from api.metadata.tags import Tags
+from api.metadata.writer import write_metadata
+from api.models.file import File
+from api.tests.utils import create_test_photo, create_test_user
+
+EXIFTOOL = shutil.which("exiftool")
+
+# Only the tags LibrePhotos actually writes. Plenty of entries in ``Tags`` are
+# legitimately read-only (Composite:GPSLatitude, File:FileSize, ImageHeight,
+# ...), so this is deliberately not a blanket sweep over the class.
+WRITTEN_TAGS = [
+    Tags.RATING,
+    Tags.DATE_CREATED,
+    Tags.REGION_INFO_WRITE,
+    Tags.SUBJECT,
+]
+
+# What ExifTool says when it does not know a tag name.
+UNKNOWN_TAG_MARKERS = (
+    "doesn't exist or isn't writable",
+    "is not defined",
+)
+
+TIMESTAMP = datetime.datetime(2019, 8, 15, 7, 45, 0, tzinfo=datetime.timezone.utc)
+TIMESTAMP_EXIFTOOL = "2019:08:15 07:45:00"
+
+
+def run_exiftool(*args):
+    return subprocess.run([EXIFTOOL, *args], capture_output=True, text=True)
+
+
+def read_tag(path, tag):
+    """Read a single tag value with a bare exiftool call (-s3 = value only)."""
+    return run_exiftool(f"-{tag}", "-s3", path).stdout.strip()
+
+
+def make_jpeg(directory, name="test.jpg"):
+    path = os.path.join(directory, name)
+    PIL.Image.new("RGB", (16, 12), (10, 20, 30)).save(path)
+    return path
+
+
+@unittest.skipUnless(EXIFTOOL, "exiftool binary not available")
+class ExifToolTagNameTest(SimpleTestCase):
+    """Every tag name LibrePhotos writes must be one ExifTool knows."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="librephotos-tagnames")
+        self.addCleanup(shutil.rmtree, self.directory, True)
+        self.image = make_jpeg(self.directory)
+
+    def test_written_tags_are_writable(self):
+        for tag in WRITTEN_TAGS:
+            with self.subTest(tag=tag):
+                # An empty value is a delete, which is enough to make ExifTool
+                # resolve the name without caring about value formatting.
+                result = run_exiftool(f"-{tag}=", "-overwrite_original", self.image)
+                for marker in UNKNOWN_TAG_MARKERS:
+                    self.assertNotIn(
+                        marker,
+                        result.stderr,
+                        f"exiftool does not know the tag {tag!r}: {result.stderr}",
+                    )
+
+    def test_date_time_tag_reads_back_modify_date(self):
+        """``Tags.DATE_TIME`` must name the EXIF tag exiftool calls ModifyDate.
+
+        Regression guard for ``DATE_TIME = "EXIF:DateTime"``: written with the
+        literal ExifTool name and read back through the constant, so a wrong
+        constant fails here.
+        """
+        written = run_exiftool(
+            f"-EXIF:ModifyDate={TIMESTAMP_EXIFTOOL}",
+            "-overwrite_original",
+            self.image,
+        )
+        self.assertEqual(0, written.returncode, written.stderr)
+
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(self.image, Tags.DATE_TIME))
+
+    def test_date_time_tag_is_writable(self):
+        result = run_exiftool(
+            f"-{Tags.DATE_TIME}={TIMESTAMP_EXIFTOOL}",
+            "-overwrite_original",
+            self.image,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(self.image, Tags.DATE_TIME))
+
+    def test_date_created_write_preserves_original_capture_time(self):
+        """Writing our date must not clobber the camera's DateTimeOriginal."""
+        run_exiftool(
+            "-EXIF:DateTimeOriginal=2005:01:02 03:04:05",
+            "-overwrite_original",
+            self.image,
+        )
+
+        result = run_exiftool(
+            f"-{Tags.DATE_CREATED}={TIMESTAMP_EXIFTOOL}",
+            "-overwrite_original",
+            self.image,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(self.image, Tags.DATE_CREATED))
+        self.assertEqual(
+            "2005:01:02 03:04:05", read_tag(self.image, Tags.DATE_TIME_ORIGINAL)
+        )
+
+    def test_exif_date_tags_do_not_round_trip_through_a_sidecar(self):
+        """Why the write-back uses XMP:DateCreated instead of an EXIF date tag.
+
+        ExifTool accepts ``-EXIF:DateTimeOriginal=`` against an ``.xmp`` and then
+        writes nothing at all, exit code 0 - a silent no-op.
+        """
+        sidecar = os.path.join(self.directory, "sidecar.xmp")
+        run_exiftool(f"-{Tags.DATE_CREATED}={TIMESTAMP_EXIFTOOL}", sidecar)
+        self.assertTrue(os.path.exists(sidecar))
+
+        result = run_exiftool(
+            f"-{Tags.DATE_TIME_ORIGINAL}={TIMESTAMP_EXIFTOOL}",
+            "-overwrite_original",
+            sidecar,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", read_tag(sidecar, Tags.DATE_TIME_ORIGINAL))
+        # ... while the XMP tag we do use is readable from the same sidecar.
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(sidecar, Tags.DATE_CREATED))
+
+
+@unittest.skipUnless(EXIFTOOL, "exiftool binary not available")
+class TimestampWriteBackRoundTripTest(TestCase):
+    """``Photo._save_metadata`` timestamp write-back, through real exiftool.
+
+    This path had never actually executed: ``Tags.DATE_TIME`` was not a real tag,
+    so nothing was ever written and the serialized value was never validated.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.directory = tempfile.mkdtemp(prefix="librephotos-writeback")
+        self.addCleanup(shutil.rmtree, self.directory, True)
+
+    def _photo_on_disk(self, name):
+        image = make_jpeg(self.directory, name)
+        photo = create_test_photo(owner=self.user)
+        photo.main_file = File.create(image, self.user)
+        photo.timestamp = TIMESTAMP
+        return photo, image
+
+    def test_round_trips_into_the_media_file(self):
+        photo, image = self._photo_on_disk("media.jpg")
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=False)
+
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(image, Tags.DATE_CREATED))
+
+    def test_round_trips_into_the_sidecar(self):
+        photo, image = self._photo_on_disk("sidecar.jpg")
+        sidecar = get_sidecar_files_in_priority_order(image)[0]
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=True)
+
+        self.assertTrue(os.path.exists(sidecar), "no sidecar was created")
+        self.assertEqual(TIMESTAMP_EXIFTOOL, read_tag(sidecar, Tags.DATE_CREATED))
+
+    def test_media_file_write_keeps_the_capture_time(self):
+        photo, image = self._photo_on_disk("preserve.jpg")
+        run_exiftool(
+            "-EXIF:DateTimeOriginal=2005:01:02 03:04:05", "-overwrite_original", image
+        )
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=False)
+
+        self.assertEqual(
+            "2005:01:02 03:04:05", read_tag(image, Tags.DATE_TIME_ORIGINAL)
+        )
+
+    def test_write_metadata_writes_nothing_for_an_unknown_tag(self):
+        """Documents the failure mode this module exists to catch."""
+        image = make_jpeg(self.directory, "bogus.jpg")
+
+        write_metadata(image, {"EXIF:DateTime": TIMESTAMP_EXIFTOOL}, use_sidecar=False)
+
+        self.assertEqual("", read_tag(image, "EXIF:ModifyDate"))

--- a/apps/backend/api/tests/test_face_writeback.py
+++ b/apps/backend/api/tests/test_face_writeback.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -8,6 +9,7 @@ from api.metadata.face_regions import (
     reverse_orientation_transform,
     thumbnail_coords_to_normalized,
 )
+from api.metadata.tags import Tags
 from api.models.person import Person
 from api.tests.utils import (
     create_test_face,
@@ -571,3 +573,40 @@ class TestSaveMetadataIntegration(TestCase):
         self.assertEqual(tags["Rating"], 5)
         self.assertIn("XMP-mwg-rs:RegionInfo", tags)
         self.assertIn("Alice", tags["XMP-mwg-rs:RegionInfo"])
+
+    @patch("api.models.photo.write_metadata")
+    def test_save_metadata_timestamp_writes_date_created(self, mock_write_metadata):
+        """A timestamp edit is persisted as XMP:DateCreated, not an EXIF date.
+
+        ``Tags.DATE_TIME`` used to be written here. It was not a valid ExifTool
+        tag, and even the correct EXIF name cannot be written into a sidecar.
+        """
+        photo = create_test_photo(owner=self.user)
+        photo.timestamp = datetime.datetime(
+            2019, 8, 15, 7, 45, 0, tzinfo=datetime.timezone.utc
+        )
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=True)
+
+        mock_write_metadata.assert_called_once()
+        tags = mock_write_metadata.call_args[0][1]
+        self.assertEqual("XMP:DateCreated", Tags.DATE_CREATED)
+        self.assertIn(Tags.DATE_CREATED, tags)
+        # exiftool's canonical form, without the misleading "+00:00" that
+        # str(datetime) would append to what is really a local time.
+        self.assertEqual("2019:08:15 07:45:00", tags[Tags.DATE_CREATED])
+        self.assertNotIn(Tags.DATE_TIME, tags)
+        self.assertNotIn("EXIF:DateTime", tags)
+
+    @patch("api.models.photo.write_metadata")
+    def test_save_metadata_clears_date_created_when_timestamp_is_removed(
+        self, mock_write_metadata
+    ):
+        """An empty value tells exiftool to delete the tag, rather than crashing."""
+        photo = create_test_photo(owner=self.user)
+        photo.timestamp = None
+
+        photo._save_metadata(modified_fields=["timestamp"], use_sidecar=True)
+
+        tags = mock_write_metadata.call_args[0][1]
+        self.assertEqual("", tags[Tags.DATE_CREATED])

--- a/apps/backend/api/tests/test_predefined_rules.py
+++ b/apps/backend/api/tests/test_predefined_rules.py
@@ -22,7 +22,7 @@ class PredefinedRulesTest(TestCase):
         self.assertIsInstance(data, str)
         rules = json.loads(data)
         self.assertIsInstance(rules, list)
-        self.assertEqual(15, len(rules))
+        self.assertEqual(16, len(rules))
 
     def test_default_rules_on_predefined_rules_endpoint(self):
         response = self.client.get("/api/predefinedrules/")
@@ -40,3 +40,8 @@ class PredefinedRulesTest(TestCase):
         rules = json.loads(response.json())
         other_rules = list(filter(lambda x: not x["is_default"], rules))
         self.assertListEqual(OTHER_RULES_PARAMS, other_rules)
+
+    def test_rule_ids_are_unique(self):
+        """Rule ids identify a rule in the settings UI, so they must not collide."""
+        ids = [rule["id"] for rule in DEFAULT_RULES_PARAMS + OTHER_RULES_PARAMS]
+        self.assertEqual(len(ids), len(set(ids)), f"duplicate rule ids in {ids}")


### PR DESCRIPTION
Supersedes #1892. Refs #1858.

Credit to @vinaykumarbharwal for the original analysis and the rule reordering in #1892 — that reorder is carried over here. While reviewing it, the root cause turned out to sit a level deeper.

## The dead tag

`Tags.DATE_TIME` is `"EXIF:DateTime"`, which is not a valid ExifTool tag. ExifTool names EXIF 0x0132 `ModifyDate`. Reads return nothing, and writes are rejected outright:

```
$ exiftool "-EXIF:DateTime=2024:05:01 10:30:00" photo.jpg
Warning: Sorry, EXIF:DateTime doesn't exist or isn't writable
```

Two consequences, both silent:

- **Datetime rule 15 has never matched a photo.** It asks for a tag that always reads back empty.
- **The timestamp write-back in `photo.py` has always written nothing.** A date edit made in LibrePhotos never reached the file or the sidecar.

## Why fixing the tag name isn't enough

Correcting `EXIF:DateTime` → `EXIF:ModifyDate` fixes the *read* rule, but it does not fix the write-back, because EXIF-prefixed tags cannot round-trip through an XMP sidecar at all:

```
$ exiftool "-EXIF:DateTimeOriginal=2024:05:01 10:30:00" -overwrite_original photo.xmp
    0 image files updated
    1 image files unchanged          # exit 0, nothing written
```

So for anyone running `save_metadata_to_disk=SIDECAR_FILE`, writing any EXIF date tag is a no-op regardless of which name we use.

## What this PR does

**1. `XMP:DateCreated` for the write-back.** `Photo._save_metadata` now writes `XMP:DateCreated` (`XMP-photoshop:DateCreated`) instead of an EXIF date tag. It:

- writes and reads correctly in **both** media-file and sidecar mode;
- is what Digikam, Lightroom and Immich read;
- is **non-destructive** — unlike `MWG:DateTimeOriginal`, writing it leaves the camera's `EXIF:DateTimeOriginal` untouched.

The value is serialized in exiftool's canonical `%Y:%m:%d %H:%M:%S` form. `Photo.timestamp` is a local time carrying a UTC `tzinfo` by LibrePhotos convention, so the offset is deliberately dropped rather than written out as a misleading `+00:00`. (The path had never actually executed, so the previous implicit `str(datetime)` serialization was entirely unvalidated. It does happen to be accepted by exiftool, but it emits an offset that isn't true.)

**2. A matching read rule, ranked above `EXIF:DateTimeOriginal`.** This is required, not cosmetic. On a file where EXIF and XMP disagree, both a plain `EXIF:DateTimeOriginal` read *and* an `MWG:DateTimeOriginal` read return the EXIF value. Without a `XMP:DateCreated` rule ranked above rule 1, LibrePhotos would write its own edit and then fail to read it back — the next scan would silently revert the user's change. New default rule id 16 sits directly below the user-defined rule.

**3. `EXIF:ModifyDate`, with rule 15 below rule 1.** `Tags.DATE_TIME` is corrected, and the rule that uses it is demoted below `EXIF:DateTimeOriginal` — `ModifyDate` is a last-edited time, not a capture time, so it should never outrank the original. This is @vinaykumarbharwal's ordering from #1892.

Resulting default rule order:

| # | id | rule |
|---|----|------|
| 1 | 14 | Timestamp set by user |
| 2 | 16 | `XMP:DateCreated` *(new)* |
| 3 | 1  | `EXIF:DateTimeOriginal` |
| 4 | 15 | `EXIF:ModifyDate` *(was the dead `EXIF:DateTime`, was ranked above rule 1)* |

Everything below is unchanged, and `OTHER_RULES_PARAMS` is untouched.

## Trade-off, stated explicitly

Because we write only XMP and leave EXIF alone, **software that reads *only* `EXIF:DateTimeOriginal` will keep showing the camera date after a LibrePhotos date edit.** That is the deliberate price of not destroying capture time. `MWG:DateTimeOriginal` would sync both, but it overwrites the original EXIF value — once that's gone, the real capture time is unrecoverable. Preserving it is worth the inconsistency for EXIF-only readers.

## No data migration

Existing users keep their stored `datetime_rules` JSON. This is intentional:

- The **write-back fix lives in code**, so it reaches *all* users immediately, regardless of their stored rules.
- Only the **rule changes** are new-users-only.
- Existing users **lose nothing**, because their rule 15 was already dead — it has never matched a photo since it was added. Users who want the new `XMP:DateCreated` rule can add it from the settings UI, where it now appears in the predefined list.

## Tests

Adds `api/tests/test_exiftool_tag_names.py`, a **non-mocked** module that runs the real exiftool binary (skipped when the binary is absent). This is the most important part of the PR: every bug above shipped green precisely because the suite mocks `write_metadata` away, so a tag name ExifTool has never heard of passed CI for years.

It asserts:

- every tag LibrePhotos actually **writes** (`Tags.RATING`, `Tags.DATE_CREATED`, `Tags.REGION_INFO_WRITE`, `Tags.SUBJECT`) is accepted as writable — exiftool's stderr contains neither `doesn't exist or isn't writable` nor `is not defined`. Deliberately not a blanket sweep over `Tags`; several entries (`Composite:GPSLatitude`, `File:FileSize`, `ImageHeight`, ...) are legitimately read-only;
- `Tags.DATE_TIME` round-trips — a real `ModifyDate` is written with the literal ExifTool name and read back through the constant, so a wrong constant fails here. Direct regression guard for the `EXIF:DateTime` bug;
- the timestamp write-back round-trips through the **real** `write_metadata`, for both `use_sidecar=False` (temp JPEG) and `use_sidecar=True` (temp `.xmp`). Direct guard for the silent sidecar no-op;
- writing `XMP:DateCreated` leaves `EXIF:DateTimeOriginal` intact;
- `-EXIF:DateTimeOriginal=` into an `.xmp` really is a silent no-op, documenting why the write-back uses XMP.

Plus, in the existing modules: a rules-order test (a file carrying all three of `XMP:DateCreated`, `EXIF:DateTimeOriginal` and `EXIF:ModifyDate` set to different dates resolves to `XMP:DateCreated`; with only the latter two it resolves to `DateTimeOriginal`), a test that `_save_metadata(modified_fields=["timestamp"], ...)` writes `Tags.DATE_CREATED` and not `Tags.DATE_TIME`, and a rule-id uniqueness check.

Verified against exiftool 13.59 with the pinned PyExifTool 0.4.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
