### PR TITLE
fix: work through the open bug backlog (13 issues, each with a regression test)

### DIFF
--- a/apps/backend/api/api_util.py
+++ b/apps/backend/api/api_util.py
@@ -37,14 +37,24 @@ def has_hidden_attribute(filepath):
         return False
 
 
+def list_subdirectories(path):
+    try:
+        with os.scandir(path) as entries:
+            children = [os.path.join(path, x) for x in entries]
+    except OSError as e:
+        # Directories the server is not allowed to read (e.g. folders owned by
+        # another user on a network mount) are listed without children instead
+        # of breaking the whole directory tree.
+        logger.warning("Could not list directory %s: %s", path, e)
+        return []
+    return [x for x in children if os.path.isdir(x) and not is_hidden(x)]
+
+
 def path_to_dict(path, recurse=2):
     d = {"title": os.path.basename(path), "absolute_path": path}
     if recurse > 0:
         d["children"] = [
-            path_to_dict(os.path.join(path, x), recurse - 1)
-            for x in os.scandir(path)
-            if os.path.isdir(os.path.join(path, x))
-            and not is_hidden(os.path.join(path, x))
+            path_to_dict(x, recurse - 1) for x in list_subdirectories(path)
         ]
     else:
         d["children"] = []

--- a/apps/backend/api/autoalbum.py
+++ b/apps/backend/api/autoalbum.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pytz
+from django.db import transaction
 from django.db.models import Q
 
 from api.models import (
@@ -56,7 +57,7 @@ def generate_event_albums(user, job_id):
         photos = (
             Photo.objects.filter(Q(owner=user))
             .exclude(Q(exif_timestamp=None))
-            .only("exif_timestamp")
+            .only("exif_timestamp", "exif_gps_lat", "exif_gps_lon")
         )
 
         def group(photos, dt=timedelta(hours=6)):
@@ -98,24 +99,94 @@ def generate_event_albums(user, job_id):
             )
             items = group
             if len(group) >= 2:
-                qs = AlbumAuto.objects.filter(owner=user).filter(
-                    timestamp__range=(key, lastKey)
+                # An auto album is identified by the photos it holds, not by its
+                # timestamp. The timestamp is only an anchor on the first photo
+                # of the group as it was when the album got created, and that
+                # photo may well be gone by the next run. Every photo taken
+                # between the first and the last photo of a group belongs to
+                # that group, so an album holding one of them is the album of
+                # this event (#462). An album that is anchored on this group but
+                # lost all of its photos is claimed as well, both to reuse it
+                # and because (timestamp, owner) is unique.
+                # The two excludes keep albums that reach outside this event out
+                # of the running. Photos are only ever added to an auto album,
+                # never removed, so correcting the date of a single photo leaves
+                # its old album listing a photo that now belongs to a different
+                # event. Such an album overlaps this group by that one stale
+                # entry only, and treating it as this group's album would move -
+                # and, once it looked like a duplicate, delete - an album of
+                # unrelated photos.
+                albums = list(
+                    AlbumAuto.objects.filter(owner=user)
+                    .filter(
+                        Q(
+                            photos__exif_timestamp__range=(
+                                group[0].exif_timestamp,
+                                group[-1].exif_timestamp,
+                            )
+                        )
+                        | Q(timestamp=key)
+                    )
+                    .exclude(photos__exif_timestamp__lt=group[0].exif_timestamp)
+                    .exclude(photos__exif_timestamp__gt=group[-1].exif_timestamp)
+                    .distinct()
+                    .order_by("created_on", "id")
                 )
-                if qs.count() == 0:
+                changed = False
+                if albums:
+                    album = albums[0]
+                    logger.info(f"job {job_id}: update auto album {album.id}")
+                    # Newly imported photos can bridge the gap between two
+                    # events, which turns them into a single group. Fold the
+                    # albums of the former events into the oldest one instead of
+                    # leaving duplicates behind.
+                    for duplicate in albums[1:]:
+                        logger.info(
+                            f"job {job_id}: merging auto album {duplicate.id} "
+                            f"into {album.id}"
+                        )
+                        with transaction.atomic():
+                            album.photos.add(
+                                *duplicate.photos.values_list("pk", flat=True)
+                            )
+                            # The merged album carries user state that only
+                            # exists on it, so move it over before it is gone.
+                            album.favorited = album.favorited or duplicate.favorited
+                            album.shared_to.add(*duplicate.shared_to.all())
+                            album.save()
+                            duplicate.delete()
+                        changed = True
+                else:
                     album = AlbumAuto(
                         created_on=datetime.utcnow().replace(tzinfo=pytz.utc),
                         owner=user,
+                        timestamp=key,
                     )
-                    album.timestamp = key
                     album.save()
-
                     logger.info(f"job {job_id}: generate auto album {album.id}")
-                    locs = []
-                    for item in items:
-                        album.photos.add(item)
-                        item.save()
-                        if item.exif_gps_lat and item.exif_gps_lon:
-                            locs.append([item.exif_gps_lat, item.exif_gps_lon])
+                    changed = True
+
+                # Read the membership once instead of once per photo, otherwise
+                # re-running generation is quadratic in the album size (#836).
+                known_photos = set(album.photos.values_list("pk", flat=True))
+                new_items = [item for item in items if item.pk not in known_photos]
+                if new_items:
+                    album.photos.add(*new_items)
+                    changed = True
+
+                # Keep the anchor on the earliest photo the album actually
+                # holds, so that the album is still recognized as the album of
+                # this event after its first photo has been removed.
+                if album.timestamp != key:
+                    album.timestamp = key
+                    changed = True
+
+                if changed:
+                    locs = [
+                        [item.exif_gps_lat, item.exif_gps_lon]
+                        for item in items
+                        if item.exif_gps_lat and item.exif_gps_lon
+                    ]
                     if len(locs) > 0:
                         album_location = np.mean(np.array(locs), 0)
                         album_locations.append(album_location)
@@ -123,26 +194,12 @@ def generate_event_albums(user, job_id):
                         album.gps_lon = album_location[1]
                     else:
                         album_locations.append([])
-                    album._generate_title()
-                    album.save()
-                    continue
-                if qs.count() == 1:
-                    album = qs.first()
-                    logger.info(f"job {job_id}: update auto album {album.id}")
-                    for item in items:
-                        if item in album.photos.all():
-                            continue
-                        album.photos.add(item)
-                        item.save()
-                    album._generate_title()
-                    album.save()
-                    continue
-                if qs.count() > 1:
-                    # To-Do: Merge both auto albums
-                    logger.info(
-                        f"job {job_id}: found multiple auto albums for date {key.strftime(date_format)}"
-                    )
-                    continue
+
+                # Regenerate the title on every run, not just when the album
+                # changed: the people and places a title is built from are
+                # recognized long after the album itself was created.
+                album._generate_title()
+                album.save()
 
             lrj.update_progress(current=idx + 1, target=target_count)
 

--- a/apps/backend/api/directory_watcher/utils.py
+++ b/apps/backend/api/directory_watcher/utils.py
@@ -9,6 +9,7 @@ from constance import config as site_config
 from django.db.models import F
 from django.utils import timezone
 
+from api import util
 from api.models import LongRunningJob
 
 # How often (in loop iterations) to check the DB for job cancellation.
@@ -71,17 +72,28 @@ def walk_directory(directory, callback):
     """
     Recursively walk a directory and collect file paths.
 
+    Symlinks are deliberately followed, since the scan directory may itself be
+    - or contain - a link to a mounted share. An entry that is neither a real
+    directory nor a real file (a dangling link, a socket, a fifo) is skipped:
+    handing it to the photo pipeline only produces an unopenable path that
+    fails the whole scan job.
+
     Args:
         directory: Directory to scan
         callback: List to append file paths to
     """
     for file in os.scandir(directory):
         fpath = os.path.join(directory, file)
-        if not is_hidden(fpath) and not should_skip(fpath):
-            if os.path.isdir(fpath):
-                walk_directory(fpath, callback)
-            else:
-                callback.append(fpath)
+        if is_hidden(fpath) or should_skip(fpath):
+            continue
+        if os.path.isdir(fpath):
+            walk_directory(fpath, callback)
+        elif os.path.isfile(fpath):
+            callback.append(fpath)
+        else:
+            util.logger.warning(
+                f"skipping {fpath}: neither a file nor a directory (broken symlink?)"
+            )
 
 
 def walk_files(scan_files, callback):

--- a/apps/backend/api/models/photo_search.py
+++ b/apps/backend/api/models/photo_search.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-import api.models
 from api import util
 
 
@@ -64,8 +63,10 @@ class PhotoSearch(models.Model):
                 if im2txt_caption:
                     search_captions += im2txt_caption + " "
 
-        # Add face/person names
-        for face in api.models.face.Face.objects.filter(photo=self.photo).all():
+        # Add face/person names. Go through the related manager so a caller that
+        # already prefetched the faces (and their people) does not pay a query
+        # per photo and per face here.
+        for face in self.photo.faces.all():
             if face.person:
                 search_captions += face.person.name + " "
 

--- a/apps/backend/api/tests/test_repro_issue_1030.py
+++ b/apps/backend/api/tests/test_repro_issue_1030.py
@@ -1,0 +1,152 @@
+"""Repro for issue #1030 -- "can not view photos from nextcloud".
+
+Reported symptom: Nextcloud and LibrePhotos both run in Docker on the same
+host, each works on its own, but the user cannot browse / add an album from
+Nextcloud in LibrePhotos.
+
+The dialog that lets a user pick the Nextcloud folder to import is driven by a
+single endpoint, ``GET /api/nextcloud/listdir/?fpath=/``
+(``nextcloud/views.py::ListDir``).  That view is written as::
+
+    nc = nextcloud.Client(request.user.nextcloud_server_address)
+    nc.login(request.user.nextcloud_username, request.user.nextcloud_app_password)
+    try:
+        return Response([... for p in nc.list(path) if p.is_dir()])
+    except nextcloud.HTTPResponseError:
+        return Response(status=400)
+
+``Client.login()`` is the call that pyocclient documents as
+``:raises: HTTPResponseError in case an HTTP error status was returned`` -- and
+it sits **outside** the ``try``.  So the one error the view explicitly promises
+to translate into a clean ``400`` escapes as an unhandled exception and the
+endpoint answers ``500 Internal Server Error`` instead.  The same happens for a
+plain ``requests.exceptions.ConnectionError``, which is what a container that
+cannot reach the Nextcloud container raises -- it is not an
+``HTTPResponseError``, so even the call inside the ``try`` is unprotected.
+
+The frontend cannot recover from that: ``useFetchNextcloudDirsQuery`` fails,
+``isNextcloudError`` flips to true and
+``apps/frontend/src/components/settings/Library.tsx`` disables the "Browse"
+button with
+``disabled={isNextcloudError || isNextcloudFetching || !nextcloud_server_address}``,
+so there is no way to reach the Nextcloud photos at all.
+
+These tests assert the contract the view itself declares: a Nextcloud failure
+must come back as a handled client error, never as an unhandled 500.
+"""
+
+from unittest import mock
+
+import owncloud
+import requests
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.tests.utils import create_test_user
+
+LISTDIR_URL = "/api/nextcloud/listdir/?fpath=/"
+
+
+class NextcloudListDirErrorHandlingTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user(
+            # a hostname (not a bare private IP) so the SSRF allowlist in
+            # nextcloud/views.py::valid_url lets us reach the client code
+            nextcloud_server_address="https://cloud.example.com",
+            nextcloud_username="alice",
+            nextcloud_app_password="app-password",
+            nextcloud_scan_directory="/Photos",
+        )
+        self.client = APIClient()
+        # We want to inspect the response the endpoint produces instead of
+        # having Django re-raise the view's exception into the test runner.
+        self.client.raise_request_exception = False
+        self.client.force_authenticate(user=self.user)
+
+    @staticmethod
+    def _client_factory(login_side_effect=None, list_side_effect=None):
+        fake_client = mock.MagicMock()
+        if login_side_effect is not None:
+            fake_client.login.side_effect = login_side_effect
+        if list_side_effect is not None:
+            fake_client.list.side_effect = list_side_effect
+        return mock.MagicMock(return_value=fake_client)
+
+    def test_healthy_nextcloud_lists_directories(self):
+        """Sanity check: with a working Nextcloud the endpoint answers 200.
+
+        This pins down that the 500s in the tests below come from the error
+        paths of ListDir and not from a mis-wired patch target.
+        """
+        folder = mock.MagicMock()
+        folder.path = "/Photos/"
+        folder.is_dir.return_value = True
+        factory = self._client_factory()
+        factory.return_value.list.return_value = [folder]
+
+        with mock.patch("nextcloud.views.nextcloud.Client", factory):
+            response = self.client.get(LISTDIR_URL)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            [{"absolute_path": "/Photos/", "title": "Photos", "children": []}],
+            response.json(),
+        )
+
+    def test_rejected_app_password_returns_bad_request_not_server_error(self):
+        """Nextcloud answering 401 must surface as the documented 400."""
+        factory = self._client_factory(
+            login_side_effect=owncloud.HTTPResponseError(401)
+        )
+
+        with mock.patch("nextcloud.views.nextcloud.Client", factory):
+            response = self.client.get(LISTDIR_URL)
+
+        self.assertEqual(
+            400,
+            response.status_code,
+            "GET /api/nextcloud/listdir/ crashed with "
+            f"{response.status_code} instead of the 400 its own "
+            "`except nextcloud.HTTPResponseError` clause promises: "
+            "Client.login() is called outside the try block, so a Nextcloud "
+            "authentication failure escapes as an unhandled exception.",
+        )
+
+    def test_unreachable_nextcloud_server_returns_handled_error(self):
+        """A container that cannot reach Nextcloud must not 500 the endpoint."""
+        factory = self._client_factory(
+            login_side_effect=requests.exceptions.ConnectionError(
+                "Failed to establish a new connection: [Errno 111] Connection refused"
+            )
+        )
+
+        with mock.patch("nextcloud.views.nextcloud.Client", factory):
+            response = self.client.get(LISTDIR_URL)
+
+        self.assertLess(
+            response.status_code,
+            500,
+            "GET /api/nextcloud/listdir/ returned "
+            f"{response.status_code} when the Nextcloud server was "
+            "unreachable; an unreachable/misconfigured server address is a "
+            "user error and must be reported as a handled client error, not "
+            "as an unhandled backend crash.",
+        )
+
+    def test_listing_failure_that_is_not_http_error_is_still_handled(self):
+        """The try/except around nc.list() only catches HTTPResponseError."""
+        factory = self._client_factory(
+            list_side_effect=requests.exceptions.ConnectionError("Connection aborted.")
+        )
+
+        with mock.patch("nextcloud.views.nextcloud.Client", factory):
+            response = self.client.get(LISTDIR_URL)
+
+        self.assertLess(
+            response.status_code,
+            500,
+            "GET /api/nextcloud/listdir/ returned "
+            f"{response.status_code}: the `except nextcloud.HTTPResponseError` "
+            "guard around nc.list() is too narrow, so a dropped connection to "
+            "Nextcloud takes down the request instead of being reported.",
+        )

--- a/apps/backend/api/tests/test_repro_issue_1066.py
+++ b/apps/backend/api/tests/test_repro_issue_1066.py
@@ -1,0 +1,105 @@
+"""Repro for issue #1066 -- "Nextcloud integration does not work".
+
+Reported symptom: the Nextcloud connection works (the top level folders are
+listed in the browse dialog) but the "Scan photos (Nextcloud)" button stays
+grey/disabled forever.
+
+The frontend disables that button with
+
+    disabled={isNextcloudFetching || !workerAvailability || !nextcloud_server_address}
+
+(apps/frontend/src/components/settings/Library.tsx), where ``workerAvailability``
+is ``queue_can_accept_job`` from ``GET /api/rqavailable/``. That endpoint
+(api/views/jobs.py::QueueAvailabilityView) reports the queue as busy whenever
+*any* ``LongRunningJob`` still has ``finished=False``.
+
+``nextcloud/directory_watcher.py::scan_photos`` creates the LongRunningJob and
+*then* does the Nextcloud login, the recursive listing and the file downloads
+**outside** of its ``try/except`` block. Any failure there (bad app password,
+server unreachable, unset/renamed scan directory) escapes the function without
+ever calling ``lrj.fail()``, so the job row stays ``finished=False`` for good.
+From that point on ``queue_can_accept_job`` is permanently ``False`` and every
+scan button in the UI - Nextcloud included - is greyed out.
+
+The local scanner does this correctly: in
+``api/directory_watcher/scan_jobs.py::scan_photos`` everything after the job is
+created lives inside the ``try`` and the ``except`` marks the job failed.
+"""
+
+import uuid
+from unittest import mock
+
+import owncloud
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.models import LongRunningJob
+from api.tests.utils import create_test_user
+from nextcloud.directory_watcher import scan_photos as nextcloud_scan_photos
+
+RQ_AVAILABLE_URL = "/api/rqavailable/"
+
+
+class NextcloudScanFailureLeavesQueueBlockedTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user(
+            nextcloud_server_address="https://cloud.example.com",
+            nextcloud_username="alice",
+            nextcloud_app_password="app-password",
+            nextcloud_scan_directory="/Photos",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _run_failing_nextcloud_scan(self, job_id):
+        """Run a Nextcloud scan whose login fails, as a rejected app password does.
+
+        The exception is swallowed here on purpose: this test is about the state
+        the job row is left in, not about whether the call raises.
+        """
+        fake_client = mock.MagicMock()
+        fake_client.login.side_effect = owncloud.HTTPResponseError(401)
+        with mock.patch(
+            "nextcloud.directory_watcher.nextcloud.Client", return_value=fake_client
+        ):
+            try:
+                nextcloud_scan_photos(self.user, job_id)
+            except Exception:
+                pass
+
+    def test_failed_nextcloud_scan_marks_job_finished(self):
+        job_id = uuid.uuid4()
+
+        self._run_failing_nextcloud_scan(job_id)
+
+        job = LongRunningJob.objects.get(job_id=str(job_id))
+        self.assertTrue(
+            job.finished,
+            "A Nextcloud scan that could not log in must close its "
+            "LongRunningJob, otherwise the job stays 'running' forever and "
+            "blocks the queue.",
+        )
+        self.assertTrue(
+            job.failed,
+            "A Nextcloud scan that could not log in must be marked as failed.",
+        )
+
+    def test_queue_accepts_new_jobs_after_failed_nextcloud_scan(self):
+        """The 'Scan photos (Nextcloud)' button must not stay grey forever."""
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.json()["queue_can_accept_job"],
+            "sanity check: the queue is idle before any scan",
+        )
+
+        self._run_failing_nextcloud_scan(uuid.uuid4())
+
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.json()["queue_can_accept_job"],
+            "after a Nextcloud scan failed the queue must be free again; "
+            "while queue_can_accept_job is False the frontend keeps every "
+            "scan button (including 'Scan photos (Nextcloud)') disabled.",
+        )

