### PR TITLE
docs: correct frontend dev-server command and drop CRA-era env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ deploy/
 ### Frontend (apps/frontend/)
 - Install: `cd apps/frontend && yarn install --legacy-peer-deps`
 - Lint: `yarn lint:error` • Test: `yarn test` • Build: `yarn build`
-- Dev server: `yarn dev`
+- Dev server: `yarn start`
 
 ### Mobile (apps/mobile/)
 - Install: `cd apps/mobile && yarn install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The full stack (backend + frontend + db + proxy) runs via Docker Compose from [`
 
 Each app can also be worked on standalone:
 - Backend: see [apps/backend/CONTRIBUTING.md](apps/backend/CONTRIBUTING.md)
-- Frontend: `cd apps/frontend && yarn install && yarn dev`
+- Frontend: `cd apps/frontend && yarn install && yarn start`
 - Mobile: `cd apps/mobile && yarn install && yarn android`
 - Docs: `cd apps/docs && yarn install && yarn start`
 

--- a/apps/frontend/.env.development.example
+++ b/apps/frontend/.env.development.example
@@ -1,12 +1,14 @@
-TSC_COMPILE_ON_ERROR=true
-BROWSER=none
-FAST_REFRESH=true
-ESLINT_NO_DEV_ERRORS=true
-HTTPS=false
-REACT_EDITOR=intellij
-DISABLE_ESLINT_PLUGIN=false
-DISABLE_NEW_JSX_TRANSFORM=false
-# custom env vars
-REACT_APP_PROXY_IP="localhost"
-REACT_APP_PROXY_PORT="3000"
-REACT_APP_WDYR=false
+# Copy to .env.development to override defaults for `yarn start`.
+#
+# The frontend builds with Vite, which only exposes variables prefixed with
+# VITE_ to client code (import.meta.env). Anything else set here is visible to
+# vite.config.ts but not to the app itself.
+
+# Base path the app is served under, and the origin its API calls are made
+# against. Leave unset for the default "/" (backend on the same origin, which
+# is what the Docker dev stack and the proxy provide).
+# VITE_PUBLIC_URL=""
+
+# Why Did You Render — logs the reason a component re-rendered to the console.
+# Must be the literal string "true" to take effect.
+VITE_APP_WDYR=false


### PR DESCRIPTION
## What

`apps/frontend/package.json` has no `dev` script, but two docs told contributors to run one. Following either produces an immediate `Command "dev" not found`.

- [`CONTRIBUTING.md`](https://github.com/LibrePhotos/librephotos/blob/dev/CONTRIBUTING.md) — "Dev environment" section
- [`CLAUDE.md`](https://github.com/LibrePhotos/librephotos/blob/dev/CLAUDE.md) — "Commands" section

Both now say `yarn start`.

## Why `yarn start` rather than a new `dev` alias

Adding a `dev` alias was the alternative, but `start` is already the established name across the repo:

| Where | Command |
|---|---|
| `deploy/docker/frontend/entrypoint.sh` | `yarn start` — the actual Docker dev flow |
| `apps/frontend/README.md` | `yarn start` |
| `apps/docs` | `yarn start` |

An alias would have meant two names for one script, with the entrypoint still invoking the other. Aligning the docs to the real name keeps a single entry point.

## `.env.development.example`

The file was entirely react-scripts-era — not just the `REACT_APP_*` pair. Vite reads none of these:

```
TSC_COMPILE_ON_ERROR  BROWSER  FAST_REFRESH  ESLINT_NO_DEV_ERRORS
HTTPS  REACT_EDITOR  DISABLE_ESLINT_PLUGIN  DISABLE_NEW_JSX_TRANSFORM
REACT_APP_PROXY_IP  REACT_APP_PROXY_PORT  REACT_APP_WDYR
```

`REACT_APP_PROXY_IP` / `REACT_APP_PROXY_PORT` were doubly inert: `vite.config.ts` hardcodes `host: "0.0.0.0"` / `port: 3000` and configures no proxy at all.

Replaced with the two variables the code actually reads — `VITE_PUBLIC_URL` (`vite.config.ts`, `api_client/api.ts`, `api_client/apiClient.js`) and `VITE_APP_WDYR` (`src/wdyr.ts`) — plus a note that Vite only exposes `VITE_`-prefixed vars to client code.

## Checked, no change needed

`apps/frontend/README.md` and `apps/docs/docs/development/dev-install.md` were both already correct. `git grep` confirms no `yarn dev` / `npm run dev` / `REACT_APP_` remains anywhere in tracked files.

## Follow-ups, deliberately not in this PR

Two real problems surfaced while verifying the above. Both need code changes, so they're left out of a docs-only PR:

1. **WDYR cannot be enabled at all.** `src/wdyr.ts:5` guards on `import.meta.env.NODE_ENV`, which Vite never defines (it exposes `MODE`/`DEV`/`PROD`), so the block is dead regardless of env vars. Separately, `apps/backend/CONTRIBUTING.md:357`, `dev-install.md:238`, and `contribution/frontend/index.md:31` all say to set `WDYR=True`, while the code reads `VITE_APP_WDYR === "true"` — and nothing in `deploy/` maps one to the other.
2. **`apps/docs/docs/development/contribution/frontend/index.md` is stale** (`last_modified_at: 2021-05-31`). It describes the stack as Redux/Axios — neither is a dependency — and links to `src/App.js`, `src/actions`, and `src/reducers`, none of which exist.

## Testing

Docs-only; no tests. CI path filters should trigger the frontend pipeline for the `.env.development.example` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