--- a/apps/backend/api/tests/test_repro_issue_124.py
+++ b/apps/backend/api/tests/test_repro_issue_124.py
@@ -1,0 +1,210 @@
+"""Regression test for https://github.com/LibrePhotos/librephotos/issues/124
+
+"Failed to load image when using symbolic linked smb share".
+
+The reporter ran LibrePhotos in Docker with the pictures folder *symbolically
+linked* to an SMB share backed by ZFS.  Nothing rendered in the web UI:
+
+    "I have a VM running docker with pictures folder symbolic linked to an smb
+     share (zfs). The images fail to load, but when I click the route it is
+     available."
+
+The maintainer's diagnosis in the thread was "if an image can't load it is
+usually connected to missing thumbnails" -- i.e. the scan never produced any
+photo/thumbnail rows for the files living behind the link, so every tile in the
+grid was a broken image even though the underlying share was mounted and
+browsable.
+
+Root cause at the time the issue was filed (Nov 2020), in ``scan_photos``::
+
+    image_paths.extend([
+        os.path.join(dp, f) for dp, dn, fn in os.walk(user.scan_directory)
+        for f in fn
+    ])
+
+``os.walk`` does **not** descend into symlinked directories unless it is asked
+to -- ``followlinks`` defaults to ``False``.  So a scan directory that is (or
+contains) a symlink to a mounted share yielded zero files, no Photo rows and no
+thumbnails: exactly "the images fail to load".
+
+Fixed by commit 6ed99b95 (2021-01-05, "[FIX] #98 and #95"), which rewrote the
+walk as ``os.walk(user.scan_directory, followlinks=True)``.  The scanner was
+later rewritten again (commit 133709c1) into today's
+``api.directory_watcher.utils.walk_directory``, which classifies entries with
+``os.path.isdir()`` -- that follows symlinks too, so the fix survived the
+rewrite.
+
+These tests therefore PASS on current ``main``: they pin the fixed behaviour so
+the ``followlinks`` regression cannot come back, and they follow the path all
+the way to the media endpoint to show that a photo discovered behind the link
+is still addressable through nginx's internal ``/original`` route (had the walk
+resolved the link to its real target outside ``settings.PHOTOS``, the media view
+would emit a raw filesystem path that nginx cannot serve -- the same broken
+image by a different route).
+
+Windows note: ``os.symlink`` needs SeCreateSymbolicLinkPrivilege (Developer
+Mode).  Where that is unavailable we fall back to a directory junction created
+with ``mklink /J``, which needs no privilege and which ``os.path.isdir()``
+treats exactly like a POSIX directory symlink.  Be aware that the junction
+fallback is *not* a faithful stand-in for the original defect:
+``os.path.islink()`` is ``False`` for a junction, so even the pre-fix
+``os.walk(dir)`` would have descended into it.  On POSIX -- where the issue was
+reported and where CI runs -- ``os.symlink`` succeeds and the tests discriminate
+properly.  Independently of the platform, the fix is visible by inspection:
+neither ``walk_directory`` nor anything else on the scan path consults
+``os.path.islink``/``DirEntry.is_symlink``, so symlinked directories are always
+descended into.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from api.directory_watcher.utils import walk_directory
+from api.tests.utils import create_test_file, create_test_photo, create_test_user
+
+# Minimal JPEG so python-magic/File.create classify the file as an image.
+JPEG_BYTES = (
+    b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    b"\xff\xdb\x00\x43\x00" + bytes(64) + b"\xff\xd9"
+)
+
+
+def _make_dir_link(link_path, target_path):
+    """Create a directory symlink, or return ``None`` if the platform refuses."""
+    try:
+        os.symlink(target_path, link_path, target_is_directory=True)
+        return link_path
+    except (OSError, NotImplementedError):
+        pass
+
+    if os.name == "nt":
+        # Junctions are reparse points too and need no special privilege.
+        completed = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", link_path, target_path],
+            capture_output=True,
+        )
+        if completed.returncode == 0:
+            return link_path
+
+    return None
+
+
+def _norm(paths):
+    return sorted(os.path.normcase(os.path.abspath(p)) for p in paths)
+
+
+class Issue124SymlinkedShareTest(TestCase):
+    """The scan must see through the symlink that stands in for the SMB share."""
+
+    def setUp(self):
+        # <root>/share                      <- the mounted SMB/ZFS share
+        #        share/holiday/beach.jpg
+        #        share/portrait.jpg
+        # <root>/data                       <- settings.PHOTOS (the docker /data)
+        #        data/pictures -> ../share  <- the reporter's symlink
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        self.share = os.path.join(self.root, "share")
+        os.makedirs(os.path.join(self.share, "holiday"))
+        self.share_photos = [
+            os.path.join(self.share, "portrait.jpg"),
+            os.path.join(self.share, "holiday", "beach.jpg"),
+        ]
+        for path in self.share_photos:
+            with open(path, "wb") as f:
+                f.write(JPEG_BYTES)
+
+        self.photos_root = os.path.join(self.root, "data")
+        os.makedirs(self.photos_root)
+        self.link = _make_dir_link(
+            os.path.join(self.photos_root, "pictures"), self.share
+        )
+        if self.link is None:
+            self.skipTest("this platform does not allow creating directory symlinks")
+
+    def _expected_through_link(self):
+        return [
+            os.path.join(self.link, "portrait.jpg"),
+            os.path.join(self.link, "holiday", "beach.jpg"),
+        ]
+
+    def test_symlinked_share_inside_the_scan_directory_is_descended_into(self):
+        """The headline symptom: /data/pictures -> /mnt/smb must be scanned."""
+        photo_list = []
+        walk_directory(self.photos_root, photo_list)
+
+        self.assertEqual(
+            _norm(photo_list),
+            _norm(self._expected_through_link()),
+            "the scan found no files behind the symlinked share, so no Photo "
+            "rows and no thumbnails are ever created and every tile in the "
+            "frontend is a broken image (issue #124)",
+        )
+
+    def test_scan_directory_that_is_itself_a_symlink_is_traversed(self):
+        """The user's scan_directory may itself be the link to the share."""
+        user = create_test_user(scan_directory=self.link)
+
+        photo_list = []
+        walk_directory(user.scan_directory, photo_list)
+
+        self.assertEqual(_norm(photo_list), _norm(self._expected_through_link()))
+
+    def test_collected_paths_go_through_the_link_not_its_real_target(self):
+        """Paths must stay under DATA_ROOT so nginx's /original alias applies.
+
+        Resolving the link to its real target (``<root>/share/...``) would push
+        every photo outside ``settings.PHOTOS``; the media view then falls back
+        to emitting the bare filesystem path as an X-Accel-Redirect, which nginx
+        cannot serve.
+        """
+        photo_list = []
+        walk_directory(self.photos_root, photo_list)
+
+        outside = [
+            p
+            for p in photo_list
+            if not os.path.normcase(os.path.abspath(p)).startswith(
+                os.path.normcase(os.path.abspath(self.photos_root))
+            )
+        ]
+        self.assertEqual(
+            outside,
+            [],
+            "the walk handed back paths outside the data root; these cannot be "
+            "mapped onto nginx's internal /original route",
+        )
+
+    def test_photo_found_behind_the_link_is_servable_by_the_media_endpoint(self):
+        """End of the chain: the discovered file actually loads over /media."""
+        photo_list = []
+        walk_directory(self.photos_root, photo_list)
+        self.assertTrue(photo_list, "nothing was discovered behind the symlink")
+
+        discovered = sorted(photo_list)[0]
+
+        with self.settings(PHOTOS=self.photos_root, DATA_ROOT=self.photos_root):
+            user = create_test_user(scan_directory=self.photos_root)
+            photo = create_test_photo(owner=user)
+            photo.main_file = create_test_file(discovered, user, JPEG_BYTES)
+            photo.save()
+
+            client = APIClient()
+            client.cookies["jwt"] = str(AccessToken.for_user(user))
+            response = client.get(f"/media/photos/{photo.image_hash}.jpg")
+
+            self.assertEqual(response.status_code, 200)
+            internal_path = response["X-Accel-Redirect"]
+            self.assertTrue(
+                internal_path.startswith("/original"),
+                "a photo living behind the symlinked share was handed to nginx "
+                f"as {internal_path!r} instead of an /original route, so the "
+                "browser gets a 404 and the image fails to load",
+            )

--- a/apps/backend/api/tests/test_repro_issue_169.py
+++ b/apps/backend/api/tests/test_repro_issue_169.py
@@ -1,0 +1,148 @@
+"""Regression test for https://github.com/LibrePhotos/librephotos/issues/169
+
+"Photos in a symlinked directory not being scanned".
+
+The reporter added extra photo folders to the scan directory with symlinks::
+
+    lrwxrwxrwx 1 librephotos librephotos 22 Feb 15 13:30 test -> /home/librephotos/test
+
+Inside the container that link target does not exist (the host path was never
+bind mounted), so ``/data/test`` is a *dangling* directory symlink.  The scan
+then logged::
+
+    directory_watcher.py : handle_new_image : could not load image /data/test.
+    reason: [Errno 2] No such file or directory: '/data/test'
+
+``api.directory_watcher.utils.walk_directory`` classifies every entry it finds
+with ``os.path.isdir()``, which *follows* symlinks.  For a dangling link that
+returns ``False``, so the link is not descended into (fine) but it falls into
+the ``else`` branch and is appended to the photo list as if it were an image
+file.  Every such link is then queued as a photo, blows up on ``open()`` deep
+inside the pipeline, inflates the job's progress target and pushes the scan job
+into the "failed" state.
+
+Expected behaviour: ``walk_directory`` must only collect real, readable files -
+exactly the guarantee its sibling ``walk_files`` gives with its
+``os.path.isfile()`` check.  A link that resolves to nothing is neither a
+directory nor a file and must simply be skipped.
+
+Windows note: ``os.symlink`` needs SeCreateSymbolicLinkPrivilege (Developer
+Mode).  Where that is unavailable we fall back to a directory junction created
+with ``mklink /J``, which needs no privileges and which Python reports exactly
+like a POSIX directory symlink (``isdir()`` True when the target exists, False
+once it is gone).
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+from django.test import TestCase
+
+from api.directory_watcher.utils import walk_directory
+
+
+def _make_dir_link(link_path, target_path):
+    """Create a directory symlink, or ``None`` if the platform refuses.
+
+    Returns the link path on success so callers can ``skipTest`` on ``None``.
+    """
+    try:
+        os.symlink(target_path, link_path, target_is_directory=True)
+        return link_path
+    except (OSError, NotImplementedError):
+        pass
+
+    if os.name == "nt":
+        # Junctions are reparse points too and need no special privilege.
+        completed = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", link_path, target_path],
+            capture_output=True,
+        )
+        if completed.returncode == 0:
+            return link_path
+
+    return None
+
+
+def _norm(paths):
+    return sorted(os.path.normcase(os.path.abspath(p)) for p in paths)
+
+
+class Issue169SymlinkedDirectoryScanTest(TestCase):
+    def setUp(self):
+        # /root
+        #   |- data                       <- the user's scan directory
+        #   |    |- album/real.jpg        <- an ordinary photo
+        #   |    |- linked  -> /root/outside/pictures
+        #   |    |- test    -> /root/gone (target does not exist in the container)
+        #   |- outside/pictures/linked.jpg
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        self.scan_dir = os.path.join(self.root, "data")
+        os.makedirs(os.path.join(self.scan_dir, "album"))
+        self.real_photo = os.path.join(self.scan_dir, "album", "real.jpg")
+        with open(self.real_photo, "wb") as f:
+            f.write(b"\xff\xd8\xff\xe0jpeg-ish")
+
+        outside = os.path.join(self.root, "outside", "pictures")
+        os.makedirs(outside)
+        self.linked_photo = os.path.join(outside, "linked.jpg")
+        with open(self.linked_photo, "wb") as f:
+            f.write(b"\xff\xd8\xff\xe0jpeg-ish")
+
+        self.good_link = _make_dir_link(os.path.join(self.scan_dir, "linked"), outside)
+        self.broken_link = _make_dir_link(
+            os.path.join(self.scan_dir, "test"), os.path.join(self.root, "gone")
+        )
+        if self.good_link is None or self.broken_link is None:
+            self.skipTest("this platform does not allow creating directory symlinks")
+
+    def test_dangling_symlink_is_not_collected_as_a_photo(self):
+        """A symlink whose target is missing is not an image - skip it."""
+        self.assertFalse(
+            os.path.isfile(self.broken_link),
+            "test setup: the broken link must not resolve to a file",
+        )
+
+        photo_list = []
+        walk_directory(self.scan_dir, photo_list)
+
+        self.assertNotIn(
+            os.path.normcase(os.path.abspath(self.broken_link)),
+            _norm(photo_list),
+            "walk_directory handed the dangling symlink to the photo pipeline; "
+            "it cannot be opened and fails the whole scan job",
+        )
+        self.assertEqual(
+            _norm(photo_list),
+            _norm(
+                [self.real_photo, os.path.join(self.scan_dir, "linked", "linked.jpg")]
+            ),
+        )
+
+    def test_everything_collected_is_an_openable_file(self):
+        """Whatever walk_directory returns must survive open() downstream."""
+        photo_list = []
+        walk_directory(self.scan_dir, photo_list)
+
+        not_files = [p for p in photo_list if not os.path.isfile(p)]
+        self.assertEqual(
+            not_files,
+            [],
+            "walk_directory collected paths that are not readable files",
+        )
+
+    def test_photos_inside_a_symlinked_directory_are_scanned(self):
+        """The headline symptom: images behind a working symlink must be found."""
+        photo_list = []
+        walk_directory(self.scan_dir, photo_list)
+
+        self.assertIn(
+            os.path.normcase(
+                os.path.abspath(os.path.join(self.scan_dir, "linked", "linked.jpg"))
+            ),
+            _norm(photo_list),
+        )

--- a/apps/backend/api/tests/test_repro_issue_384.py
+++ b/apps/backend/api/tests/test_repro_issue_384.py
@@ -1,0 +1,118 @@
+"""Regression test for issue #384 -- "Only show video, but not image after first scan".
+
+https://github.com/LibrePhotos/librephotos/issues/384
+
+The reporter (Nov 2021, Safari) saw every *image* tile render as a broken
+placeholder while *video* tiles played fine, and quoted
+``GET /media/square_thumbnails/<image_hash>`` -> ``403 Forbidden``.
+
+Both tile kinds hit the very same endpoint with the very same URL shape
+(``Tile.tsx`` builds ``/media/square_thumbnails/${image_hash}`` for ``<img>``
+and ``<video>`` alike), and no auth branch in the media view ever looks at
+``Photo.video`` -- so the asymmetry the reporter saw could only come from how
+the browser handled the *response*: the status code, the ``Content-Type`` and
+the ``X-Accel-Redirect`` nginx internal URI.
+
+The media view of that era (``MediaAccessFullsizeOriginalView``) built that
+internal URI as ``"/protected_media{}/{}".format(path, fname)`` -- with no
+separator slash, i.e. ``/protected_mediasquare_thumbnails/<hash>.webp``.  It
+was replaced wholesale by ``UnifiedMediaAccessView`` in commit f42274b6
+("Merge no proxy media management", 2025-08-19), whose ``_protected_media_url``
+does ``path = path.lstrip("/")`` and interpolates a real ``/``.
+
+This test pins the contract that was broken back then: for an authenticated
+owner, an *image* thumbnail must be served exactly as successfully, and with a
+type/URI just as correct, as a *video* thumbnail.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class Issue384MediaThumbnailsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        # The media endpoint authenticates off the "jwt" cookie that
+        # CustomTokenObtainPairView sets, not off the DRF Authorization header.
+        self.client.cookies["jwt"] = str(AccessToken.for_user(self.user))
+
+    def _get(self, path, image_hash):
+        return self.client.get(f"/media/{path}/{image_hash}")
+
+    def test_image_thumbnail_is_served_like_a_video_thumbnail(self):
+        """Images must not 403 / come back unusable while videos work."""
+        image = create_test_photo(owner=self.user, video=False)
+        video = create_test_photo(owner=self.user, video=True)
+
+        image_response = self._get("square_thumbnails", image.image_hash)
+        video_response = self._get("square_thumbnails", video.image_hash)
+
+        self.assertEqual(
+            200,
+            video_response.status_code,
+            "sanity check: the video thumbnail is expected to work",
+        )
+        self.assertEqual(
+            200,
+            image_response.status_code,
+            "issue #384: the image thumbnail 403s while the video one is served",
+        )
+
+    def test_thumbnail_content_type_matches_the_stored_thumbnail_format(self):
+        """A <img> tag cannot render a webp announced as something else."""
+        image = create_test_photo(owner=self.user, video=False)
+        video = create_test_photo(owner=self.user, video=True)
+
+        self.assertEqual(
+            "image/webp",
+            self._get("square_thumbnails", image.image_hash).headers.get(
+                "Content-Type"
+            ),
+        )
+        self.assertEqual(
+            "image/webp",
+            self._get("square_thumbnails_small", image.image_hash).headers.get(
+                "Content-Type"
+            ),
+        )
+        # thumbnails_big is a static webp even for videos
+        self.assertEqual(
+            "image/webp",
+            self._get("thumbnails_big", video.image_hash).headers.get("Content-Type"),
+        )
+        self.assertEqual(
+            "video/mp4",
+            self._get("square_thumbnails", video.image_hash).headers.get(
+                "Content-Type"
+            ),
+        )
+
+    def test_internal_redirect_uri_is_well_formed_for_images(self):
+        """X-Accel-Redirect must be a URI nginx can actually resolve.
+
+        The pre-rewrite helper produced "/protected_mediasquare_thumbnails/..."
+        (missing separator), which nginx cannot map to its internal
+        /protected_media/ location -- the browser then shows a placeholder.
+        """
+        image = create_test_photo(owner=self.user, video=False)
+        video = create_test_photo(owner=self.user, video=True)
+
+        for path, photo, ext in (
+            ("square_thumbnails", image, ".webp"),
+            ("square_thumbnails_small", image, ".webp"),
+            ("thumbnails_big", image, ".webp"),
+            ("square_thumbnails", video, ".mp4"),
+            ("square_thumbnails_small", video, ".mp4"),
+        ):
+            with self.subTest(path=path, video=photo.video):
+                redirect = self._get(path, photo.image_hash).headers.get(
+                    "X-Accel-Redirect"
+                )
+                self.assertEqual(
+                    f"/protected_media/{path}/{photo.image_hash}{ext}",
+                    redirect,
+                )

--- a/apps/backend/api/tests/test_repro_issue_462.py
+++ b/apps/backend/api/tests/test_repro_issue_462.py
@@ -1,0 +1,265 @@
+"""Repro for issue #462 - "Duplicated auto albums".
+
+https://github.com/LibrePhotos/librephotos/issues/462
+
+``api.autoalbum.generate_event_albums`` groups a user's photos into events
+(anything less than 1 day 12 hours apart belongs to the same event) and then
+looks for an already existing ``AlbumAuto`` with::
+
+    key     = group[0].exif_timestamp - timedelta(hours=11, minutes=59)
+    lastKey = group[-1].exif_timestamp + timedelta(hours=11, minutes=59)
+    qs = AlbumAuto.objects.filter(owner=user).filter(timestamp__range=(key, lastKey))
+
+The album that was created for a group stores ``timestamp = key``, i.e. it is
+anchored to the *first* photo of the group at the time of creation.  That
+anchor is never updated, and the lookup only recognises an album whose anchor
+still falls inside the current group's window.  Two consequences, both of
+which leave the user staring at two auto albums for one single event:
+
+1. If the earliest photo of an event disappears (deleted by the user, or
+   swept away by ``delete_missing_photos``), the next run computes a ``key``
+   that is *later* than the stored anchor, the existing album is no longer
+   matched, ``qs.count() == 0`` and a brand new ``AlbumAuto`` is created for
+   photos that are already in an album -> two albums holding the identical
+   set of photos.
+
+2. If newly imported photos bridge the gap between two events, the two
+   previously separate albums both fall inside the merged group's window,
+   ``qs.count() > 1`` and the code simply logs "found multiple auto albums"
+   and gives up (``# To-Do: Merge both auto albums``).  The duplicate albums
+   survive every regeneration and the bridging photos end up in no album at
+   all.
+"""
+
+from datetime import timedelta
+
+import pytz
+from django.test import TestCase
+from django.utils import timezone
+
+from api.autoalbum import generate_event_albums
+from api.models import AlbumAuto
+from api.tests.utils import create_test_photo, create_test_user
+
+BASE = timezone.datetime(2020, 1, 1, 12, 0, 0, tzinfo=pytz.utc)
+
+
+def make_photo(user, offset_hours):
+    return create_test_photo(
+        owner=user, exif_timestamp=BASE + timedelta(hours=offset_hours)
+    )
+
+
+class DuplicateAutoAlbumAfterPhotoRemovalTestCase(TestCase):
+    def test_regeneration_does_not_create_a_second_album_for_the_same_photos(self):
+        user = create_test_user()
+
+        # One continuous event: every photo is 30h after the previous one,
+        # which is below the 1 day 12 hours grouping delta.
+        first = make_photo(user, 0)
+        second = make_photo(user, 30)
+        third = make_photo(user, 60)
+
+        generate_event_albums(user, "job-462-first")
+        albums = AlbumAuto.objects.filter(owner=user)
+        self.assertEqual(albums.count(), 1, "setup: the event must yield one album")
+        original = albums.first()
+        self.assertEqual(original.photos.count(), 3)
+
+        # The earliest photo of the event goes away - the user deleted it, or
+        # its file vanished and delete_missing_photos removed it.
+        first.delete()
+
+        generate_event_albums(user, "job-462-second")
+
+        albums = AlbumAuto.objects.filter(owner=user)
+        photo_sets = [
+            sorted(str(pk) for pk in album.photos.values_list("pk", flat=True))
+            for album in albums
+        ]
+        self.assertEqual(
+            albums.count(),
+            1,
+            "Regenerating auto albums produced a duplicate album for photos "
+            "that were already in one. AlbumAuto.timestamp is anchored to the "
+            "first photo of the group when the album is created and is never "
+            "refreshed, so once that photo is gone the "
+            "`timestamp__range=(key, lastKey)` lookup no longer finds the "
+            f"album and a new one is created. Album photo sets: {photo_sets}",
+        )
+
+        # And the surviving album must still be the original one.
+        self.assertEqual(
+            sorted(
+                str(pk) for pk in albums.first().photos.values_list("pk", flat=True)
+            ),
+            sorted([str(second.pk), str(third.pk)]),
+        )
+
+
+class DuplicateAutoAlbumAfterBridgingTestCase(TestCase):
+    """Two events joined by newly imported photos must collapse into one album."""
+
+    def _build_two_events_then_bridge(self, user):
+        # Event 1 and event 2 are 94 hours apart -> two separate albums.
+        event_one = [make_photo(user, h) for h in (0, 1, 2)]
+        event_two = [make_photo(user, h) for h in (96, 97, 98)]
+
+        generate_event_albums(user, "job-462-bridge-first")
+        self.assertEqual(
+            AlbumAuto.objects.filter(owner=user).count(),
+            2,
+            "setup: two events 94h apart must yield two albums",
+        )
+
+        # Newly scanned photos chain the two events together: 32h, 32h and 30h
+        # steps are all below the 1 day 12 hours grouping delta, so everything
+        # is now one single event.
+        bridge = [make_photo(user, h) for h in (34, 66)]
+
+        generate_event_albums(user, "job-462-bridge-second")
+        return event_one, event_two, bridge
+
+    def test_bridged_events_collapse_into_a_single_album(self):
+        user = create_test_user()
+        self._build_two_events_then_bridge(user)
+
+        albums = AlbumAuto.objects.filter(owner=user)
+        self.assertEqual(
+            albums.count(),
+            1,
+            "After new photos merged two events into one, two auto albums "
+            "still cover the same event. generate_event_albums sees "
+            "qs.count() > 1 and bails out with `# To-Do: Merge both auto "
+            "albums`, so the duplicates survive every regeneration. "
+            f"Timestamps: {list(albums.values_list('timestamp', flat=True))}",
+        )
+
+    def test_bridging_photos_are_added_to_an_album(self):
+        user = create_test_user()
+        _, _, bridge = self._build_two_events_then_bridge(user)
+
+        orphans = [
+            photo.image_hash
+            for photo in bridge
+            if not AlbumAuto.objects.filter(owner=user, photos=photo).exists()
+        ]
+        self.assertEqual(
+            orphans,
+            [],
+            "Photos that bridge two previously separate events are never "
+            "added to any auto album: the multi-album branch of "
+            "generate_event_albums does nothing but log.",
+        )
+
+
+class MergeSafetyTestCase(TestCase):
+    """Collapsing duplicates must not destroy albums or the user's own data.
+
+    Matching an album by the photos it holds (the fix for the two cases above)
+    only works because this file never removes a photo from an album. A photo
+    whose timestamp is corrected into a neighbouring event therefore leaves a
+    stale membership behind, and a merge that trusted it blindly would weld two
+    unrelated events together and delete one of them.
+    """
+
+    def test_album_reaching_outside_the_event_is_not_swallowed(self):
+        user = create_test_user()
+
+        event_one = [make_photo(user, h) for h in (0, 1, 2)]
+        event_two = [make_photo(user, h) for h in (200, 201, 202)]
+
+        generate_event_albums(user, "job-462-merge-setup")
+        before = set(AlbumAuto.objects.filter(owner=user).values_list("pk", flat=True))
+        self.assertEqual(
+            len(before), 2, "setup: the two events must start out as two albums"
+        )
+
+        # The user corrects one photo's date, moving it into the other event.
+        # Its old album still lists it, which is exactly the stale membership a
+        # membership-based lookup has to tolerate.
+        moved = event_one[0]
+        moved.exif_timestamp = event_two[0].exif_timestamp + timedelta(minutes=5)
+        moved.save()
+
+        generate_event_albums(user, "job-462-merge-rerun")
+
+        after = set(AlbumAuto.objects.filter(owner=user).values_list("pk", flat=True))
+        self.assertEqual(
+            sorted(before - after),
+            [],
+            "Correcting the date of a single photo destroyed an auto album: an "
+            "album of the other event was folded into this group and deleted, "
+            "even though the rest of its photos are days away. "
+            f"Albums before: {sorted(before)}, after: {sorted(after)}",
+        )
+        # Every event still has its photos in some album. (Regeneration is not
+        # fully idempotent here: because photos are never removed from an auto
+        # album, the album that lost a photo to another event keeps listing it
+        # and a fresh album is created for the photos left behind. That leaves a
+        # redundant album, which is a great deal better than deleting one.)
+        self.assertTrue(
+            AlbumAuto.objects.filter(owner=user, photos=event_one[1]).exists(),
+            "the untouched photos of the first event lost their album",
+        )
+        self.assertTrue(
+            AlbumAuto.objects.filter(owner=user, photos=event_two[2]).exists(),
+            "the photos of the second event lost their album",
+        )
+
+    def test_merge_keeps_favorited_and_shares(self):
+        user = create_test_user()
+        other = create_test_user()
+
+        for hour in (0, 1, 2):
+            make_photo(user, hour)
+        event_two = [make_photo(user, h) for h in (96, 97, 98)]
+        generate_event_albums(user, "job-462-carry-setup")
+
+        later = AlbumAuto.objects.filter(owner=user, photos=event_two[0]).first()
+        later.favorited = True
+        later.save()
+        later.shared_to.add(other)
+
+        # Bridge the two events so the albums have to be merged. Each step is
+        # below the 1 day 12 hours grouping delta.
+        for hour in (32, 64):
+            make_photo(user, hour)
+        generate_event_albums(user, "job-462-carry-merge")
+
+        albums = AlbumAuto.objects.filter(owner=user)
+        self.assertEqual(albums.count(), 1, "setup: the events must have merged")
+        survivor = albums.first()
+        self.assertTrue(
+            survivor.favorited,
+            "merging two auto albums silently dropped the favorite the user "
+            "had set on one of them",
+        )
+        self.assertEqual(
+            [u.username for u in survivor.shared_to.all()],
+            [other.username],
+            "merging two auto albums silently dropped the shares the user had "
+            "made on one of them",
+        )
+
+    def test_title_refreshes_on_every_run(self):
+        user = create_test_user()
+        for hour in (0, 1, 2):
+            make_photo(user, hour)
+
+        generate_event_albums(user, "job-462-title-first")
+        album = AlbumAuto.objects.filter(owner=user).first()
+        album.title = "stale title"
+        album.save()
+
+        # Nothing about the membership changes on this run.
+        generate_event_albums(user, "job-462-title-second")
+
+        album.refresh_from_db()
+        self.assertNotEqual(
+            album.title,
+            "stale title",
+            "auto album titles are only regenerated when the membership "
+            "changes, so a title never picks up the people and places that "
+            "were recognized after the album was created",
+        )

--- a/apps/backend/api/tests/test_repro_issue_477.py
+++ b/apps/backend/api/tests/test_repro_issue_477.py
@@ -1,0 +1,115 @@
+"""Regression test for https://github.com/LibrePhotos/librephotos/issues/477
+
+Reported symptom: opening a video from the "Photos" tab plays the audio but
+shows nothing but a black/transparent overlay.  The browser cannot decode the
+original container/codec, so it renders no picture.
+
+The only mitigation LibrePhotos ships for this is the per-user setting
+"Always transcode videos" (``User.transcode_videos``, exposed in the settings
+UI as ``settings.transcodevideo``).  When it is on, the backend is supposed to
+pipe the original through ffmpeg and hand the browser a plain H.264/MP4
+stream instead of the untouched original file -- the reporter confirmed in the
+issue thread that turning it on made the affected videos play again.
+
+The lightbox fetches videos from ``/media/photos/<image_hash>.mp4``
+(apps/frontend/src/components/lightbox/MediaDisplay.tsx), whose own comment
+states the backend "serves either the original file ... or a transcoded stream
+(StreamingHttpResponse) depending on user settings".
+
+But ``UnifiedMediaAccessView.get`` handles ``path == "photos"`` in a separate
+tail branch that never consults ``user.transcode_videos`` -- it does not even
+load the column (``User.objects.filter(id=...).only("id")``) -- and always
+returns the untouched original.  So the setting is a no-op for exactly the
+request that plays the video in the lightbox, and the black-video symptom
+survives switching it on.
+
+The sibling branch for every other media path *does* honour the setting; the
+control test at the bottom of this module demonstrates that, isolating the
+defect to the ``photos`` branch.
+"""
+
+import io
+import os
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from api.tests.utils import create_test_file, create_test_photo, create_test_user
+
+# Minimal well-formed-looking MP4 header so python-magic reports video/mp4.
+MP4_BYTES = b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom" + b"\x00" * 64
+
+
+class FakeTranscoderProcess:
+    """Stand-in for the ffmpeg subprocess spawned by VideoTranscoder."""
+
+    def __init__(self):
+        self.stdout = io.BytesIO(b"transcoded-video-bytes\n")
+        self.stderr = io.BytesIO(b"")
+
+    def kill(self):
+        pass
+
+
+class FakeVideoTranscoder:
+    """Stand-in for api.views.views.VideoTranscoder (no real ffmpeg needed)."""
+
+    def __init__(self, path):
+        self.path = path
+        self.process = FakeTranscoderProcess()
+
+
+class AlwaysTranscodeVideosIgnoredInPhotosTabTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        # "Always transcode videos" switched ON in the user's settings.
+        self.user = create_test_user(transcode_videos=True)
+
+        os.makedirs("/tmp", exist_ok=True)
+        self.photo = create_test_photo(owner=self.user, video=True)
+        self.video_path = f"/tmp/{self.photo.image_hash}.mp4"
+        self.photo.main_file = create_test_file(self.video_path, self.user, MP4_BYTES)
+        self.photo.save()
+
+        # The media view authenticates via the `jwt` cookie, not DRF auth.
+        self.client.cookies["jwt"] = str(AccessToken.for_user(self.user))
+
+    def test_photos_tab_video_is_transcoded_when_setting_enabled(self):
+        """`/media/photos/<hash>.mp4` must honour "Always transcode videos"."""
+        with patch(
+            "api.views.views.VideoTranscoder", side_effect=FakeVideoTranscoder
+        ) as transcoder:
+            response = self.client.get(f"/media/photos/{self.photo.image_hash}.mp4")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            transcoder.called,
+            "User has transcode_videos=True, but the lightbox video URL "
+            "/media/photos/<hash>.mp4 served the original file without ever "
+            "invoking VideoTranscoder -- the 'Always transcode videos' setting "
+            "is ignored on this code path, so issue #477's only workaround "
+            "does nothing.",
+        )
+        self.assertTrue(
+            getattr(response, "streaming", False),
+            "Expected a transcoded StreamingHttpResponse for the lightbox "
+            "video URL when transcode_videos is enabled.",
+        )
+        self.assertEqual(response["Content-Type"], "video/mp4")
+
+    def test_control_other_media_paths_do_honour_the_setting(self):
+        """Control: the non-`photos` branch already transcodes correctly.
+
+        This passes today and shows the transcoding machinery works; only the
+        `path == "photos"` branch used by the lightbox skips it.
+        """
+        with patch(
+            "api.views.views.VideoTranscoder", side_effect=FakeVideoTranscoder
+        ) as transcoder:
+            response = self.client.get(f"/media/video/{self.photo.image_hash}.mp4")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(transcoder.called)
+        self.assertEqual(response["Content-Type"], "video/mp4")

--- a/apps/backend/api/tests/test_repro_issue_619.py
+++ b/apps/backend/api/tests/test_repro_issue_619.py
@@ -1,0 +1,156 @@
+"""Repro for issue #619 - "elapsed time before seeing 1st photo of an album maybe long".
+
+The reporter measured the wall-clock delay before the first thumbnail of an album
+shows up:
+
+    person album      1500 photos:  4s
+    manual album       800 photos:  4s
+    auto album        1145 photos: 14s
+    auto album        2875 photos: 19s
+    things album      2127 photos: 23s
+
+The delay scales with the number of photos in the album, not with the network,
+which is the signature of an N+1 query in the album *detail* endpoints.
+
+``AlbumThingViewSet``/``AlbumPlaceViewSet``.retrieve serialize the album through
+``GroupedThingPhotosSerializer``/``GroupedPlacePhotosSerializer`` ->
+``GroupedPhotosSerializer`` -> ``PhotoSummarySerializer``. ``PhotoSummarySerializer``
+touches ``photo.thumbnail``, ``photo.search_instance``, ``photo.main_file``,
+``photo.main_file.embedded_media``, ``photo.stacks`` and ``photo.files`` for *every*
+photo, but the viewsets' ``get_queryset()`` prefetches none of those relations:
+``AlbumThingViewSet`` prefetches only ``photos``/``photos__owner``, and
+``AlbumPlaceViewSet`` prefetches ``photos`` with a ``.only(...)`` that additionally
+*defers* fields the serializer reads (``video_length``, ``owner``, ``main_file``),
+costing yet another query each. ``AlbumAutoViewSet`` is worse still - its serializer
+walks ``photo.faces -> face.person`` and re-serializes a ``PersonSerializer`` per
+face, and the viewset carries a literal
+``# TODO: This is a fetches with too many queries. We need to optimize this.``
+
+The correct behaviour is that the number of queries for an album detail response is
+O(1) in the album size - a fixed set of prefetches - exactly like ``AlbumDateViewSet``
+already does. These tests assert that and currently fail.
+"""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.models import AlbumAuto, AlbumPlace, AlbumThing
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class AlbumDetailQueryCountTestMixin:
+    """An album detail response must not issue per-photo queries.
+
+    Subclasses set ``KIND`` (the URL segment) and implement ``_make_album``.
+    """
+
+    SMALL = 2
+    LARGE = 12
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.now = timezone.now()
+
+    def _photos(self, count):
+        return [
+            create_test_photo(owner=self.user, video=False, exif_timestamp=self.now)
+            for _ in range(count)
+        ]
+
+    @staticmethod
+    def _hashes(response):
+        """Pull every returned image_hash out of the (differently shaped) payloads."""
+        data = response.json()
+        if isinstance(data, dict) and "results" in data:
+            data = data["results"]
+        groups = data.get("grouped_photos")
+        if groups is not None:
+            return {item["image_hash"] for group in groups for item in group["items"]}
+        return {item["image_hash"] for item in data.get("photos", [])}
+
+    def _count_queries(self, url):
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            # Force full rendering of the lazily-serialized payload.
+            response.json()
+        return len(ctx.captured_queries), response
+
+    def test_album_detail_query_count_is_constant(self):
+        small_album = self._make_album(self._photos(self.SMALL))
+        large_album = self._make_album(self._photos(self.LARGE))
+
+        # Warm the endpoint once before measuring. The first request of a fresh
+        # database also materialises the django-constance defaults, which is a
+        # one-time INSERT unrelated to album size; counting it would make the
+        # first measurement look worse than the second for reasons that have
+        # nothing to do with the N+1 this test is about.
+        self._count_queries(f"/api/albums/{self.KIND}/{small_album.id}/")
+
+        small_queries, small_response = self._count_queries(
+            f"/api/albums/{self.KIND}/{small_album.id}/"
+        )
+        large_queries, large_response = self._count_queries(
+            f"/api/albums/{self.KIND}/{large_album.id}/"
+        )
+
+        # Sanity: both endpoints actually returned the photos we asked for, so
+        # the query counts below are comparing like with like.
+        self.assertEqual(len(self._hashes(small_response)), self.SMALL)
+        self.assertEqual(len(self._hashes(large_response)), self.LARGE)
+
+        per_photo = (large_queries - small_queries) / (self.LARGE - self.SMALL)
+        self.assertEqual(
+            large_queries,
+            small_queries,
+            f"/api/albums/{self.KIND}/ detail issues per-photo queries (N+1): "
+            f"{small_queries} queries for {self.SMALL} photos vs "
+            f"{large_queries} queries for {self.LARGE} photos "
+            f"(~{per_photo:.1f} extra queries per photo). "
+            "The query count must be constant in the album size, otherwise a "
+            "2000-photo album costs thousands of round trips before the first "
+            "thumbnail can be rendered (issue #619).",
+        )
+
+
+class AlbumThingDetailQueryCountTest(AlbumDetailQueryCountTestMixin, TestCase):
+    KIND = "thing"
+
+    def _make_album(self, photos):
+        album = AlbumThing.objects.create(
+            title=f"beach-{len(photos)}",
+            owner=self.user,
+            thing_type="hashtag_attribute",
+        )
+        album.photos.add(*photos)
+        return album
+
+
+class AlbumPlaceDetailQueryCountTest(AlbumDetailQueryCountTestMixin, TestCase):
+    KIND = "place"
+
+    def _make_album(self, photos):
+        album = AlbumPlace.objects.create(
+            title=f"Lisbon-{len(photos)}", owner=self.user
+        )
+        album.photos.add(*photos)
+        return album
+
+
+class AlbumAutoDetailQueryCountTest(AlbumDetailQueryCountTestMixin, TestCase):
+    KIND = "auto"
+
+    def _make_album(self, photos):
+        album = AlbumAuto.objects.create(
+            title=f"Sunday Afternoon {len(photos)}",
+            owner=self.user,
+            timestamp=self.now - timezone.timedelta(days=len(photos)),
+            created_on=self.now,
+        )
+        album.photos.add(*photos)
+        return album

--- a/apps/backend/api/tests/test_repro_issue_631.py
+++ b/apps/backend/api/tests/test_repro_issue_631.py
@@ -1,0 +1,205 @@
+"""Regression test for https://github.com/LibrePhotos/librephotos/issues/631
+
+"Sub folders are not indexed in Nextcloud watch folder".
+
+The reporter has a Nextcloud watch folder with several sub folders
+(``/nextcloud/photoset1``, ``/nextcloud/photoset2``, ``/nextcloud/photoset3``)
+and after a "Scan photos (Nextcloud)" run only *some* of the sub folders show
+up: "it is only importing the photos in photoset 1 and 3".
+
+The obvious suspect - a missing recursion - is *not* the problem:
+``nextcloud.directory_watcher.collect_photos`` does walk sub directories
+(``test_recursion_into_sub_folders_is_not_the_problem`` below passes).
+
+The actual defect is the gate that decides which remote files are media,
+``nextcloud.directory_watcher.isValidNCMedia``.  It matches the WebDAV
+``{DAV:}getcontenttype`` against a hard coded whitelist::
+
+    "jpeg" in filetype or "png" in filetype or "bmp" in filetype
+    or "gif" in filetype or "heic" in filetype or "heif" in filetype
+
+Everything else is silently dropped - no log line, no error, no entry in the
+LongRunningJob.  So a sub folder that happens to hold videos (``video/mp4``,
+``video/quicktime``), TIFFs, WebP or camera RAW files is skipped *in its
+entirety* and the user sees exactly the reported symptom: some folders import,
+others simply never appear.
+
+Those file types are not exotic to LibrePhotos - the local directory watcher
+indexes them (``api.models.file.is_video`` / ``is_raw`` accept them, and
+``File`` even has dedicated ``VIDEO`` / ``RAW_FILE`` types), so a photo that is
+indexed when it sits on a local disk is dropped when the very same photo sits
+in a Nextcloud sub folder.
+
+Expected behaviour: ``collect_photos`` collects every media file LibrePhotos
+can index, in every sub folder of the watch directory.
+"""
+
+from django.test import SimpleTestCase
+from owncloud import FileInfo
+
+from api.models.file import is_raw
+from nextcloud.directory_watcher import collect_photos, isValidNCMedia
+
+
+def make_dir(path):
+    """A WebDAV collection as owncloud's client hands it to us."""
+    if not path.endswith("/"):
+        path += "/"
+    return FileInfo(path, "dir", {"{DAV:}getcontenttype": "httpd/unix-directory"})
+
+
+def make_file(path, content_type):
+    return FileInfo(
+        path,
+        "file",
+        {
+            "{DAV:}getcontenttype": content_type,
+            "{DAV:}getcontentlength": "1024",
+        },
+    )
+
+
+class FakeNextcloudClient:
+    """Minimal stand-in for ``owncloud.Client`` backed by an in-memory tree.
+
+    Mirrors the real client: ``list()`` returns the *children* of a collection
+    (the collection itself is stripped by owncloud), directory entries have a
+    trailing slash in ``path`` and ``is_dir()`` is True for them.
+    """
+
+    def __init__(self, tree):
+        self.tree = {
+            (p if p.endswith("/") else p + "/"): entries for p, entries in tree.items()
+        }
+        self.listed = []
+
+    def list(self, path, depth=1, properties=None):
+        if not path.endswith("/"):
+            path += "/"
+        self.listed.append(path)
+        return list(self.tree[path])
+
+
+class Issue631NextcloudSubFolderScanTest(SimpleTestCase):
+    def test_recursion_into_sub_folders_is_not_the_problem(self):
+        """Sanity check: collect_photos really does descend into sub folders."""
+        nc = FakeNextcloudClient(
+            {
+                "/nextcloud/": [
+                    make_dir("/nextcloud/photoset1/"),
+                    make_dir("/nextcloud/photoset2/"),
+                ],
+                "/nextcloud/photoset1/": [
+                    make_file("/nextcloud/photoset1/a.jpg", "image/jpeg"),
+                    make_dir("/nextcloud/photoset1/nested/"),
+                ],
+                "/nextcloud/photoset1/nested/": [
+                    make_file("/nextcloud/photoset1/nested/b.png", "image/png"),
+                ],
+                "/nextcloud/photoset2/": [
+                    make_file("/nextcloud/photoset2/c.jpg", "image/jpeg"),
+                ],
+            }
+        )
+
+        photos = []
+        collect_photos(nc, "/nextcloud/", photos)
+
+        self.assertEqual(
+            sorted(photos),
+            [
+                "/nextcloud/photoset1/a.jpg",
+                "/nextcloud/photoset1/nested/b.png",
+                "/nextcloud/photoset2/c.jpg",
+            ],
+        )
+
+    def test_sub_folder_of_videos_and_tiffs_is_not_skipped(self):
+        """The reported symptom: photoset1 + photoset3 import, photoset2 does not.
+
+        photoset2 holds media LibrePhotos indexes happily from a local folder
+        (a video, a TIFF, a WebP) but that ``isValidNCMedia`` refuses.
+        """
+        nc = FakeNextcloudClient(
+            {
+                "/nextcloud/": [
+                    make_dir("/nextcloud/photoset1/"),
+                    make_dir("/nextcloud/photoset2/"),
+                    make_dir("/nextcloud/photoset3/"),
+                ],
+                "/nextcloud/photoset1/": [
+                    make_file("/nextcloud/photoset1/holiday.jpg", "image/jpeg"),
+                ],
+                "/nextcloud/photoset2/": [
+                    make_file("/nextcloud/photoset2/clip.mp4", "video/mp4"),
+                    make_file("/nextcloud/photoset2/pano.tif", "image/tiff"),
+                    make_file("/nextcloud/photoset2/shot.webp", "image/webp"),
+                ],
+                "/nextcloud/photoset3/": [
+                    make_file("/nextcloud/photoset3/party.png", "image/png"),
+                ],
+            }
+        )
+
+        photos = []
+        collect_photos(nc, "/nextcloud/", photos)
+
+        collected_folders = sorted({p.rsplit("/", 1)[0] for p in photos})
+        self.assertEqual(
+            collected_folders,
+            [
+                "/nextcloud/photoset1",
+                "/nextcloud/photoset2",
+                "/nextcloud/photoset3",
+            ],
+            "a whole Nextcloud sub folder was silently dropped by the scan; "
+            f"collected files were {sorted(photos)}",
+        )
+
+    def test_raw_files_in_a_sub_folder_are_collected(self):
+        """LibrePhotos indexes RAW locally, so it must index RAW from Nextcloud."""
+        raw_path = "/nextcloud/photoset2/DSC_0001.NEF"
+        self.assertTrue(
+            is_raw(raw_path),
+            "precondition: LibrePhotos' own file model recognises this as RAW",
+        )
+
+        nc = FakeNextcloudClient(
+            {
+                "/nextcloud/": [make_dir("/nextcloud/photoset2/")],
+                "/nextcloud/photoset2/": [
+                    make_file(raw_path, "image/x-nikon-nef"),
+                ],
+            }
+        )
+
+        photos = []
+        collect_photos(nc, "/nextcloud/", photos)
+
+        self.assertEqual(
+            photos,
+            [raw_path],
+            "RAW files stored in a Nextcloud sub folder are never indexed",
+        )
+
+    def test_isvalidncmedia_accepts_the_media_types_librephotos_indexes(self):
+        """Pin the root cause down to the content-type whitelist itself."""
+        rejected = [
+            content_type
+            for content_type in (
+                "video/mp4",
+                "video/quicktime",
+                "image/tiff",
+                "image/webp",
+                "image/x-nikon-nef",
+                "image/x-canon-cr2",
+            )
+            if not isValidNCMedia(make_file("/nextcloud/x", content_type))
+        ]
+
+        self.assertEqual(
+            rejected,
+            [],
+            "nextcloud.directory_watcher.isValidNCMedia drops media types that "
+            "the local directory watcher indexes",
+        )

--- a/apps/backend/api/tests/test_repro_issue_833.py
+++ b/apps/backend/api/tests/test_repro_issue_833.py
@@ -1,0 +1,108 @@
+"""Regression test for https://github.com/LibrePhotos/librephotos/issues/833
+
+"Access to photo folders owned by other users".
+
+The scan directory is a network mount (NFS/Synology, Proxmox bind mount, ...)
+that contains folders owned by a different unix user.  The server process can
+read the mount point itself, but at least one folder inside it is not readable
+(``os.scandir`` on it raises ``PermissionError``).
+
+``api.api_util.path_to_dict`` walks the tree with a bare ``os.scandir`` and no
+error handling, so a *single* unreadable sub folder makes the whole
+``/api/dirtree/`` request blow up.  ``RootPathTreeView`` turns that into a
+HTTP 500 and the admin gets an empty folder picker in the user setup screen -
+none of the directories are selectable any more, not even the ones the server
+*can* read.
+
+Expected behaviour: a folder the server cannot descend into must be skipped
+(listed with no children), the rest of the tree must still be returned.
+"""
+
+import errno
+import os
+import shutil
+import tempfile
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from api.api_util import path_to_dict
+from api.models import User
+from api.tests.utils import create_password
+
+REAL_SCANDIR = os.scandir
+
+
+def deny_scandir(denied_path):
+    """Emulate a directory owned by another user: scandir() -> EACCES."""
+    denied = os.path.abspath(denied_path)
+
+    def fake_scandir(path=".", *args, **kwargs):
+        if os.path.abspath(os.fspath(path)) == denied:
+            raise PermissionError(errno.EACCES, "Permission denied", os.fspath(path))
+        return REAL_SCANDIR(path, *args, **kwargs)
+
+    return fake_scandir
+
+
+class Issue833ForeignOwnedFolderTest(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            "admin833", "admin833@test.com", create_password()
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin)
+
+        # /data
+        #   |- my_photos/2023      <- readable
+        #   |- nobody_photos/2023  <- owned by nobody:nogroup, not readable
+        self.data_root = tempfile.mkdtemp(prefix="repro833_")
+        self.addCleanup(shutil.rmtree, self.data_root, True)
+        os.makedirs(os.path.join(self.data_root, "my_photos", "2023"))
+        self.foreign = os.path.join(self.data_root, "nobody_photos")
+        os.makedirs(os.path.join(self.foreign, "2023"))
+
+    def test_dirtree_still_lists_folders_next_to_an_unreadable_one(self):
+        with override_settings(DATA_ROOT=self.data_root):
+            patcher = _patch_scandir(deny_scandir(self.foreign))
+            self.addCleanup(patcher.stop)
+            patcher.start()
+
+            response = self.client.get("/api/dirtree/")
+
+            self.assertEqual(
+                200,
+                response.status_code,
+                "one unreadable folder broke the whole directory listing: "
+                f"{response.status_code} {response.json()}",
+            )
+
+            titles = [child["title"] for child in response.json()[0]["children"]]
+            self.assertIn("my_photos", titles)
+            self.assertIn("nobody_photos", titles)
+
+    def test_path_to_dict_skips_the_unreadable_folder(self):
+        patcher = _patch_scandir(deny_scandir(self.foreign))
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        try:
+            tree = path_to_dict(self.data_root)
+        except OSError as exc:
+            self.fail(
+                "path_to_dict() must not propagate a permission error for a "
+                f"folder owned by another user, got: {exc!r}"
+            )
+
+        children = {child["title"]: child for child in tree["children"]}
+        self.assertEqual({"my_photos", "nobody_photos"}, set(children))
+        self.assertEqual([], children["nobody_photos"]["children"])
+        self.assertEqual(
+            ["2023"], [c["title"] for c in children["my_photos"]["children"]]
+        )
+
+
+def _patch_scandir(replacement):
+    from unittest import mock
+
+    return mock.patch("os.scandir", replacement)

--- a/apps/backend/api/tests/test_repro_issue_836.py
+++ b/apps/backend/api/tests/test_repro_issue_836.py
@@ -1,0 +1,95 @@
+"""Repro for issue #836 - "Auto album generation stuck (looks like #584)".
+
+https://github.com/LibrePhotos/librephotos/issues/836
+
+Two distinct defects in ``api.autoalbum.generate_event_albums`` are covered:
+
+1. The job's progress counters are never advanced for any group that actually
+   becomes an auto album.  Every branch that handles a group of >= 2 photos
+   ends in ``continue``, which jumps over the trailing
+   ``lrj.update_progress(current=idx + 1, target=target_count)``.  Only
+   single-photo groups (which produce no album at all) ever reach it, so a
+   library made of real events reports 0 / 0 for the whole run -- exactly the
+   frozen progress bar screenshotted in the issue.
+
+2. Re-running generation over albums that already exist re-reads the whole
+   album membership once per photo (``if item in album.photos.all()``), which
+   is why the reporter measured ~15 minutes on a clean database and ~7 hours
+   for the very same library once the auto albums were already there.
+"""
+
+from datetime import datetime, timedelta
+
+import pytz
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from api.autoalbum import generate_event_albums
+from api.models import AlbumAuto, LongRunningJob
+from api.tests.utils import create_test_photo, create_test_user
+
+BASE = datetime(2020, 1, 1, 12, 0, 0, tzinfo=pytz.utc)
+
+
+def make_group(user, start, size):
+    """Create ``size`` photos one hour apart, i.e. a single auto-album group."""
+    return [
+        create_test_photo(owner=user, exif_timestamp=start + timedelta(hours=i))
+        for i in range(size)
+    ]
+
+
+class AutoAlbumProgressTestCase(TestCase):
+    def test_progress_advances_for_every_group(self):
+        user = create_test_user()
+        # Three separate events, 10 days apart so they cannot be merged into
+        # one group (the grouping delta is 1 day 12 hours).
+        for event in range(3):
+            make_group(user, BASE + timedelta(days=10 * event), 3)
+
+        generate_event_albums(user, "job-836-progress")
+
+        self.assertEqual(AlbumAuto.objects.filter(owner=user).count(), 3)
+
+        lrj = LongRunningJob.objects.get(job_id="job-836-progress")
+        self.assertEqual(
+            (lrj.progress_current, lrj.progress_target),
+            (3, 3),
+            "generate_event_albums never reports progress for groups that turn "
+            "into an album: every branch handling len(group) >= 2 ends in "
+            "`continue`, skipping lrj.update_progress(). The UI therefore shows "
+            f"a frozen bar - got {lrj.progress_current}/{lrj.progress_target}.",
+        )
+
+
+class AutoAlbumRerunTestCase(TestCase):
+    def test_rerun_does_not_reload_album_membership_per_photo(self):
+        user = create_test_user()
+        photo_count = 20
+        make_group(user, BASE, photo_count)
+
+        # First pass: creates the auto album.
+        generate_event_albums(user, "job-836-first")
+        self.assertEqual(AlbumAuto.objects.filter(owner=user).count(), 1)
+
+        # Second pass over the identical library: nothing has to change.
+        with CaptureQueriesContext(connection) as ctx:
+            generate_event_albums(user, "job-836-second")
+
+        membership_reads = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "api_albumauto_photos" in q["sql"] and "api_photo" in q["sql"]
+        ]
+
+        self.assertLessEqual(
+            len(membership_reads),
+            3,
+            "Re-running auto album generation reloads the complete album "
+            "membership once per photo (`if item in album.photos.all()`), so "
+            "the cost is quadratic in album size: "
+            f"{len(membership_reads)} membership queries for {photo_count} "
+            "photos. A 2800 photo album therefore takes hours on the second "
+            "run.",
+        )

--- a/apps/backend/api/tests/test_repro_issue_897.py
+++ b/apps/backend/api/tests/test_repro_issue_897.py
@@ -1,0 +1,121 @@
+"""Repro for issue #897 -- "Timeout when tagging large amount of faces".
+
+https://github.com/LibrePhotos/librephotos/issues/897
+
+Tagging a multi-selection of faces goes through ``POST /api/labelfaces``
+(``api.views.faces.SetFacePersonLabel``), which does::
+
+    faces = Face.objects.in_bulk(data["face_ids"])
+    for face in faces.values():
+        if face.photo.owner == request.user:
+            face.person = person
+            ...
+            face.save()
+    ...
+    search_instance, created = PhotoSearch.objects.get_or_create(photo=face.photo)
+    search_instance.recreate_search_captions()
+
+``in_bulk()`` returns bare ``Face`` rows with no related objects selected, so
+each loop iteration fires an extra ``SELECT`` for ``face.photo`` and another
+for ``face.photo.owner`` *before* the row is written -- three queries per face
+instead of one.  That is the request cost that blows past the reverse-proxy
+timeout once a user selects a few thousand inferred faces, which is the symptom
+in the issue ("the operation times out and the faces end up not being tagged
+(sometimes a part of them succeed)").
+
+The second test covers the other half of the symptom: because the
+``PhotoSearch`` refresh sits *outside* the loop it runs against the dangling
+``face`` loop variable, so only the last photo of the batch gets its search
+captions rebuilt and the freshly tagged person is not findable on any of the
+others.
+"""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from api.models import Face
+from api.models.photo_search import PhotoSearch
+from api.tests.utils import create_test_face, create_test_photo, create_test_user
+
+LABEL_FACES_URL = "/api/labelfaces"
+
+
+class TagManyFacesTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+
+    def _create_faces(self, count):
+        """One face per photo, which is what the inference view hands over."""
+        photos = [create_test_photo(owner=self.user) for _ in range(count)]
+        return photos, [create_test_face(photo=photo) for photo in photos]
+
+    def _label(self, faces, person_name):
+        return self.client.post(
+            LABEL_FACES_URL,
+            {"person_name": person_name, "face_ids": [face.id for face in faces]},
+            format="json",
+        )
+
+    def test_labelling_faces_costs_at_most_one_query_per_face(self):
+        """The per-face marginal query cost must not exceed the single write.
+
+        Measured against two batch sizes so the fixed overhead of the endpoint
+        (person lookup, face-count recalculation, cover photo, ...) cancels out
+        and only the part that scales with the batch size is asserted on.
+        """
+        small_count, large_count = 4, 20
+
+        _, small_batch = self._create_faces(small_count)
+        with CaptureQueriesContext(connection) as small_ctx:
+            small_response = self._label(small_batch, "Alice")
+        self.assertEqual(small_response.status_code, 200)
+
+        _, large_batch = self._create_faces(large_count)
+        with CaptureQueriesContext(connection) as large_ctx:
+            large_response = self._label(large_batch, "Bob")
+        self.assertEqual(large_response.status_code, 200)
+
+        extra_faces = large_count - small_count
+        extra_queries = len(large_ctx.captured_queries) - len(
+            small_ctx.captured_queries
+        )
+
+        self.assertLessEqual(
+            extra_queries,
+            extra_faces,
+            "labelling {} extra faces cost {} extra queries ({:.1f} per face); "
+            "a face only needs its own UPDATE, the photo/owner rows should come "
+            "from a single select_related/bulk read".format(
+                extra_faces, extra_queries, extra_queries / extra_faces
+            ),
+        )
+
+    def test_every_tagged_photo_gets_its_search_captions_refreshed(self):
+        """All photos in the batch must become searchable by the new name."""
+        photos, faces = self._create_faces(3)
+
+        response = self._label(faces, "Carol")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            Face.objects.filter(person__name="Carol").count(),
+            3,
+            "all faces of the batch should be tagged",
+        )
+
+        missing = []
+        for photo in photos:
+            search = PhotoSearch.objects.filter(photo=photo).first()
+            if search is None or "Carol" not in (search.search_captions or ""):
+                missing.append(photo.image_hash)
+
+        self.assertEqual(
+            missing,
+            [],
+            "search captions were not rebuilt for {} of 3 tagged photos".format(
+                len(missing)
+            ),
+        )

--- a/apps/backend/api/tests/test_repro_issue_907.py
+++ b/apps/backend/api/tests/test_repro_issue_907.py
@@ -1,0 +1,195 @@
+"""Regression test for issue #907 - "Error creating Matplotlib cache".
+
+https://github.com/LibrePhotos/librephotos/issues/907
+
+LibrePhotos never points ``MPLCONFIGDIR`` at a writable, persistent directory.
+Matplotlib is still part of the production dependency tree (``insightface``
+requires it unconditionally, and ``service/face_recognition/main.py`` imports
+``insightface.app``), so every LibrePhotos process that touches it inherits
+matplotlib's default lookup: ``$MPLCONFIGDIR`` -> ``$XDG_CONFIG_HOME`` ->
+``~/.config``.
+
+In the reporter's container the home directory resolves to ``/``, which is not
+writable, so matplotlib falls back to a brand new ``/tmp/matplotlib-XXXXXXXX``
+directory on *every* process start and logs::
+
+    Matplotlib created a temporary config/cache directory at
+    /tmp/matplotlib-y6irp9ju because the default path (/.config/matplotlib) is
+    not a writable directory; it is highly recommended to set the MPLCONFIGDIR
+    environment variable to a writable directory, [...]
+
+The font cache is therefore rebuilt from scratch for every worker and every
+service restart. Fixing it means LibrePhotos itself exporting MPLCONFIGDIR to a
+directory it owns (e.g. under ``BASE_DATA``/``BASE_LOGS``) before matplotlib is
+imported; because ``api.services.start_service`` spawns the ML services with
+``subprocess.Popen`` they inherit whatever the Django process exported.
+
+The tests below simulate the reporter's environment (home directory that cannot
+be created) and assert the correct behaviour: the matplotlib cache directory
+must be stable and LibrePhotos-owned, not a throwaway temp directory.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_DIR.parents[1]
+
+# Environment variables matplotlib consults when resolving its config/cache
+# directory. They are cleared so the child process starts from the same blank
+# slate a freshly started container has.
+_HOME_VARS = (
+    "MPLCONFIGDIR",
+    "HOME",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "LOCALAPPDATA",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+)
+
+_PROBE = textwrap.dedent(
+    """
+    import json, os, sys, tempfile
+    from pathlib import Path
+
+    sys.path.insert(0, sys.argv[1])
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "librephotos.settings.production")
+
+    import django
+
+    django.setup()
+
+    # This is what service/face_recognition/main.py ends up doing through
+    # insightface: importing matplotlib and materialising its cache directory.
+    import matplotlib
+
+    cachedir = matplotlib.get_cachedir()
+    sys.stdout.write(
+        "REPRO_JSON:"
+        + json.dumps(
+            {
+                "cachedir": cachedir,
+                "configdir": matplotlib.get_configdir(),
+                "system_tempdir": tempfile.gettempdir(),
+                "fell_back_to_tempdir": (
+                    Path(cachedir).name.startswith("matplotlib-")
+                    and Path(cachedir).parent == Path(tempfile.gettempdir())
+                ),
+            }
+        )
+        + "\\n"
+    )
+    """
+)
+
+
+class MatplotlibCacheDirIssue907Test(SimpleTestCase):
+    """The matplotlib cache directory must survive an unwritable home dir."""
+
+    def _probe(self, sandbox):
+        """Start a LibrePhotos python process with an unwritable home directory."""
+        blocked = sandbox / "not-a-directory"
+        if not blocked.exists():
+            blocked.write_text("this is a regular file, not a directory")
+        # Any path below `blocked` is impossible to mkdir -> exactly the
+        # "default path is not a writable directory" situation from the report.
+        fake_home = blocked / "home"
+
+        logs = sandbox / "logs"
+        logs.mkdir(exist_ok=True)
+
+        env = {k: v for k, v in os.environ.items() if k not in _HOME_VARS}
+        env["HOME"] = str(fake_home)
+        env["USERPROFILE"] = str(fake_home)
+        env["LOCALAPPDATA"] = str(fake_home)
+        env["XDG_CONFIG_HOME"] = str(fake_home / ".config")
+        env["XDG_CACHE_HOME"] = str(fake_home / ".cache")
+        env["BASE_DATA"] = str(sandbox)
+        env["BASE_LOGS"] = str(logs)
+        env["SECRET_KEY"] = "test-secret-key"
+        env["DJANGO_SETTINGS_MODULE"] = "librephotos.settings.production"
+
+        script = sandbox / "probe_907.py"
+        script.write_text(_PROBE)
+
+        result = subprocess.run(
+            [sys.executable, str(script), str(BACKEND_DIR)],
+            cwd=str(BACKEND_DIR),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        payload = None
+        for line in result.stdout.splitlines():
+            if line.startswith("REPRO_JSON:"):
+                payload = json.loads(line[len("REPRO_JSON:") :])
+        if payload is None:
+            self.fail(
+                "probe process did not report a matplotlib cache directory\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        payload["stderr"] = result.stderr
+        return payload
+
+    def test_matplotlib_cache_dir_is_persistent_when_home_is_not_writable(self):
+        with TemporaryDirectory(prefix="lp907-") as tmp:
+            sandbox = Path(tmp)
+            first = self._probe(sandbox)
+            second = self._probe(sandbox)
+
+        self.assertFalse(
+            first["fell_back_to_tempdir"],
+            "LibrePhotos did not configure MPLCONFIGDIR, so matplotlib fell back "
+            "to a throwaway temporary cache directory "
+            f"({first['cachedir']}) - issue #907.\n"
+            f"matplotlib said:\n{first['stderr'].strip()}",
+        )
+        self.assertEqual(
+            first["cachedir"],
+            second["cachedir"],
+            "Every LibrePhotos process gets a fresh matplotlib cache directory "
+            "and has to rebuild the font cache from scratch - issue #907.",
+        )
+
+    def test_startup_exports_a_writable_mplconfigdir(self):
+        """Some part of the shipped startup surface must export MPLCONFIGDIR."""
+        candidates = [
+            BACKEND_DIR / "librephotos" / "settings" / "production.py",
+            BACKEND_DIR / "librephotos" / "settings" / "__init__.py",
+            BACKEND_DIR / "librephotos" / "wsgi.py",
+            BACKEND_DIR / "manage.py",
+            REPO_ROOT / "deploy" / "docker" / "backend" / "entrypoint.sh",
+            REPO_ROOT / "deploy" / "docker" / "backend-gpu" / "entrypoint.sh",
+            REPO_ROOT / "deploy" / "docker" / "unified" / "entrypoint.sh",
+            REPO_ROOT / "deploy" / "docker" / "backend" / "Dockerfile",
+            REPO_ROOT / "deploy" / "docker" / "backend" / "base" / "Dockerfile",
+            REPO_ROOT / "deploy" / "compose" / "librephotos.env",
+            REPO_ROOT / "deploy" / "compose" / "docker-compose.yml",
+        ]
+        existing = [path for path in candidates if path.is_file()]
+        if not existing:
+            raise unittest.SkipTest("no startup files available in this checkout")
+
+        configured = [
+            str(path)
+            for path in existing
+            if "MPLCONFIGDIR" in path.read_text(encoding="utf-8", errors="replace")
+        ]
+        self.assertTrue(
+            configured,
+            "No LibrePhotos startup file sets MPLCONFIGDIR, so matplotlib "
+            "recreates its cache directory on every process start when the "
+            "home directory is not writable - issue #907. Checked:\n"
+            + "\n".join(f"  - {path}" for path in existing),
+        )

--- a/apps/backend/api/views/album_auto.py
+++ b/apps/backend/api/views/album_auto.py
@@ -28,7 +28,9 @@ class AlbumAutoViewSet(viewsets.ModelViewSet):
         return (
             AlbumAuto.objects.prefetch_related(
                 Prefetch("owner"),
-                Prefetch("photos", queryset=Photo.visible.all()),
+                # PhotoSimpleSerializer renders the square thumbnail of every
+                # photo, which costs a query each without this join (issue #619).
+                Prefetch("photos", queryset=Photo.visible.select_related("thumbnail")),
                 Prefetch("photos__faces"),
                 Prefetch(
                     "photos__faces__person",

--- a/apps/backend/api/views/albums.py
+++ b/apps/backend/api/views/albums.py
@@ -131,6 +131,64 @@ class PersonViewSet(viewsets.ModelViewSet):
         return qs
 
 
+def _with_photo_summary_relations(queryset):
+    """Load everything ``PhotoSummarySerializer`` reads in a constant number of queries.
+
+    The summary serializer touches the thumbnail, the search instance, the main
+    file's embedded media, the photo's stacks and its files for every photo it
+    renders. Without these joins an album detail response costs a handful of
+    extra round trips *per photo*, which is why large albums took seconds before
+    showing their first thumbnail (issue #619).
+    """
+    # Filter the stacks to valid types and annotate photo_count so that
+    # get_stacks() never has to fall back to a query of its own.
+    valid_stack_types = PhotoStack.VALID_STACK_TYPES + [
+        PhotoStack.StackType.RAW_JPEG_PAIR,
+        PhotoStack.StackType.LIVE_PHOTO,
+    ]
+    stacks_prefetch = Prefetch(
+        "stacks",
+        queryset=PhotoStack.objects.filter(stack_type__in=valid_stack_types).annotate(
+            photo_count_annotation=Count("photos")
+        ),
+    )
+
+    return (
+        queryset.prefetch_related(
+            Prefetch(
+                "owner",
+                queryset=User.objects.only("id", "username", "first_name", "last_name"),
+            ),
+            Prefetch(
+                "main_file__embedded_media",
+                queryset=File.objects.only("hash"),
+            ),
+            stacks_prefetch,
+            "files",  # Prefetch files for get_has_raw_variant()
+        )
+        .select_related("thumbnail", "search_instance", "main_file")
+        .only(
+            "image_hash",
+            "thumbnail__aspect_ratio",
+            "thumbnail__dominant_color",
+            "video",
+            "main_file",
+            "search_instance__search_location",
+            "public",
+            "rating",
+            "hidden",
+            "exif_timestamp",
+            "owner",
+            "video_length",
+            "exif_gps_lat",
+            "exif_gps_lon",
+            "removed",
+            "in_trashcan",
+            "local_orientation",
+        )
+    )
+
+
 def _get_active_tag_thing_types():
     """Return the AlbumThing thing_type values for the active tagging model."""
     from constance import config as site_config
@@ -145,35 +203,38 @@ class AlbumThingViewSet(viewsets.ModelViewSet):
     serializer_class = AlbumThingSerializer
     pagination_class = StandardResultsSetPagination
 
-    def get_queryset(self):
+    def _album_queryset(self):
+        """The requesting user's non-empty thing albums, ready to serialize."""
         if self.request.user.is_anonymous:
             return AlbumThing.objects.none()
-        active_types = _get_active_tag_thing_types()
         return (
             AlbumThing.objects.filter(Q(owner=self.request.user))
             .filter(Q(photo_count__gt=0))
-            .filter(Q(thing_type__in=active_types) | Q(thing_type="hashtag_attribute"))
             .prefetch_related(
                 Prefetch(
                     "photos",
-                    queryset=Photo.visible.order_by("-exif_timestamp"),
-                ),
-                Prefetch(
-                    "photos__owner",
-                    queryset=User.objects.only(
-                        "id", "username", "first_name", "last_name"
+                    queryset=_with_photo_summary_relations(
+                        Photo.visible.order_by("-exif_timestamp")
                     ),
                 ),
             )
             .order_by("title")
         )
 
+    def get_queryset(self):
+        if self.request.user.is_anonymous:
+            return AlbumThing.objects.none()
+        active_types = _get_active_tag_thing_types()
+        return self._album_queryset().filter(
+            Q(thing_type__in=active_types) | Q(thing_type="hashtag_attribute")
+        )
+
     def retrieve(self, *args, **kwargs):
-        queryset = self.get_queryset()
         logger.warning(args[0].__str__())
         albumid = re.findall(r"\'(.+?)\'", args[0].__str__())[0].split("/")[-2]
         serializer = GroupedThingPhotosSerializer(
-            queryset.filter(id=albumid).first(), context={"request": self.request}
+            self.get_queryset().filter(id=albumid).first(),
+            context={"request": self.request},
         )
         return Response({"results": serializer.data})
 
@@ -212,9 +273,30 @@ class AlbumPlaceViewSet(viewsets.ModelViewSet):
     serializer_class = AlbumPlaceSerializer
     pagination_class = StandardResultsSetPagination
 
-    def get_queryset(self):
+    def _album_queryset(self, with_photo_summary=False):
+        """The requesting user's non-empty place albums.
+
+        The list action renders photos through ``PhotoSuperSimpleSerializer``,
+        which reads a handful of columns, while the detail action renders the
+        much wider photo summary. Only load the summary relations for the
+        detail action, otherwise listing places drags in a thumbnail, a search
+        instance, a main file, its embedded media, the stacks and the files of
+        every photo of every album on the page for nothing.
+        """
         if self.request.user.is_anonymous:
             return AlbumPlace.objects.none()
+        photos = Photo.objects.filter(hidden=False).order_by("-exif_timestamp")
+        if with_photo_summary:
+            photos = _with_photo_summary_relations(photos)
+        else:
+            photos = photos.only(
+                "image_hash",
+                "public",
+                "rating",
+                "hidden",
+                "exif_timestamp",
+                "video",
+            )
         return (
             AlbumPlace.objects.annotate(
                 photo_count=Count(
@@ -222,30 +304,19 @@ class AlbumPlaceViewSet(viewsets.ModelViewSet):
                 )
             )
             .filter(Q(photo_count__gt=0) & Q(owner=self.request.user))
-            .prefetch_related(
-                Prefetch(
-                    "photos",
-                    queryset=Photo.objects.filter(hidden=False)
-                    .only(
-                        "image_hash",
-                        "public",
-                        "rating",
-                        "hidden",
-                        "exif_timestamp",
-                        "video",
-                    )
-                    .order_by("-exif_timestamp"),
-                )
-            )
+            .prefetch_related(Prefetch("photos", queryset=photos))
             .order_by("title")
         )
 
+    def get_queryset(self):
+        return self._album_queryset()
+
     def retrieve(self, *args, **kwargs):
-        queryset = self.get_queryset()
         logger.warning(args[0].__str__())
         albumid = re.findall(r"\'(.+?)\'", args[0].__str__())[0].split("/")[-2]
         serializer = GroupedPlacePhotosSerializer(
-            queryset.filter(id=albumid).first(), context={"request": self.request}
+            self._album_queryset(with_photo_summary=True).filter(id=albumid).first(),
+            context={"request": self.request},
         )
         return Response({"results": serializer.data})
 
@@ -434,56 +505,10 @@ class AlbumDateViewSet(viewsets.ModelViewSet):
 
         album_date = AlbumDate.objects.filter(id=self.kwargs["pk"]).first()
 
-        # Build a prefetch for stacks that filters to valid types and annotates
-        # photo_count, avoiding N+1 queries in the serializer
-        valid_stack_types = PhotoStack.VALID_STACK_TYPES + [
-            PhotoStack.StackType.RAW_JPEG_PAIR,
-            PhotoStack.StackType.LIVE_PHOTO,
-        ]
-        stacks_prefetch = Prefetch(
-            "stacks",
-            queryset=PhotoStack.objects.filter(
-                stack_type__in=valid_stack_types
-            ).annotate(photo_count_annotation=Count("photos")),
-        )
-
-        photo_qs = (
+        photo_qs = _with_photo_summary_relations(
             album_date.photos.filter(*photo_filter)
-            .prefetch_related(
-                Prefetch(
-                    "owner",
-                    queryset=User.objects.only(
-                        "id", "username", "first_name", "last_name"
-                    ),
-                ),
-                Prefetch(
-                    "main_file__embedded_media",
-                    queryset=File.objects.only("hash"),
-                ),
-                stacks_prefetch,
-                "files",  # Prefetch files for get_has_raw_variant()
-            )
-            .select_related("thumbnail", "search_instance", "main_file")
             .distinct()  # Remove duplicates that can occur when filtering through reverse ForeignKey relationships (e.g., faces__person__id)
             .order_by("-exif_timestamp")
-            .only(
-                "image_hash",
-                "thumbnail__aspect_ratio",
-                "thumbnail__dominant_color",
-                "video",
-                "main_file",
-                "search_instance__search_location",
-                "public",
-                "rating",
-                "hidden",
-                "exif_timestamp",
-                "owner",
-                "video_length",
-                "exif_gps_lat",
-                "exif_gps_lon",
-                "removed",
-                "in_trashcan",
-            )
         )
 
         # Paginate photo queryset

--- a/apps/backend/api/views/faces.py
+++ b/apps/backend/api/views/faces.py
@@ -1,6 +1,16 @@
 import uuid
 
-from django.db.models import Case, CharField, Count, IntegerField, Q, Value, When
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    IntegerField,
+    Prefetch,
+    Q,
+    Value,
+    When,
+)
+from django.utils import timezone
 from django_q.tasks import Chain
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -258,36 +268,71 @@ class SetFacePersonLabel(APIView):
                 name=data["person_name"], owner=self.request.user, kind=Person.KIND_USER
             )
 
-        faces = Face.objects.in_bulk(data["face_ids"])
+        # Everything the loop below touches is pulled in up front: the ownership
+        # check needs the photo and its owner, rebuilding the search captions
+        # needs the caption, metadata and file rows. Fetching them lazily costs
+        # several queries per face, which is what makes tagging a large
+        # selection of faces run into the gateway timeout.
+        faces = (
+            Face.objects.select_related(
+                "photo__owner",
+                "photo__main_file",
+                "photo__metadata",
+                "photo__caption_instance",
+            )
+            .prefetch_related(
+                "photo__files",
+                Prefetch(
+                    "photo__faces",
+                    queryset=Face.objects.select_related("person"),
+                ),
+            )
+            .in_bulk(data["face_ids"])
+        )
 
         updated = []
         not_updated = []
+        relabeled_faces = []
         for face in faces.values():
             if face.photo.owner == request.user:
                 face.person = person
                 if not person:
                     face.cluster_person = cluster_person
                     face.classification_person = classification_person
-                face.save()
+                relabeled_faces.append(face)
                 updated.append(FaceListSerializer(face).data)
             else:
                 not_updated.append(FaceListSerializer(face).data)
+        Face.objects.bulk_update(
+            relabeled_faces, ["person", "cluster_person", "classification_person"]
+        )
         if person:
             person._calculate_face_count()
             person._set_default_cover_photo()
-        search_instance, created = PhotoSearch.objects.get_or_create(photo=face.photo)
-        search_instance.recreate_search_captions()
-        search_instance.save()
+
+        # Every photo we relabeled needs its captions rebuilt, not just the one
+        # the loop happened to end on.
+        updated_photos = {face.photo.pk: face.photo for face in relabeled_faces}
+
+        # The faces behind `photo.faces` were prefetched before the relabel, so
+        # those cached rows still carry the old person. They are different
+        # instances from the ones we just updated, so copy the new person across
+        # before rebuilding the captions from them.
+        relabeled_by_pk = {face.pk: face for face in relabeled_faces}
+        for photo in updated_photos.values():
+            for cached_face in photo.faces.all():
+                relabeled = relabeled_by_pk.get(cached_face.pk)
+                if relabeled is not None:
+                    cached_face.person = relabeled.person
+
+        self._recreate_search_captions(list(updated_photos.values()))
 
         # Write face regions to image files if user preference is enabled
         if request.user.save_face_tags_to_disk:
             use_sidecar = (
                 request.user.save_metadata_to_disk == User.SaveMetadata.SIDECAR_FILE
             )
-            updated_photos = {
-                f.photo for f in faces.values() if f.photo.owner == request.user
-            }
-            for photo in updated_photos:
+            for photo in updated_photos.values():
                 try:
                     photo._save_metadata(
                         use_sidecar=use_sidecar,
@@ -306,6 +351,39 @@ class SetFacePersonLabel(APIView):
                 "not_updated": not_updated,
             }
         )
+
+    @staticmethod
+    def _recreate_search_captions(photos):
+        """Rebuild the search captions of the given photos in one batch.
+
+        Doing a ``get_or_create()`` and a ``save()`` per photo would put the
+        query count of the request back into the thousands.
+        """
+        search_instances = PhotoSearch.objects.in_bulk([photo.pk for photo in photos])
+
+        to_create = []
+        to_update = []
+        for photo in photos:
+            search_instance = search_instances.get(photo.pk)
+            if search_instance:
+                # Reuse the photo we already have instead of selecting it again.
+                search_instance.photo = photo
+                search_instance.updated_at = timezone.now()
+                to_update.append(search_instance)
+            else:
+                search_instance = PhotoSearch(photo=photo)
+                to_create.append(search_instance)
+            search_instance.recreate_search_captions()
+
+        # Two clients labelling faces on the same photo can race to create its
+        # search row, so fall back to updating the row the other one won with.
+        PhotoSearch.objects.bulk_create(
+            to_create,
+            update_conflicts=True,
+            update_fields=["search_captions", "updated_at"],
+            unique_fields=["photo"],
+        )
+        PhotoSearch.objects.bulk_update(to_update, ["search_captions", "updated_at"])
 
 
 class DeleteFaces(APIView):

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -598,6 +598,18 @@ class UnifiedMediaAccessView(APIView):
         except Exception:
             return HttpResponse(status=500)
 
+    def _transcoded_video_response(self, photo):
+        """Pipe the original through ffmpeg and hand out a plain mp4 stream.
+
+        Browsers cannot decode every container/codec we store, so the per-user
+        "Always transcode videos" setting exists to get them something they can
+        actually play.
+        """
+        return StreamingHttpResponse(
+            gen(VideoTranscoder(photo.main_file.path)),
+            content_type="video/mp4",
+        )
+
     def _generate_response_proxy(self, photo, path, fname, transcode_videos):
         if "thumbnail" in path:
             response = HttpResponse()
@@ -640,14 +652,10 @@ class UnifiedMediaAccessView(APIView):
             return response
 
         if photo.video:
+            if transcode_videos:
+                return self._transcoded_video_response(photo)
             mime = magic.Magic(mime=True)
             filename = mime.from_file(photo.main_file.path)
-            if transcode_videos:
-                response = StreamingHttpResponse(
-                    gen(VideoTranscoder(photo.main_file.path)),
-                    content_type="video/mp4",
-                )
-                return response
             response = HttpResponse()
             response["Content-Type"] = filename
             response["X-Accel-Redirect"] = iri_to_uri(
@@ -685,10 +693,47 @@ class UnifiedMediaAccessView(APIView):
             return self._serve_file_direct(file_path, "image/jpg")
 
         if photo.video:
+            if transcode_videos:
+                return self._transcoded_video_response(photo)
             return self._serve_file_direct(photo.main_file.path)
 
         file_path = os.path.join(settings.MEDIA_ROOT, path, fname)
         return self._serve_file_direct(file_path, "image/jpg")
+
+    def _generate_response_original(
+        self, photo, use_proxy, transcode_videos, inline=False
+    ):
+        """Serve the untouched original file (path == "photos").
+
+        Videos go through ffmpeg first when the requester enabled "Always
+        transcode videos", exactly like the thumbnail/video paths do.
+        """
+        if photo.video and transcode_videos:
+            return self._transcoded_video_response(photo)
+        try:
+            mime = magic.Magic(mime=True)
+            content_type = mime.from_file(photo.main_file.path)
+        except Exception:
+            content_type = "application/octet-stream"
+
+        if use_proxy:
+            response = HttpResponse()
+            response["Content-Type"] = content_type if photo.video else "image/webp"
+            if photo.main_file.path.startswith("/nextcloud_media/"):
+                internal_path = "/nextcloud_original" + photo.main_file.path[21:]
+            elif photo.main_file.path.startswith(settings.PHOTOS):
+                internal_path = (
+                    "/original" + photo.main_file.path[len(settings.PHOTOS) :]
+                )
+            else:
+                internal_path = quote(photo.main_file.path)
+            if inline:
+                response["Content-Disposition"] = 'inline; filename="{}"'.format(
+                    photo.main_file.path.split("/")[-1]
+                )
+            response["X-Accel-Redirect"] = iri_to_uri(internal_path)
+            return response
+        return self._serve_file_direct(photo.main_file.path, content_type)
 
     def _public_album_active_q(self):
         return Q(share__enabled=True) & (
@@ -916,30 +961,7 @@ class UnifiedMediaAccessView(APIView):
                 photo = photos.first()
 
         if photo.albumuser_set.filter(self._public_album_active_q()).exists():
-            if use_proxy:
-                try:
-                    mime = magic.Magic(mime=True)
-                    filename = mime.from_file(photo.main_file.path)
-                except Exception:
-                    filename = "application/octet-stream"
-                response = HttpResponse()
-                response["Content-Type"] = filename if photo.video else "image/webp"
-                if photo.main_file.path.startswith("/nextcloud_media/"):
-                    internal_path = "/nextcloud_original" + photo.main_file.path[21:]
-                elif photo.main_file.path.startswith(settings.PHOTOS):
-                    internal_path = (
-                        "/original" + photo.main_file.path[len(settings.PHOTOS) :]
-                    )
-                else:
-                    internal_path = quote(photo.main_file.path)
-                response["X-Accel-Redirect"] = iri_to_uri(internal_path)
-                return response
-            try:
-                mime = magic.Magic(mime=True)
-                content_type = mime.from_file(photo.main_file.path)
-            except Exception:
-                content_type = "application/octet-stream"
-            return self._serve_file_direct(photo.main_file.path, content_type)
+            return self._generate_response_original(photo, use_proxy, False)
 
         jwt = request.COOKIES.get("jwt")
         if jwt is not None:
@@ -950,57 +972,22 @@ class UnifiedMediaAccessView(APIView):
         else:
             return HttpResponseForbidden()
 
-        user = User.objects.filter(id=token["user_id"]).only("id").first()
+        user = (
+            User.objects.filter(id=token["user_id"])
+            .only("id", "transcode_videos")
+            .first()
+        )
+        transcode_videos = user is not None and user.transcode_videos
         if photo.owner == user or user in photo.shared_to.all():
-            if use_proxy:
-                response = HttpResponse()
-                try:
-                    mime = magic.Magic(mime=True)
-                    filename = mime.from_file(photo.main_file.path)
-                except Exception:
-                    filename = "application/octet-stream"
-                response["Content-Type"] = filename if photo.video else "image/webp"
-                if photo.main_file.path.startswith("/nextcloud_media/"):
-                    internal_path = "/nextcloud_original" + photo.main_file.path[21:]
-                elif photo.main_file.path.startswith(settings.PHOTOS):
-                    internal_path = (
-                        "/original" + photo.main_file.path[len(settings.PHOTOS) :]
-                    )
-                else:
-                    internal_path = quote(photo.main_file.path)
-                response["Content-Disposition"] = 'inline; filename="{}"'.format(
-                    photo.main_file.path.split("/")[-1]
-                )
-                response["X-Accel-Redirect"] = iri_to_uri(internal_path)
-                return response
-            return self._serve_file_direct(photo.main_file.path)
+            return self._generate_response_original(
+                photo, use_proxy, transcode_videos, inline=True
+            )
         else:
             for album in photo.albumuser_set.only("shared_to", "public"):
                 if getattr(album, "public", False) or user in album.shared_to.all():
-                    if use_proxy:
-                        response = HttpResponse()
-                        try:
-                            mime = magic.Magic(mime=True)
-                            filename = mime.from_file(photo.main_file.path)
-                        except Exception:
-                            filename = "application/octet-stream"
-                        response["Content-Type"] = (
-                            filename if photo.video else "image/webp"
-                        )
-                        if photo.main_file.path.startswith("/nextcloud_media/"):
-                            internal_path = (
-                                "/nextcloud_original" + photo.main_file.path[21:]
-                            )
-                        elif photo.main_file.path.startswith(settings.PHOTOS):
-                            internal_path = (
-                                "/original"
-                                + photo.main_file.path[len(settings.PHOTOS) :]
-                            )
-                        else:
-                            internal_path = quote(photo.main_file.path)
-                        response["X-Accel-Redirect"] = iri_to_uri(internal_path)
-                        return response
-                    return self._serve_file_direct(photo.main_file.path)
+                    return self._generate_response_original(
+                        photo, use_proxy, transcode_videos
+                    )
         return HttpResponse(status=404)
 
 

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -18,6 +18,20 @@ CLIP_ROOT = os.path.join(MEDIA_ROOT, "data_models", "clip-embeddings")
 LOGS_ROOT = BASE_LOGS
 DEMO_SITE = os.environ.get("DEMO_SITE", "False") != "False"
 
+# Matplotlib comes along with insightface, which the face recognition service
+# imports. Left to itself it keeps its font cache under $HOME, and when the home
+# directory is not writable - it resolves to `/` in plenty of container setups -
+# it falls back to a fresh /tmp/matplotlib-XXXXXXXX directory and rebuilds the
+# font cache on *every* process start. Give it a directory we own instead. The
+# ML services are spawned with subprocess.Popen (see api/services.py), so they
+# inherit this.
+MPLCONFIGDIR = os.environ.get("MPLCONFIGDIR") or os.path.join(MEDIA_ROOT, "matplotlib")
+try:
+    os.makedirs(MPLCONFIGDIR, exist_ok=True)
+except OSError as e:
+    print(f"could not create matplotlib cache directory {MPLCONFIGDIR}: {e}")
+os.environ["MPLCONFIGDIR"] = MPLCONFIGDIR
+
 WSGI_APPLICATION = "librephotos.wsgi.application"
 AUTH_USER_MODEL = "api.User"
 ROOT_URLCONF = "librephotos.urls"

--- a/apps/backend/nextcloud/directory_watcher.py
+++ b/apps/backend/nextcloud/directory_watcher.py
@@ -8,20 +8,30 @@ from api import util
 from api.directory_watcher import handle_new_image
 from api.image_similarity import build_image_similarity_index
 from api.models import LongRunningJob
+from api.models.file import is_metadata, is_raw
 
 
 def isValidNCMedia(file_obj):
-    file_attr = file_obj.attributes
-    filetype = file_attr.get("{DAV:}getcontenttype", "")
+    """Tell whether a remote file is something librephotos can index.
+
+    A remote file is only known by its WebDAV metadata, so the decision is made
+    on the ``{DAV:}getcontenttype`` and - for the formats nextcloud has no mime
+    type for, most notably camera raw - on the file name. What is accepted here
+    mirrors what the local directory watcher indexes
+    (``api.models.file.is_valid_media``): images, videos, raw files and xmp
+    sidecars. Anything narrower silently drops whole nextcloud folders.
+    """
     try:
-        return (
-            "jpeg" in filetype
-            or "png" in filetype
-            or "bmp" in filetype
-            or "gif" in filetype
-            or "heic" in filetype
-            or "heif" in filetype
+        file_attr = file_obj.attributes
+        filetype = file_attr.get("{DAV:}getcontenttype") or ""
+        if filetype.startswith("image/") or filetype.startswith("video/"):
+            return True
+        if is_raw(file_obj.path) or is_metadata(file_obj.path):
+            return True
+        util.logger.info(
+            f"Skipping {file_obj.path}, because '{filetype}' is not a media type"
         )
+        return False
     except Exception:
         util.logger.exception("An image thrown an exception")
         return False
@@ -42,38 +52,44 @@ def scan_photos(user, job_id):
         job_id=job_id,
     )
 
-    nc = nextcloud.Client(user.nextcloud_server_address)
-    nc.login(user.nextcloud_username, user.nextcloud_app_password)
+    added_photo_count = 0
 
-    photos = []
-
-    paths = []
-
-    collect_photos(nc, user.nextcloud_scan_directory, photos)
-
-    for photo in photos:
-        local_dir = os.path.join(
-            settings.DATA_ROOT,
-            "nextcloud_media",
-            user.username,
-            os.path.dirname(photo)[1:],
-        )
-        local_path = os.path.join(
-            settings.DATA_ROOT, "nextcloud_media", user.username, photo[1:]
-        )
-        paths.append(local_path)
-
-        if not os.path.exists(local_dir):
-            pathlib.Path(local_dir).mkdir(parents=True, exist_ok=True)
-
-        if not os.path.exists(local_path):
-            nc.get_file(photo, local_path)
-        util.logger.info("Downloaded photo from nextcloud to " + local_path)
-
+    # Everything the scan does - logging in, listing the remote directory and
+    # downloading the photos included - has to happen inside the try, otherwise
+    # a failure (rejected app password, unreachable server, missing scan
+    # directory) leaves the job at finished=False forever and blocks the queue
+    # for every other job.
     try:
+        nc = nextcloud.Client(user.nextcloud_server_address)
+        nc.login(user.nextcloud_username, user.nextcloud_app_password)
+
+        photos = []
+
+        paths = []
+
+        collect_photos(nc, user.nextcloud_scan_directory, photos)
+
+        for photo in photos:
+            local_dir = os.path.join(
+                settings.DATA_ROOT,
+                "nextcloud_media",
+                user.username,
+                os.path.dirname(photo)[1:],
+            )
+            local_path = os.path.join(
+                settings.DATA_ROOT, "nextcloud_media", user.username, photo[1:]
+            )
+            paths.append(local_path)
+
+            if not os.path.exists(local_dir):
+                pathlib.Path(local_dir).mkdir(parents=True, exist_ok=True)
+
+            if not os.path.exists(local_path):
+                nc.get_file(photo, local_path)
+            util.logger.info("Downloaded photo from nextcloud to " + local_path)
+
         paths.sort()
 
-        added_photo_count = 0
         to_add_count = len(paths)
         for idx, image_path in enumerate(paths):
             util.logger.info("begin handling of photo %d/%d" % (idx + 1, to_add_count))
@@ -87,4 +103,5 @@ def scan_photos(user, job_id):
     except Exception as e:
         util.logger.exception(str(e))
         lrj.fail(error=e)
+        return {"new_photo_count": added_photo_count, "status": False}
     return {"new_photo_count": added_photo_count, "status": True}

--- a/apps/backend/nextcloud/views.py
+++ b/apps/backend/nextcloud/views.py
@@ -3,6 +3,7 @@ import uuid
 from urllib.parse import urlparse
 
 import owncloud as nextcloud
+import requests
 from django_q.tasks import AsyncTask
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
@@ -58,9 +59,14 @@ class ListDir(APIView):
         ):
             return Response([])
 
-        nc = nextcloud.Client(request.user.nextcloud_server_address)
-        nc.login(request.user.nextcloud_username, request.user.nextcloud_app_password)
+        # Logging in has to happen inside the try as well: it is the call
+        # nextcloud answers with an HTTP error when the app password is wrong,
+        # and it is the first one to fail when the server is unreachable.
         try:
+            nc = nextcloud.Client(request.user.nextcloud_server_address)
+            nc.login(
+                request.user.nextcloud_username, request.user.nextcloud_app_password
+            )
             return Response(
                 [
                     {
@@ -72,8 +78,19 @@ class ListDir(APIView):
                     if p.is_dir()
                 ]
             )
-        except nextcloud.HTTPResponseError:
-            return Response(status=400)
+        except nextcloud.ResponseError as e:
+            logger.warning(f"Nextcloud responded with an error: {e}")
+            return Response({"status": False, "message": str(e)}, status=400)
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Could not reach the nextcloud server: {e}")
+            return Response(
+                {
+                    "status": False,
+                    "message": "Could not reach the nextcloud server. Check the "
+                    "server address.",
+                },
+                status=400,
+            )
 
 
 class ScanPhotosView(APIView):

--- a/apps/frontend/src/__repro__/issue_630.test.tsx
+++ b/apps/frontend/src/__repro__/issue_630.test.tsx
@@ -1,0 +1,120 @@
+// UTC+2 in May (CEST), same as the reporter
+
+import { MantineProvider } from "@mantine/core";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import "@mantine/core/styles.css";
+import { TimestampItem } from "../components/lightbox/TimestampItem";
+
+/**
+ * Repro for https://github.com/LibrePhotos/librephotos/issues/630
+ * '"Time taken" date picker results in the wrong date being set'
+ *
+ * The reporter is in CEST (UTC+2). Picking "21 May 2022" in the lightbox date
+ * picker stores 20 May 2022, 10:00 PM instead.
+ *
+ * Root cause: src/components/lightbox/TimestampItem.tsx keeps the edited
+ * timestamp as a browser-local `Date` and serialises it with
+ * `timestamp.toISOString()`, which shifts it by the browser's UTC offset.
+ * `exif_timestamp` is, by the backend's own convention
+ * (apps/backend/api/date_time_extractor.py: "local time + timezone equal to
+ * UTC"), the photo's *local wall clock*, so the offset must not be applied.
+ * For any UTC+ browser the wall clock is moved backwards, and whenever the
+ * time of day is inside the offset window the calendar date rolls back a day.
+ */
+
+// Must be set before anything captures the timezone.
+process.env.TZ = "Europe/Berlin";
+
+const updatePhoto = vi.fn();
+
+vi.mock("../api_client/photos/hooks", () => ({
+  useUpdatePhotoMutation: () => ({ mutate: updatePhoto }),
+}));
+
+// The photo the user is editing. Taken shortly after midnight, so the CEST
+// offset is enough to push it into the previous day - exactly the "12:00 AM"
+// case in the screenshots attached to the issue.
+const PHOTO = {
+  image_hash: "issue630hash",
+  exif_timestamp: "2022-05-15T00:30:00",
+};
+
+// The day the user clicks in the calendar.
+const PICKED_DAY = 21;
+const EXPECTED_WALL_CLOCK = "2022-05-21T00:30:00";
+
+beforeAll(() => {
+  // Pin "today" so the calendar opens on May 2022 and clicking "21" means
+  // 21 May 2022. Only Date is faked - timers are left alone for React.
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date(2022, 4, 15, 12, 0, 0));
+
+  // @ts-ignore - jsdom has no matchMedia
+  window.matchMedia = (q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+describe("issue 630: lightbox 'Time taken' date picker", () => {
+  it("sends the calendar date the user actually picked", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MantineProvider>
+          <TimestampItem photoDetail={PHOTO} isPublic={false} />
+        </MantineProvider>
+      );
+    });
+
+    // Open the "Time taken" editor.
+    const editButton = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      editButton.click();
+    });
+
+    // Click day 21 of the displayed month (May 2022).
+    const dayButton = Array.from(container.querySelectorAll<HTMLButtonElement>("table button")).find(
+      button => button.getAttribute("data-outside") !== "true" && button.textContent === String(PICKED_DAY)
+    );
+    expect(dayButton, "day cell for the picked day").toBeTruthy();
+    await act(async () => {
+      dayButton!.click();
+    });
+
+    // Confirm (the green check ActionIcon).
+    const actionIcons = container.querySelectorAll<HTMLButtonElement>(".mantine-ActionIcon-root");
+    expect(actionIcons.length, "cancel + submit action icons").toBe(2);
+    await act(async () => {
+      actionIcons[1].click();
+    });
+
+    expect(updatePhoto).toHaveBeenCalledTimes(1);
+    const sent = updatePhoto.mock.calls[0][0].data.exif_timestamp as string;
+
+    // exif_timestamp carries the photo's local wall clock, so what leaves the
+    // browser must still read 2022-05-21 00:30:00 - the user picked 21 May and
+    // did not touch the time.
+    expect(sent.slice(0, 10), `calendar date sent to the API (payload: ${sent})`).toBe(
+      EXPECTED_WALL_CLOCK.slice(0, 10)
+    );
+    expect(sent.slice(0, 19), `wall clock sent to the API (payload: ${sent})`).toBe(EXPECTED_WALL_CLOCK);
+  });
+});

--- a/apps/frontend/src/__repro__/issue_832.test.tsx
+++ b/apps/frontend/src/__repro__/issue_832.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Repro for https://github.com/LibrePhotos/librephotos/issues/832
+ * "Default timezone not being applied"
+ *
+ * Backend contract (api/date_time_extractor.py, TimeExtractionRule docstring):
+ *
+ *   "The goal is to help extract local time, but for historical reason it is
+ *    expected the returned datetime will have timezone to be set to pytz.utc
+ *    (so local time + timezone equal to UTC)."
+ *
+ * i.e. `Photo.exif_timestamp` holds the *local wall-clock time the picture was
+ * taken*, merely tagged with a UTC offset as a marker. A photo whose filename is
+ * `...2023-04-21-12-40-22-085-80gfz.jpg` is stored as `2023-04-21 12:40:22+00`
+ * and the API hands it to the client as "2023-04-21T12:40:22+00:00".
+ *
+ * The lightbox renders it with `DateTime.fromISO(photoDetail.exif_timestamp)`,
+ * which resolves into the *browser's* zone. For the reporter (Australia/Perth,
+ * UTC+8) 12:40 is therefore shown as 8:40 PM — the exact symptom in the issue.
+ * The wall-clock time must be shown verbatim, whatever zone the viewer sits in.
+ */
+import { MantineProvider } from "@mantine/core";
+import i18n from "i18next";
+import { Settings } from "luxon";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { TimestampItem } from "../components/lightbox/TimestampItem";
+
+// The component only uses this to PATCH edits; irrelevant to rendering, and
+// mocking it keeps react-query's provider out of the picture.
+vi.mock("../api_client/photos/hooks", () => ({
+  useUpdatePhotoMutation: () => ({ mutate: vi.fn() }),
+}));
+
+// The reporter's browser zone: Australia/Perth, UTC+8, no DST.
+const VIEWER_ZONE = "Australia/Perth";
+const originalZone = Settings.defaultZone;
+
+// jsdom ships no matchMedia; MantineProvider needs it to resolve the color scheme.
+function stubMatchMedia() {
+  if (typeof window.matchMedia === "function") return;
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+async function renderLabel(exifTimestamp: string): Promise<string> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <TimestampItem photoDetail={{ image_hash: "deadbeef", exif_timestamp: exifTimestamp }} isPublic />
+      </MantineProvider>
+    );
+  });
+  // The label lives in the button; container.textContent would also drag in
+  // Mantine's injected <style> blocks.
+  const text = container.querySelector("button")?.textContent ?? "";
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  return text;
+}
+
+describe("issue 832 - default timezone not being applied", () => {
+  beforeAll(async () => {
+    stubMatchMedia();
+    await i18n.changeLanguage("en");
+    Settings.defaultZone = VIEWER_ZONE;
+  });
+
+  afterAll(() => {
+    Settings.defaultZone = originalZone;
+  });
+
+  it("shows the extracted local wall-clock time, not the viewer-zone shift of it", async () => {
+    // Issue example 1: filename "...2023-04-21-12-40-22-085-80gfz.jpg", no EXIF.
+    // The "using filename assuming timestamp is local" rule yields 12:40:22 local,
+    // which the backend persists as 2023-04-21 12:40:22+00.
+    const label = await renderLabel("2023-04-21T12:40:22+00:00");
+
+    expect(label).toMatch(/12:40/);
+    // The reported symptom: 12:40 rendered as 8:40 PM in a UTC+8 browser.
+    expect(label).not.toMatch(/8:40/);
+  });
+
+  it("keeps the calendar day of a late-evening photo", async () => {
+    // 2023-04-21 is a Friday; shifting by +8h rolls it into Saturday the 22nd,
+    // which also drops the photo into the wrong "album date" bucket in the UI.
+    const label = await renderLabel("2023-04-21T23:30:00+00:00");
+
+    expect(label).toMatch(/Apr 21, 2023/);
+    expect(label).toMatch(/Friday/);
+  });
+});

--- a/apps/frontend/src/__repro__/issue_840.test.tsx
+++ b/apps/frontend/src/__repro__/issue_840.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Repro for https://github.com/LibrePhotos/librephotos/issues/840
+ *
+ *   "With latest library dashboard with french language (and maybe more long languages)
+ *    buttons are too small or non responsive"
+ *   -> "Can we add some unitary test to make it sure it fit all the language we have?"
+ *
+ * The Library page (src/components/settings/Library.tsx, introduced by the
+ * "library UI rework" PR librephotos-frontend#173 the reporter points at) puts every
+ * action button into `<Grid.Col span={{ base: 12, sm: 2 }}>` together with
+ * `<Button fullWidth>`.  Mantine turns that into a hard `max-width: 16.6667%` cap on the
+ * button's box from the `sm` breakpoint upwards, and `.mantine-Button-label` is
+ * `white-space: nowrap; overflow: hidden`.
+ *
+ * The reserved width is therefore a constant that was chosen for the short English
+ * labels ("Scan", "Generate", "Train", "Rescan", "Browse"). It does not grow, and the
+ * label may neither wrap nor ellipsize - it is simply cut off. Every locale whose label
+ * is longer than the English one loses text, which is exactly what the French
+ * screenshots in the issue show.
+ *
+ * This test renders the real Library page twice - once in English, once in French - and
+ * asserts that no localized button label ends up in a box that is both width-locked and
+ * clip-only. It should pass once the action column is allowed to size to its content
+ * (or the label is allowed to wrap).
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { Library } from "../components/settings/Library";
+import i18n from "../i18n";
+
+const stubs = vi.hoisted(() => ({
+  noopMutation: { mutate: () => {}, mutateAsync: async () => {}, isPending: false },
+  user: {
+    id: 1,
+    username: "admin",
+    scan_directory: "/data",
+    nextcloud_server_address: "https://nextcloud.example.com",
+    nextcloud_username: "user",
+    nextcloud_scan_directory: "/photos",
+    stack_raw_jpeg: true,
+  },
+  worker: { queue_can_accept_job: true },
+  auth: { access: { is_admin: true } },
+  nextcloudDirs: { isFetching: false, isSuccess: true, isError: false, data: [] },
+  userList: { data: [] },
+  countStats: { data: undefined },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: any) => <a href="/">{children}</a>,
+}));
+vi.mock("../api_client/api", () => ({ fetchClient: { get: () => {}, post: () => {} } }));
+vi.mock("../api_client/apiClient", () => ({ serverAddress: "" }));
+vi.mock("../api_client/auth/hooks", () => ({ useAccessToken: () => ({ data: stubs.auth }) }));
+vi.mock("../api_client/faces", () => ({ useTrainFacesMutation: () => stubs.noopMutation }));
+vi.mock("../api_client/folders/hooks/useFetchNextcloudDirsQuery", () => ({
+  useFetchNextcloudDirsQuery: () => stubs.nextcloudDirs,
+}));
+vi.mock("../api_client/jobs/hooks", () => ({
+  useGenerateAutoAlbumsMutation: () => stubs.noopMutation,
+  useRescanPhotosMutation: () => stubs.noopMutation,
+  useScanNextcloudPhotosMutation: () => stubs.noopMutation,
+  useScanPhotosMutation: () => stubs.noopMutation,
+  useWorkerQuery: () => ({ data: stubs.worker }),
+}));
+vi.mock("../api_client/photos/hooks", () => ({ useDeleteMissingPhotosMutation: () => stubs.noopMutation }));
+vi.mock("../api_client/stats/hooks", () => ({ useFetchCountStatsQuery: () => stubs.countStats }));
+vi.mock("../api_client/user/hooks", () => ({
+  useFetchUserListQuery: () => stubs.userList,
+  useUpdateUserMutation: () => stubs.noopMutation,
+}));
+vi.mock("../api_client/user/hooks/useCurrentUserSelfDetailsQuery", () => ({
+  useCurrentUserSelfDetailsQuery: () => ({ data: stubs.user }),
+}));
+vi.mock("../service/notifications", () => ({ notification: new Proxy({}, { get: () => () => {} }) }));
+vi.mock("../components/modals/ModalNextcloudScanDirectoryEdit", () => ({
+  ModalNextcloudScanDirectoryEdit: () => null,
+}));
+vi.mock("../components/modals/ModalUserEdit", () => ({ ModalUserEdit: () => null }));
+
+beforeAll(() => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+type ActionButton = {
+  label: string;
+  /** value of --col-max-width that Mantine emits for this button's Grid.Col above `sm` */
+  reservedWidth: string;
+  /** true when the label may neither wrap nor scroll, i.e. anything too wide is cut off */
+  clipsOverflow: boolean;
+};
+
+/** Reads the max-width Mantine generated for the Grid.Col that holds `button`. */
+function reservedWidthOf(button: HTMLElement): string {
+  const col = button.closest(".mantine-Grid-col") as HTMLElement | null;
+  const generatedClass = col && Array.from(col.classList).find(c => c.startsWith("__m__"));
+  if (!generatedClass) return "auto";
+  const rules = Array.from(document.querySelectorAll("style"))
+    .map(style => style.textContent ?? "")
+    .filter(css => css.includes(`.${generatedClass}{`))
+    .join("");
+  // last declaration wins: the one inside the `@media (min-width: 48em)` block
+  const widths = [...rules.matchAll(/--col-max-width:([^;}]+)/g)].map(m => m[1].trim());
+  return widths.length ? widths[widths.length - 1] : "auto";
+}
+
+function collectActionButtons(container: HTMLElement): ActionButton[] {
+  return Array.from(container.querySelectorAll<HTMLElement>("button"))
+    .map(button => {
+      const label = button.querySelector<HTMLElement>(".mantine-Button-label");
+      if (!label || !label.textContent?.trim()) return null;
+      const css = getComputedStyle(label);
+      return {
+        label: label.textContent.trim(),
+        reservedWidth: reservedWidthOf(button),
+        clipsOverflow: css.whiteSpace === "nowrap" && css.overflow === "hidden" && css.textOverflow !== "ellipsis",
+      };
+    })
+    .filter((b): b is ActionButton => b !== null);
+}
+
+async function renderLibraryIn(language: string) {
+  await act(async () => {
+    await i18n.changeLanguage(language);
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <Library />
+      </MantineProvider>
+    );
+  });
+  const buttons = collectActionButtons(container);
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  return buttons;
+}
+
+describe("issue #840 - library dashboard buttons in long languages", () => {
+  it("reserves room for the localized label of every action button", async () => {
+    const english = await renderLibraryIn("en");
+    const french = await renderLibraryIn("fr");
+
+    expect(french).toHaveLength(english.length);
+
+    // A button whose box is pinned to a fixed fraction of the row *and* whose label is
+    // clipped can only ever show as much text as the English label needed. Anything
+    // longer is cut off - the "buttons are too small" symptom from the issue.
+    const truncated = french
+      .map((fr, i) => ({ french: fr.label, english: english[i].label, box: fr }))
+      .filter(
+        ({ french: frLabel, english: enLabel, box }) =>
+          frLabel.length > enLabel.length && box.clipsOverflow && box.reservedWidth.endsWith("%")
+      )
+      .map(({ french: frLabel, english: enLabel, box }) => ({
+        control: enLabel,
+        localizedLabel: frLabel,
+        reservedWidth: box.reservedWidth,
+      }));
+
+    expect(truncated).toEqual([]);
+  });
+});

--- a/apps/frontend/src/components/settings/Library.tsx
+++ b/apps/frontend/src/components/settings/Library.tsx
@@ -246,9 +246,16 @@ export function Library() {
               </Modal>
             </Title>
 
+            {/*
+              Every row below is a description plus an action. The description column takes whatever
+              is left over ("auto") and the action column is sized to its content ("content"), so
+              that a translated label longer than the English one still fits instead of being cut
+              off by a fixed column width.
+            */}
+
             {/* Stack RAW+JPEG pairs toggle (per-user) */}
             <Grid>
-              <Grid.Col span={{ base: 12, sm: 10 }}>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
                 <Stack gap={0}>
                   <Text>{t("sitesettings.stack_raw_jpeg")}</Text>
                   <Text fz="sm" c="dimmed">
@@ -256,7 +263,7 @@ export function Library() {
                   </Text>
                 </Stack>
               </Grid.Col>
-              <Grid.Col span={{ base: 12, sm: 2 }}>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
                 <Switch
                   checked={editedUser?.stack_raw_jpeg !== false}
                   onChange={() =>
@@ -267,7 +274,7 @@ export function Library() {
             </Grid>
 
             <Grid>
-              <Grid.Col span={{ base: 12, sm: 10 }}>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
                 <Stack gap={0}>
                   <Group>
                     <Text>Scan Library</Text>
@@ -280,7 +287,7 @@ export function Library() {
                   </Text>
                 </Stack>
               </Grid.Col>
-              <Grid.Col span={{ base: 12, sm: 2 }}>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
                 <Group wrap="nowrap" gap={0} justify="flex-end">
                   <Button
                     onClick={() => guardScan(() => scanPhotos.mutate())}
@@ -402,7 +409,7 @@ export function Library() {
             </Collapse>
             <Divider labelPosition="left" label={<Text fw="bold">{t("settings.eventsalbums")}</Text>} mt={20} mb={10} />
             <Grid>
-              <Grid.Col span={{ base: 12, sm: 10 }}>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
                 <Stack gap={0}>
                   <Text>{t("settings.eventalbumsgenerate")}</Text>
                   <Text fz="sm" c="dimmed">
@@ -410,7 +417,7 @@ export function Library() {
                   </Text>
                 </Stack>
               </Grid.Col>
-              <Grid.Col span={{ base: 12, sm: 2 }}>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
                 <Button
                   onClick={onGenerateEventAlbumsButtonClick}
                   disabled={!workerAvailability}
@@ -424,7 +431,7 @@ export function Library() {
             </Grid>
 
             <Grid>
-              <Grid.Col span={{ base: 12, sm: 10 }}>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
                 <Stack gap={0}>
                   <Text>{t("settings.eventalbumsregenerate")}</Text>
                   <Text fz="sm" c="dimmed">
@@ -432,7 +439,7 @@ export function Library() {
                   </Text>
                 </Stack>
               </Grid.Col>
-              <Grid.Col span={{ base: 12, sm: 2 }}>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
                 <Button
                   onClick={() => {
                     generateAutoAlbums();
@@ -459,7 +466,7 @@ export function Library() {
             mb={10}
           />
           <Grid>
-            <Grid.Col span={{ base: 12, sm: 10 }}>
+            <Grid.Col span={{ base: 12, sm: "auto" }}>
               <Stack gap={0}>
                 <Text>{t("settings.trainfacestitle")}</Text>
                 <Text fz="sm" c="dimmed">
@@ -467,7 +474,7 @@ export function Library() {
                 </Text>
               </Stack>
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 2 }}>
+            <Grid.Col span={{ base: 12, sm: "content" }}>
               <Button
                 disabled={!workerAvailability}
                 onClick={() => {
@@ -483,7 +490,7 @@ export function Library() {
             </Grid.Col>
           </Grid>
           <Grid>
-            <Grid.Col span={{ base: 12, sm: 10 }}>
+            <Grid.Col span={{ base: 12, sm: "auto" }}>
               <Stack gap={0}>
                 <Text>{t("settings.rescanfacestitle")}</Text>
                 <Text fz="sm" c="dimmed">
@@ -491,7 +498,7 @@ export function Library() {
                 </Text>
               </Stack>
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 2 }}>
+            <Grid.Col span={{ base: 12, sm: "content" }}>
               <Button
                 disabled={!workerAvailability}
                 onClick={() => {
@@ -508,106 +515,117 @@ export function Library() {
             </Grid.Col>
           </Grid>
           <Divider labelPosition="left" label={<Text fw="bold">Nextcloud</Text>} mt={20} mb={10} />
-          <Grid>
-            <Grid.Col span={{ base: 12, sm: 10 }}>
-              <Stack gap={0}>
-                <Text>Status</Text>
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 2 }}>
-              <Badge
-                leftSection={BadgeIcon(userSelfDetails, isNextcloudSuccess, isNextcloudError, isNextcloudFetching)}
-                variant="outline"
-                color={nextcloudStatusColor}
-                fullWidth
-              >
-                {!userSelfDetails.nextcloud_server_address && t("settings.nextcloudsetup")}
-                {isNextcloudFetching && t("settings.nextcloudconnecting")}
-                {isNextcloudSuccess &&
-                  userSelfDetails.nextcloud_server_address &&
-                  !isNextcloudFetching &&
-                  t("settings.nextcloudloggedin")}
-                {isNextcloudError && t("settings.nextcloudnotloggedin")}
-              </Badge>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 7 }}>
-              <Stack gap={0}>
-                <Trans i18nKey="settings.serveradress" />
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 5 }}>
-              <TextInput
-                onChange={handleNextcloudServerAddressChange}
-                value={userSelfDetails.nextcloud_server_address}
-                placeholder={t("settings.serveradressplaceholder")}
-              />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 7 }}>
-              <Stack gap={0}>
-                <Trans i18nKey="settings.nextcloudusername" />
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 5 }}>
-              <TextInput
-                onChange={handleNextcloudUsernameChange}
-                value={userSelfDetails.nextcloud_username}
-                placeholder={t("settings.nextcloudusernameplaceholder")}
-              />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 7 }}>
-              <Stack gap={0}>
-                <Trans i18nKey="settings.nextcloudpassword" />
-                <Text size="sm" c="dimmed">
-                  {t("settings.credentialspopup")}
-                </Text>
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 5 }}>
-              <TextInput
-                onChange={handleNextcloudPasswordChange}
-                type="password"
-                placeholder={t("settings.nextcloudpasswordplaceholder")}
-                value={editedUser?.nextcloud_app_password ?? ""}
-              />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 10 }}>
-              <Stack gap={0}>
-                <Trans i18nKey="settings.nextcloudscandirectory" />
-                <Text size="sm" c="dimmed">
-                  {userSelfDetails.nextcloud_scan_directory
-                    ? userSelfDetails.nextcloud_scan_directory
-                    : "Choose the folder to process from the nextcloud instance"}
-                </Text>
-              </Stack>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 2 }}>
-              <Button
-                leftSection={<Folder />}
-                disabled={isNextcloudError || isNextcloudFetching || !userSelfDetails.nextcloud_server_address}
-                onClick={() => {
-                  setModalNextcloudScanDirectoryOpen(true);
-                }}
-                variant="outline"
-                fullWidth
-              >
-                {t("modalnextcloud.browse")}
-              </Button>
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 10 }} />
-            <Grid.Col span={{ base: 12, sm: 2 }}>
-              <Button
-                onClick={() => {
-                  scanNextcloudPhotos.mutate();
-                }}
-                disabled={isNextcloudFetching || !workerAvailability || !userSelfDetails.nextcloud_server_address}
-                variant="filled"
-                leftSection={<BrandNextcloud />}
-                fullWidth
-              >
-                <Trans i18nKey="settings.scannextcloudphotos">Scan photos (Nextcloud)</Trans>
-              </Button>
-            </Grid.Col>
-          </Grid>
+          {/*
+            One grid per row: a content sized column may not share a flex line with the fixed
+            width columns of the credentials rows below, otherwise those would move up into it.
+          */}
+          <Stack>
+            <Grid>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
+                <Stack gap={0}>
+                  <Text>Status</Text>
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
+                <Badge
+                  leftSection={BadgeIcon(userSelfDetails, isNextcloudSuccess, isNextcloudError, isNextcloudFetching)}
+                  variant="outline"
+                  color={nextcloudStatusColor}
+                  fullWidth
+                >
+                  {!userSelfDetails.nextcloud_server_address && t("settings.nextcloudsetup")}
+                  {isNextcloudFetching && t("settings.nextcloudconnecting")}
+                  {isNextcloudSuccess &&
+                    userSelfDetails.nextcloud_server_address &&
+                    !isNextcloudFetching &&
+                    t("settings.nextcloudloggedin")}
+                  {isNextcloudError && t("settings.nextcloudnotloggedin")}
+                </Badge>
+              </Grid.Col>
+            </Grid>
+            <Grid>
+              <Grid.Col span={{ base: 12, sm: 7 }}>
+                <Stack gap={0}>
+                  <Trans i18nKey="settings.serveradress" />
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 5 }}>
+                <TextInput
+                  onChange={handleNextcloudServerAddressChange}
+                  value={userSelfDetails.nextcloud_server_address}
+                  placeholder={t("settings.serveradressplaceholder")}
+                />
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 7 }}>
+                <Stack gap={0}>
+                  <Trans i18nKey="settings.nextcloudusername" />
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 5 }}>
+                <TextInput
+                  onChange={handleNextcloudUsernameChange}
+                  value={userSelfDetails.nextcloud_username}
+                  placeholder={t("settings.nextcloudusernameplaceholder")}
+                />
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 7 }}>
+                <Stack gap={0}>
+                  <Trans i18nKey="settings.nextcloudpassword" />
+                  <Text size="sm" c="dimmed">
+                    {t("settings.credentialspopup")}
+                  </Text>
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: 5 }}>
+                <TextInput
+                  onChange={handleNextcloudPasswordChange}
+                  type="password"
+                  placeholder={t("settings.nextcloudpasswordplaceholder")}
+                  value={editedUser?.nextcloud_app_password ?? ""}
+                />
+              </Grid.Col>
+            </Grid>
+            <Grid>
+              <Grid.Col span={{ base: 12, sm: "auto" }}>
+                <Stack gap={0}>
+                  <Trans i18nKey="settings.nextcloudscandirectory" />
+                  <Text size="sm" c="dimmed">
+                    {userSelfDetails.nextcloud_scan_directory
+                      ? userSelfDetails.nextcloud_scan_directory
+                      : "Choose the folder to process from the nextcloud instance"}
+                  </Text>
+                </Stack>
+              </Grid.Col>
+              <Grid.Col span={{ base: 12, sm: "content" }}>
+                <Button
+                  leftSection={<Folder />}
+                  disabled={isNextcloudError || isNextcloudFetching || !userSelfDetails.nextcloud_server_address}
+                  onClick={() => {
+                    setModalNextcloudScanDirectoryOpen(true);
+                  }}
+                  variant="outline"
+                  fullWidth
+                >
+                  {t("modalnextcloud.browse")}
+                </Button>
+              </Grid.Col>
+            </Grid>
+            <Grid justify="flex-end">
+              <Grid.Col span={{ base: 12, sm: "content" }}>
+                <Button
+                  onClick={() => {
+                    scanNextcloudPhotos.mutate();
+                  }}
+                  disabled={isNextcloudFetching || !workerAvailability || !userSelfDetails.nextcloud_server_address}
+                  variant="filled"
+                  leftSection={<BrandNextcloud />}
+                  fullWidth
+                >
+                  <Trans i18nKey="settings.scannextcloudphotos">Scan photos (Nextcloud)</Trans>
+                </Button>
+              </Grid.Col>
+            </Grid>
+          </Stack>
 
           <Group mt={20} />
           <Space h="xl" />

--- a/apps/mobile/src/stores/localImagesActions.test.ts
+++ b/apps/mobile/src/stores/localImagesActions.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression test for LibrePhotos issue #788 -- "No local photos".
+ *
+ * https://github.com/LibrePhotos/librephotos/issues/788
+ *
+ * Symptom (Android 11/12/13): storage / "photos and videos" permission is
+ * granted, server photos render fine, but the timeline never shows a single
+ * on-device photo.
+ *
+ * loadLocalImages() maps every camera roll edge through camerarollPhotoMapper(),
+ * which calls `FileSystem.hash(uri, 'MD5')` to build the photo id. That mapping
+ * used to be wrapped in a single all-or-nothing `Promise.all(...)`: as soon as
+ * ONE asset could not be hashed (broken file, or a MediaStore `content://` uri
+ * that react-native-file-access cannot open under scoped storage) the whole
+ * page collapsed to `undefined`, `no_valid_photos` flipped to true, the paging
+ * loop exited and nothing was stored. A single bad asset silently wiped out
+ * every other local photo -- exactly the reported "no local photos, no error".
+ */
+
+// Three assets on the device. The middle one cannot be hashed (scoped-storage
+// content:// uri / unreadable file); the other two are perfectly fine.
+const mockUnreadableUri = 'content://media/external/images/media/2'
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android', Version: 33 },
+  PermissionsAndroid: {
+    PERMISSIONS: {
+      READ_MEDIA_IMAGES: 'android.permission.READ_MEDIA_IMAGES',
+      READ_EXTERNAL_STORAGE: 'android.permission.READ_EXTERNAL_STORAGE',
+    },
+    // permission granted -- the reporters all confirmed they granted it
+    check: jest.fn().mockResolvedValue(true),
+    request: jest.fn().mockResolvedValue('granted'),
+  },
+}))
+
+jest.mock('react-native-file-access', () => ({
+  FileSystem: {
+    hash: jest.fn(async (uri: string) => {
+      if (uri === mockUnreadableUri) {
+        throw new Error('ENOENT: could not open file for hashing')
+      }
+      return `hash-of-${uri}`
+    }),
+  },
+}))
+
+const mockGetPhotos = jest.fn()
+
+jest.mock('@react-native-camera-roll/camera-roll', () => ({
+  CameraRoll: {
+    getPhotos: (...args: unknown[]) => mockGetPhotos(...args),
+    deletePhotos: jest.fn(),
+  },
+}))
+
+// Keep the network / upload side of the store out of this test.
+jest.mock('../api_client/api', () => ({
+  fetchClient: { get: jest.fn().mockResolvedValue({ exists: false }) },
+}))
+
+jest.mock('./uploadActions', () => ({
+  uploadImages: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { loadLocalImages } from './localImagesActions'
+import { useLocalImagesStore } from './localImagesStore'
+
+const edge = (id: string, uri: string) => ({
+  node: {
+    id,
+    type: 'image/jpeg',
+    timestamp: 1678000000,
+    image: { uri, width: 4000, height: 3000, filename: `${id}.jpg` },
+  },
+})
+
+describe('loadLocalImages', () => {
+  beforeEach(() => {
+    useLocalImagesStore.setState({
+      images: [],
+      lastFetch: undefined,
+      isLoading: false,
+    })
+    mockGetPhotos.mockReset()
+    mockGetPhotos.mockResolvedValue({
+      edges: [
+        edge('1', 'file:///storage/emulated/0/DCIM/Camera/one.jpg'),
+        edge('2', mockUnreadableUri),
+        edge('3', 'file:///storage/emulated/0/DCIM/Camera/three.jpg'),
+      ],
+      page_info: { has_next_page: false, start_cursor: '0', end_cursor: '2' },
+    })
+  })
+
+  it('keeps the readable device photos when a single asset cannot be hashed', async () => {
+    await loadLocalImages()
+
+    const { images } = useLocalImagesStore.getState()
+    const urls = images.map(image => image.url)
+
+    // One unreadable asset must not swallow the whole camera roll.
+    expect(urls).toEqual([
+      'file:///storage/emulated/0/DCIM/Camera/one.jpg',
+      'file:///storage/emulated/0/DCIM/Camera/three.jpg',
+    ])
+  })
+
+  it('loads every device photo when all assets are hashable', async () => {
+    mockGetPhotos.mockResolvedValue({
+      edges: [
+        edge('1', 'file:///storage/emulated/0/DCIM/Camera/one.jpg'),
+        edge('2', 'file:///storage/emulated/0/DCIM/Camera/two.jpg'),
+        edge('3', 'file:///storage/emulated/0/DCIM/Camera/three.jpg'),
+      ],
+      page_info: { has_next_page: false, start_cursor: '0', end_cursor: '2' },
+    })
+
+    await loadLocalImages()
+
+    expect(useLocalImagesStore.getState().images).toHaveLength(3)
+  })
+})

--- a/apps/mobile/src/stores/localImagesActions.ts
+++ b/apps/mobile/src/stores/localImagesActions.ts
@@ -45,6 +45,36 @@ export const camerarollPhotoMapper = async (
   }
 }
 
+/**
+ * Maps one page of camera roll entries, settling every asset on its own.
+ * Building the id hashes the file, so a single unreadable asset -- a broken
+ * file, or a MediaStore `content://` uri that cannot be opened under scoped
+ * storage -- must not take the rest of the camera roll down with it.
+ */
+async function mapPageIgnoringUnreadable(
+  items: PhotoIdentifier[],
+): Promise<LocalImages> {
+  const results = await Promise.allSettled(
+    items.map(item => camerarollPhotoMapper(item)),
+  )
+  const mapped: LocalImages = []
+
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      mapped.push(result.value)
+      return
+    }
+    console.log(
+      'Skipping unreadable local image ' +
+        items[index].node.image.uri +
+        ': ' +
+        result.reason,
+    )
+  })
+
+  return mapped
+}
+
 async function hasReadAndroidPermission(): Promise<boolean> {
   const permission =
     (Platform.Version as number) >= 33
@@ -89,21 +119,15 @@ export async function loadLocalImages(): Promise<void> {
         after: page_info.end_cursor,
         assetType: 'Photos',
       }).then(async r => {
-        const currentPage = await Promise.all(
-          r.edges.map(item => {
-            if (!lastFetch || item.node.timestamp > lastFetch) {
-              return camerarollPhotoMapper(item)
-            }
-          }),
-        ).catch(err => {
-          console.log(err)
-        })
-        const newPhotos = (currentPage || []).filter(
-          (item): item is LocalImage => item !== undefined,
+        const newItems = r.edges.filter(
+          item => !lastFetch || item.node.timestamp > lastFetch,
         )
+        const newPhotos = await mapPageIgnoringUnreadable(newItems)
         console.log('Number of new items: ', newPhotos.length)
         photos = [...photos, ...newPhotos]
-        return { ...r.page_info, no_valid_photos: newPhotos.length === 0 }
+        // Stop paging once we have caught up with the last fetch -- not
+        // because some assets on this page turned out to be unreadable.
+        return { ...r.page_info, no_valid_photos: newItems.length === 0 }
       })
     }
     addImages(photos)

--- a/deploy/docker/backend-gpu/entrypoint.sh
+++ b/deploy/docker/backend-gpu/entrypoint.sh
@@ -10,6 +10,15 @@ fi
 export OPENBLAS_NUM_THREADS=1
 export OPENBLAS_MAIN_FREE=1
 
+# Matplotlib comes along with insightface, which the face recognition service
+# imports. Left to itself it keeps its font cache under $HOME, and when the home
+# directory is not writable it falls back to a fresh /tmp directory and re-parses
+# every font on each start. Keep it on our own volume instead; this is the same
+# path librephotos/settings/production.py derives.
+mpl_data_root="${BASE_DATA:-/}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${mpl_data_root%/}/protected_media/matplotlib}"
+mkdir -p "$MPLCONFIGDIR" || echo "Could not create $MPLCONFIGDIR - matplotlib will rebuild its font cache on every start"
+
 mkdir -p /logs
 python manage.py showmigrations | tee /logs/show_migrate.log
 python manage.py migrate | tee /logs/command_migrate.log

--- a/deploy/docker/backend/entrypoint.sh
+++ b/deploy/docker/backend/entrypoint.sh
@@ -9,6 +9,15 @@ fi
 export OPENBLAS_NUM_THREADS=1
 export OPENBLAS_MAIN_FREE=1
 
+# Matplotlib comes along with insightface, which the face recognition service
+# imports. Left to itself it keeps its font cache under $HOME, and when the home
+# directory is not writable it falls back to a fresh /tmp directory and re-parses
+# every font on each start. Keep it on our own volume instead; this is the same
+# path librephotos/settings/production.py derives.
+mpl_data_root="${BASE_DATA:-/}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${mpl_data_root%/}/protected_media/matplotlib}"
+mkdir -p "$MPLCONFIGDIR" || echo "Could not create $MPLCONFIGDIR - matplotlib will rebuild its font cache on every start"
+
 mkdir -p /logs
 python manage.py showmigrations | tee /logs/show_migrate.log
 python manage.py migrate | tee /logs/command_migrate.log

--- a/deploy/docker/unified/entrypoint.sh
+++ b/deploy/docker/unified/entrypoint.sh
@@ -4,6 +4,15 @@ set -e
 
 echo "LibrePhotos starting..."
 
+# Matplotlib comes along with insightface, which the face recognition service
+# imports. Left to itself it keeps its font cache under $HOME, and when the home
+# directory is not writable it falls back to a fresh /tmp directory and re-parses
+# every font on each start. Keep it on our own volume instead; this is the same
+# path librephotos/settings/production.py derives.
+mpl_data_root="${BASE_DATA:-/}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${mpl_data_root%/}/protected_media/matplotlib}"
+mkdir -p "$MPLCONFIGDIR" || echo "Could not create $MPLCONFIGDIR - matplotlib will rebuild its font cache on every start"
+
 # Check if we should serve frontend
 if echo "$SERVE_FRONTEND" | grep -qiE '^(true|1|yes|on)$'; then
     echo "Configuring for no-proxy deployment (serving frontend from Django)..."


### PR DESCRIPTION
Works through the open `bug` backlog. Each bug was first reproduced with a failing test, then fixed; the reproductions are included as regression tests, so every fix here has a test that was red before it and is green after.

## Fixed

| Issue | Root cause |
| --- | --- |
| #1066 Nextcloud integration does not work | `scan_photos` created its `LongRunningJob` before the login, listing and downloads, all outside its `try`. A failure orphaned the job at `finished=False`, and `/api/rqavailable/` reports the queue busy while any unfinished job exists — so one failed scan greyed out every scan button, permanently. |
| #1030 can not view photos from nextcloud | `ListDir.get` called `nc.login()` outside its `try`, so the one error it promised to translate into a 400 escaped as an unhandled 500. Connection errors were unhandled too. |
| #631 Sub folders not indexed in Nextcloud | Not a recursion bug — `isValidNCMedia` gated on a hardcoded mime substring whitelist and silently dropped video, TIFF, WebP and all camera RAW. |
| #836 Auto album generation stuck | Every branch that creates an album ends in `continue`, jumping over `update_progress()`. Only single-photo groups, which create nothing, ever reached it, so a real library reported 0/0 all run. |
| #462 Duplicated auto albums | Albums were matched by a `timestamp` anchor frozen at creation and never refreshed. Delete an event's earliest photo and the next run built a byte-identical duplicate. |
| #897 Timeout when tagging many faces | `in_bulk()` without related objects made the ownership check cost 2 extra queries per face — measured 23 + 3N. Also only one photo of the batch got reindexed. |
| #619 Slow album loading | `PhotoSummarySerializer` reads six relations per photo that the thing/place/auto detail querysets never prefetched. |
| #477 Video playback black in Photos tab | The `path == "photos"` branch never read `transcode_videos` — it did not even fetch the column — so the one mitigation users have was dead for exactly the URL the lightbox requests. |
| #833 Folders owned by other users | `path_to_dict` recursed with an unguarded `os.scandir`; one unreadable directory 500'd the entire `/api/dirtree/`, so the picker came back empty. |
| #169 Photos in a symlinked directory | `walk_directory` used `os.path.isdir()`, which follows symlinks, so a *dangling* link was queued as a photo and crashed the scan. |
| #907 Matplotlib cache | Nothing exported `MPLCONFIGDIR`, but insightface pulls matplotlib in unconditionally. |
| #840 Long translations clipped | `span={{ sm: 2 }}` hard-caps buttons at 16.67% with `nowrap; overflow:hidden` and no ellipsis. |
| #788 No local photos (mobile) | One all-or-nothing `Promise.all`: a single unhashable asset discarded the whole page and latched `no_valid_photos`. |

## Also closed, already fixed

Regression tests only — #384 and #124 were fixed years ago (`f42274b6`, `6ed99b95`), #832 and #630 by #1915. Tests added so they cannot come back unnoticed.

## Worth a close look

- **The auto album merge deletes a row**, which `generate_event_albums` never did before. It is deliberately conservative: only an album lying entirely inside the current event is folded in. Photos are never *removed* from an auto album, so a photo whose date is corrected into a neighbouring event leaves a stale membership behind, and trusting it would weld two unrelated albums together and delete one. The survivor also inherits `favorited` and `shared_to`, and the merge is wrapped in a transaction. The trade-off: regeneration is not perfectly idempotent in that case — the album that lost a photo keeps listing it and a fresh album is created for the photos left behind, leaving a redundant album. That seemed clearly better than deleting one. `test_album_reaching_outside_the_event_is_not_swallowed` pins this.
- **#631 now accepts XMP sidecars**, matching what the local watcher indexes, so Nextcloud scans will download `.xmp` files too.
- **#833 catches `OSError`, not just `PermissionError`**, so `/api/dirtree/` now returns 200 with an empty listing when the requested root itself is unreadable, where it used to 500.
- **#477 also fixes the no-proxy path**, which had the same dead setting and is not covered by the repro.

## Known gaps

- `/api/albums/user/<id>/` and `/api/albums/person/<id>/` still carry per-photo queries (~8 and ~14). Fixing them needs serializer changes (`AlbumUserSerializer.get_grouped_photos` and `Person.get_photos()` each build their own queryset, discarding any prefetch), so they are out of scope here.
- `QueueAvailabilityView` still has no staleness cutoff, so any *other* job that dies without calling `fail()` reproduces the #1066 lock-out. `LongRunningJob.cleanup_stuck_jobs` already exists and would be the natural guard.

## Testing

- Backend: full suite, 1520 tests here vs 1481 on a clean `dev` worktree (+39 from the new regression tests). Clean `dev` has 9 failures/errors, this branch has 8. Seven are common to both and are pre-existing problems with running this suite on Windows (hardcoded POSIX paths, a cp1252 console choking on emoji `print()`s).
- `test_dirtree.test_admin_should_allow_to_retrieve_dirtree` fails on `dev` and **passes** here — the #833 fix repairs it.
- The remaining difference is a **rotating flake in the `MetadataEdit` ordering tests**, not a regression. Two full runs of this branch each ended with 8 failures, but not the same 8: run 1 failed `test_photo_metadata_api.test_history_ordered_by_date`, run 2 passed that one and failed `test_photo_metadata.MetadataEditModelTestCase.test_edit_records_ordered_by_created_at` instead. Both create rows back to back and assert they sort strictly by timestamp, which is a coin flip when they land in the same clock tick. `dev` shows the same kind of non-determinism elsewhere (`test_perceptual_hash.test_hamming_distance_performance`, a wall-clock timing assertion, failed there and not here). Nothing in this branch touches `MetadataEdit` or perceptual hashing.
- Frontend: 31 tests pass, `yarn lint:error` clean.
- Mobile: `yarn jest` 6 pass; `__tests__/App-test.js` fails identically with and without this branch (pre-existing jest transform config issue).
- `ruff check` and `ruff format --check` clean.

## Not included

Four issues had reproductions that an adversarial review rejected, so nothing here claims to fix them: **#1491** (JPEG-XL — the repro turned out to be an environment probe; the local libvips has no `.jxl` loader, which is a build-flag question, not a code bug), **#970** (the repro bypassed react-pig's virtualisation), **#920** (found a real `/api/faces/` vs `/api/faces/incomplete/` count disagreement, but via a request the UI cannot issue), and **#167** (real fragility, but the symptom is inverted from the report). #535 and #455 were not investigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
