### PR TITLE
fix(frontend): match PhotoMetadata zod schema to the real serializer

### DIFF
--- a/apps/frontend/src/api_client/photos/hooks/useFetchMetadataHistoryQuery.ts
+++ b/apps/frontend/src/api_client/photos/hooks/useFetchMetadataHistoryQuery.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
-import { fetchClient } from "../../api";
+import { fetchMetadataHistory } from "../metadata";
 import type { MetadataHistoryResponse } from "../types";
 
 type FetchMetadataHistoryOptions = UseQueryOptions<MetadataHistoryResponse, Error>;
@@ -18,11 +18,10 @@ export function useFetchMetadataHistoryQuery(
   options?: Omit<FetchMetadataHistoryOptions, "queryKey" | "queryFn">
 ) {
   return useQuery({
+    // Goes through the api_client function so the response is validated against
+    // the MetadataHistoryResponse schema instead of being blind-cast.
     queryKey: ["metadataHistory", photoId, page, pageSize],
-    queryFn: async () => {
-      const response = await fetchClient.get(`/photos/${photoId}/metadata/history?page=${page}&page_size=${pageSize}`);
-      return response as MetadataHistoryResponse;
-    },
+    queryFn: () => fetchMetadataHistory(photoId!, page, pageSize),
     enabled: !!photoId,
     staleTime: 10 * 1000, // 10 seconds
     ...options,

--- a/apps/frontend/src/api_client/photos/hooks/useFetchPhotoMetadataQuery.ts
+++ b/apps/frontend/src/api_client/photos/hooks/useFetchPhotoMetadataQuery.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
-import { fetchClient } from "../../api";
+import { fetchPhotoMetadata } from "../metadata";
 import type { PhotoMetadata } from "../types";
 
 type FetchPhotoMetadataOptions = UseQueryOptions<PhotoMetadata, Error>;
@@ -16,11 +16,10 @@ export function useFetchPhotoMetadataQuery(
   options?: Omit<FetchPhotoMetadataOptions, "queryKey" | "queryFn">
 ) {
   return useQuery({
+    // Goes through the api_client function so the response is validated against
+    // the PhotoMetadata schema instead of being blind-cast.
     queryKey: ["photoMetadata", photoId],
-    queryFn: async () => {
-      const response = await fetchClient.get(`/photos/${photoId}/metadata`);
-      return response as PhotoMetadata;
-    },
+    queryFn: () => fetchPhotoMetadata(photoId!),
     enabled: !!photoId,
     staleTime: 30 * 1000, // 30 seconds - metadata changes rarely
     ...options,

--- a/apps/frontend/src/api_client/photos/hooks/usePhotoMetadataMutations.ts
+++ b/apps/frontend/src/api_client/photos/hooks/usePhotoMetadataMutations.ts
@@ -3,29 +3,26 @@
  */
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { fetchClient } from "../../api";
-import type { PhotoMetadata } from "../types";
-
-type MetadataUpdateFields = {
-  title?: string;
-  caption?: string;
-  keywords?: string[];
-  rating?: number;
-  copyright?: string;
-  creator?: string;
-};
+import {
+  bulkUpdateMetadata,
+  revertAllMetadataEdits,
+  revertMetadataEdit,
+  updatePhotoMetadata,
+  type MetadataUpdateFields,
+} from "../metadata";
 
 /**
  * Update metadata for a photo (changes are tracked in history)
+ *
+ * These mutations delegate to the api_client functions so their responses are
+ * validated against the PhotoMetadata schema instead of being blind-cast.
  */
 export function useUpdatePhotoMetadataMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ photoId, updates }: { photoId: string; updates: MetadataUpdateFields }) => {
-      const response = await fetchClient.patch(`/photos/${photoId}/metadata`, updates);
-      return response as PhotoMetadata;
-    },
+    mutationFn: ({ photoId, updates }: { photoId: string; updates: MetadataUpdateFields }) =>
+      updatePhotoMetadata(photoId, updates),
     onSuccess: (data, { photoId }) => {
       // Invalidate metadata queries
       queryClient.invalidateQueries({ queryKey: ["photoMetadata", photoId] });
@@ -43,10 +40,7 @@ export function useRevertMetadataEditMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ photoId, editId }: { photoId: string; editId: number }) => {
-      const response = await fetchClient.post(`/photos/${photoId}/metadata/revert/${editId}`);
-      return response as PhotoMetadata;
-    },
+    mutationFn: ({ photoId, editId }: { photoId: string; editId: string }) => revertMetadataEdit(photoId, editId),
     onSuccess: (data, { photoId }) => {
       queryClient.invalidateQueries({ queryKey: ["photoMetadata", photoId] });
       queryClient.invalidateQueries({ queryKey: ["metadataHistory", photoId] });
@@ -62,10 +56,7 @@ export function useRevertAllMetadataEditsMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (photoId: string) => {
-      const response = await fetchClient.post(`/photos/${photoId}/metadata/revert-all`);
-      return response as PhotoMetadata;
-    },
+    mutationFn: (photoId: string) => revertAllMetadataEdits(photoId),
     onSuccess: (data, photoId) => {
       queryClient.invalidateQueries({ queryKey: ["photoMetadata", photoId] });
       queryClient.invalidateQueries({ queryKey: ["metadataHistory", photoId] });
@@ -81,13 +72,8 @@ export function useBulkUpdateMetadataMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ photoIds, updates }: { photoIds: string[]; updates: MetadataUpdateFields }) => {
-      const response = await fetchClient.patch("/photos/metadata/bulk", {
-        photo_ids: photoIds,
-        updates,
-      });
-      return response as { updated_count: number; message: string };
-    },
+    mutationFn: ({ photoIds, updates }: { photoIds: string[]; updates: MetadataUpdateFields }) =>
+      bulkUpdateMetadata(photoIds, updates),
     onSuccess: (data, { photoIds }) => {
       // Invalidate all affected photo metadata queries
       photoIds.forEach(photoId => {

--- a/apps/frontend/src/api_client/photos/metadata.ts
+++ b/apps/frontend/src/api_client/photos/metadata.ts
@@ -70,9 +70,9 @@ export async function fetchMetadataHistory(photoId: string, page = 1, pageSize =
 /**
  * Revert a specific metadata edit
  * @param photoId Photo UUID or image_hash
- * @param editId The ID of the edit to revert
+ * @param editId The UUID of the edit to revert
  */
-export async function revertMetadataEdit(photoId: string, editId: number): Promise<PhotoMetadata> {
+export async function revertMetadataEdit(photoId: string, editId: string): Promise<PhotoMetadata> {
   const response = await fetchClient.post(`/photos/${photoId}/metadata/revert/${editId}`);
   return parseWithNotification(PhotoMetadata, response, "Failed to parse reverted photo metadata");
 }

--- a/apps/frontend/src/api_client/photos/types.test.ts
+++ b/apps/frontend/src/api_client/photos/types.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { MetadataHistoryResponse, PhotoMetadata } from "./types";
+
+/**
+ * Regression coverage for the PhotoMetadata zod schema drifting from the
+ * backend serializer.
+ *
+ * `PhotoMetadataSerializer` (api/serializers/photo_metadata.py) serializes the
+ * `PhotoMetadata` model, whose primary key is a `UUIDField` — so `id` is a UUID
+ * string, not a number. The serializer also never emits `photo_id` (the photo is
+ * addressed by the URL), nor `has_edits` (that field only exists on
+ * `PhotoMetadataSummarySerializer`).
+ *
+ * The mismatch was masked because `useFetchPhotoMetadataQuery` cast the response
+ * instead of parsing it, while `fetchPhotoMetadata` in metadata.ts parses. Both
+ * paths now parse, so the schema has to match what the backend really sends.
+ */
+
+// A fully-populated response, as PhotoMetadataSerializer emits it.
+const fullMetadata = {
+  id: "3f2a9c1e-8b7d-4e5f-9a01-2b3c4d5e6f70",
+  // Capture settings
+  aperture: 2.8,
+  shutter_speed: "1/250",
+  shutter_speed_seconds: 0.004,
+  iso: 400,
+  focal_length: 35.0,
+  focal_length_35mm: 52,
+  exposure_compensation: -0.33,
+  flash_fired: false,
+  metering_mode: "Multi-segment",
+  white_balance: "Auto",
+  // Camera/lens info
+  camera_make: "FUJIFILM",
+  camera_model: "X-T4",
+  lens_make: "FUJIFILM",
+  lens_model: "XF35mmF1.4 R",
+  serial_number: null,
+  camera_display: "FUJIFILM X-T4",
+  lens_display: "FUJIFILM XF35mmF1.4 R",
+  // Image properties
+  width: 6240,
+  height: 4160,
+  orientation: 1,
+  color_space: "sRGB",
+  bit_depth: 14,
+  resolution: "6240x4160",
+  megapixels: 26.0,
+  // Timestamps
+  date_taken: "2024-03-15T14:23:11Z",
+  date_taken_subsec: "123",
+  date_modified: "2024-03-15T14:25:02Z",
+  timezone_offset: "+01:00",
+  // Location
+  gps_latitude: 48.137154,
+  gps_longitude: 11.576124,
+  gps_altitude: 519.0,
+  location_country: "Germany",
+  location_state: "Bavaria",
+  location_city: "Munich",
+  location_address: "Marienplatz 1, 80331 Munich",
+  has_location: true,
+  // Content
+  title: "Marienplatz at dusk",
+  caption: null,
+  keywords: ["architecture", "munich"],
+  rating: 4,
+  copyright: null,
+  creator: null,
+  // Tracking
+  source: "embedded",
+  version: 3,
+  created_at: "2024-03-16T09:00:00Z",
+  updated_at: "2024-03-18T11:42:17Z",
+  // Related
+  edit_history: [
+    {
+      id: "b1d4e7a2-5c36-4f88-9e10-7a2b3c4d5e6f",
+      field_name: "title",
+      old_value: null,
+      new_value: "Marienplatz at dusk",
+      user: 1,
+      user_name: "derneuere",
+      synced_to_file: false,
+      synced_at: null,
+      created_at: "2024-03-18T11:42:17Z",
+    },
+  ],
+  sidecar_files: [
+    {
+      id: "c9e8f7a6-1b2c-4d3e-8f90-a1b2c3d4e5f6",
+      file_type: "xmp",
+      source: "software",
+      priority: 10,
+      creator_software: "darktable",
+      created_at: "2024-03-16T09:00:00Z",
+      updated_at: "2024-03-16T09:00:00Z",
+    },
+  ],
+};
+
+// What the view returns for a photo that has never been scanned: the viewset's
+// `_get_or_create_metadata` creates a near-empty row on the fly.
+const freshMetadata = {
+  ...fullMetadata,
+  aperture: null,
+  shutter_speed: null,
+  shutter_speed_seconds: null,
+  iso: null,
+  focal_length: null,
+  focal_length_35mm: null,
+  exposure_compensation: null,
+  flash_fired: null,
+  metering_mode: null,
+  white_balance: null,
+  camera_make: null,
+  camera_model: null,
+  lens_make: null,
+  lens_model: null,
+  camera_display: null,
+  lens_display: null,
+  width: null,
+  height: null,
+  bit_depth: null,
+  resolution: null,
+  megapixels: null,
+  date_taken: null,
+  date_taken_subsec: null,
+  date_modified: null,
+  timezone_offset: null,
+  gps_latitude: null,
+  gps_longitude: null,
+  gps_altitude: null,
+  has_location: false,
+  title: null,
+  // keywords is a nullable JSONField, so an unpopulated row sends null (not [])
+  keywords: null,
+  rating: null,
+  version: 1,
+  edit_history: [],
+  sidecar_files: [],
+};
+
+describe("PhotoMetadata schema vs. PhotoMetadataSerializer", () => {
+  test("documents the symptom: the pre-fix id/photo_id declaration rejects the real payload", () => {
+    // The schema used to declare `id: z.number()` and `photo_id: z.string().uuid()`.
+    const preFix = z.object({ id: z.number(), photo_id: z.string().uuid() });
+
+    const result = preFix.safeParse(fullMetadata);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map(i => i.path.join("."));
+      // "Expected number, received string" at id; "Required" at photo_id.
+      expect(paths).toEqual(expect.arrayContaining(["id", "photo_id"]));
+    }
+  });
+
+  test("accepts the payload the serializer actually returns", () => {
+    expect(() => PhotoMetadata.parse(fullMetadata)).not.toThrow();
+
+    const parsed = PhotoMetadata.parse(fullMetadata);
+    expect(parsed.id).toBe("3f2a9c1e-8b7d-4e5f-9a01-2b3c4d5e6f70");
+    expect(parsed.camera_display).toBe("FUJIFILM X-T4");
+    expect(parsed.keywords).toEqual(["architecture", "munich"]);
+  });
+
+  test("accepts the near-empty row the viewset creates for an unscanned photo", () => {
+    expect(() => PhotoMetadata.parse(freshMetadata)).not.toThrow();
+    expect(PhotoMetadata.parse(freshMetadata).keywords).toBeNull();
+  });
+
+  test("parses nested edit_history and sidecar_files, both keyed by UUID", () => {
+    const parsed = PhotoMetadata.parse(fullMetadata);
+
+    expect(parsed.edit_history).toHaveLength(1);
+    expect(parsed.edit_history[0].id).toBe("b1d4e7a2-5c36-4f88-9e10-7a2b3c4d5e6f");
+    expect(parsed.edit_history[0].user_name).toBe("derneuere");
+    expect(parsed.edit_history[0].synced_at).toBeNull();
+
+    expect(parsed.sidecar_files).toHaveLength(1);
+    expect(parsed.sidecar_files[0].id).toBe("c9e8f7a6-1b2c-4d3e-8f90-a1b2c3d4e5f6");
+    expect(parsed.sidecar_files[0].file_type).toBe("xmp");
+    expect(parsed.sidecar_files[0].source).toBe("software");
+  });
+
+  test("rejects a numeric id, so the schema cannot silently drift back", () => {
+    expect(PhotoMetadata.safeParse({ ...fullMetadata, id: 42 }).success).toBe(false);
+  });
+
+  test("does not carry has_edits — only the summary serializer has that flag", () => {
+    // If the backend ever sent it, zod would strip it rather than expose it.
+    const parsed = PhotoMetadata.parse({ ...fullMetadata, has_edits: true });
+    expect(parsed).not.toHaveProperty("has_edits");
+  });
+});
+
+describe("MetadataHistoryResponse schema", () => {
+  test("accepts the paginated envelope the history endpoint returns", () => {
+    const payload = {
+      results: fullMetadata.edit_history,
+      count: 1,
+      page: 1,
+      page_size: 20,
+    };
+
+    expect(() => MetadataHistoryResponse.parse(payload)).not.toThrow();
+    expect(MetadataHistoryResponse.parse(payload).results[0].field_name).toBe("title");
+  });
+});

--- a/apps/frontend/src/api_client/photos/types.ts
+++ b/apps/frontend/src/api_client/photos/types.ts
@@ -216,79 +216,105 @@ export const Photo = z.object({
 });
 export type Photo = z.infer<typeof Photo>;
 
-// Metadata edit history entry
+// Metadata edit history entry — mirrors MetadataEditSerializer.
+// `id` is a UUID string: MetadataEdit uses a UUIDField primary key.
 export const MetadataEdit = z.object({
-  id: z.number(),
+  id: z.string().uuid(),
   field_name: z.string(),
   old_value: z.any(),
   new_value: z.any(),
-  created_at: z.string(),
+  user: z.number(),
   user_name: z.string(),
+  synced_to_file: z.boolean(),
+  synced_at: z.string().nullable(),
+  created_at: z.string(),
 });
 export type MetadataEdit = z.infer<typeof MetadataEdit>;
 
-// XMP sidecar file info
+export const MetadataFileTypeEnum = z.enum(["xmp", "json", "exif", "other"]);
+export type MetadataFileTypeEnum = z.infer<typeof MetadataFileTypeEnum>;
+
+export const MetadataFileSourceEnum = z.enum(["original", "software", "librephotos", "user"]);
+export type MetadataFileSourceEnum = z.infer<typeof MetadataFileSourceEnum>;
+
+// XMP sidecar file info — mirrors MetadataFileSerializer.
+// `id` is a UUID string: MetadataFile uses a UUIDField primary key.
 export const MetadataFile = z.object({
-  id: z.number(),
-  file_path: z.string(),
-  file_type: z.string(),
-  last_modified: z.string(),
-  last_synced: z.string().nullable(),
+  id: z.string().uuid(),
+  file_type: MetadataFileTypeEnum,
+  source: MetadataFileSourceEnum,
+  priority: z.number(),
+  creator_software: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
 });
 export type MetadataFile = z.infer<typeof MetadataFile>;
 
 // Full metadata response from /api/photos/{id}/metadata/
+//
+// Mirrors PhotoMetadataSerializer.Meta.fields exactly — keep the two in sync.
+// Notably the serializer does NOT emit `photo_id` (the photo is addressed by the
+// URL), nor `has_edits` (that lives only on PhotoMetadataSummarySerializer);
+// use `edit_history` to tell whether a photo has been edited.
 export const PhotoMetadata = z.object({
-  id: z.number(),
-  photo_id: z.string().uuid(),
-  // Camera info
-  camera_make: z.string().nullable(),
-  camera_model: z.string().nullable(),
-  camera_display: z.string().nullable(),
-  lens_make: z.string().nullable(),
-  lens_model: z.string().nullable(),
-  lens_display: z.string().nullable(),
+  // PhotoMetadata uses a UUIDField primary key, so this is a string.
+  id: z.string().uuid(),
   // Capture settings
   aperture: z.number().nullable(),
   shutter_speed: z.string().nullable(),
+  shutter_speed_seconds: z.number().nullable(),
   iso: z.number().nullable(),
   focal_length: z.number().nullable(),
   focal_length_35mm: z.number().nullable(),
   exposure_compensation: z.number().nullable(),
+  flash_fired: z.boolean().nullable(),
   metering_mode: z.string().nullable(),
-  flash: z.string().nullable(),
   white_balance: z.string().nullable(),
+  // Camera/lens info
+  camera_make: z.string().nullable(),
+  camera_model: z.string().nullable(),
+  lens_make: z.string().nullable(),
+  lens_model: z.string().nullable(),
+  serial_number: z.string().nullable(),
+  camera_display: z.string().nullable(),
+  lens_display: z.string().nullable(),
   // Image properties
   width: z.number().nullable(),
   height: z.number().nullable(),
-  resolution: z.string().nullable(),
-  megapixels: z.number().nullable(),
   orientation: z.number().nullable(),
   color_space: z.string().nullable(),
-  // Date/time
+  bit_depth: z.number().nullable(),
+  resolution: z.string().nullable(),
+  megapixels: z.number().nullable(),
+  // Timestamps
   date_taken: z.string().nullable(),
-  date_digitized: z.string().nullable(),
-  timezone: z.string().nullable(),
-  // GPS
+  date_taken_subsec: z.string().nullable(),
+  date_modified: z.string().nullable(),
+  timezone_offset: z.string().nullable(),
+  // Location
   gps_latitude: z.number().nullable(),
   gps_longitude: z.number().nullable(),
   gps_altitude: z.number().nullable(),
+  location_country: z.string().nullable(),
+  location_state: z.string().nullable(),
+  location_city: z.string().nullable(),
+  location_address: z.string().nullable(),
   has_location: z.boolean(),
   // Content
   title: z.string().nullable(),
   caption: z.string().nullable(),
-  keywords: z.string().array(),
+  // keywords is a nullable JSONField holding a list of strings
+  keywords: z.string().array().nullable(),
   rating: z.number().nullable(),
-  // Copyright
   copyright: z.string().nullable(),
   creator: z.string().nullable(),
   // Tracking
   source: MetadataSourceEnum,
   version: z.number(),
-  has_edits: z.boolean(),
   created_at: z.string(),
   updated_at: z.string(),
   // Related
+  edit_history: MetadataEdit.array(),
   sidecar_files: MetadataFile.array(),
 });
 export type PhotoMetadata = z.infer<typeof PhotoMetadata>;

--- a/apps/frontend/src/components/lightbox/MetadataSection.tsx
+++ b/apps/frontend/src/components/lightbox/MetadataSection.tsx
@@ -297,9 +297,13 @@ export function MetadataSection({ photoDetail, isPublic = false }: MetadataSecti
   // Fetch full metadata (optional - enhances display if available)
   const { data: fullMetadata } = useFetchPhotoMetadataQuery(photoDetail.id, { enabled: !isPublic });
 
+  // The full metadata serializer has no `has_edits` flag (that lives on the
+  // summary); it ships the recent edits themselves, so derive it from those.
+  const fullMetadataHasEdits = (fullMetadata?.edit_history?.length ?? 0) > 0;
+
   // Fetch edit history (only if metadata exists and has edits)
   const { data: historyData } = useFetchMetadataHistoryQuery(photoDetail.id, 1, 10, {
-    enabled: !isPublic && !!fullMetadata?.has_edits,
+    enabled: !isPublic && fullMetadataHasEdits,
   });
 
   // Mutations for reverting edits
@@ -310,7 +314,7 @@ export function MetadataSection({ photoDetail, isPublic = false }: MetadataSecti
   const summaryMetadata = photoDetail.metadata;
 
   // Check if there are any user edits
-  const hasEdits = summaryMetadata?.has_edits || fullMetadata?.has_edits;
+  const hasEdits = summaryMetadata?.has_edits || fullMetadataHasEdits;
   const editCount = historyData?.count || 0;
 
   return (


### PR DESCRIPTION
## Problem

The frontend `PhotoMetadata` zod schema described a response the backend never sends.

`PhotoMetadata`, `MetadataFile` and `MetadataEdit` all use `UUIDField` primary keys, so `id` is a UUID string, not a number. And `PhotoMetadataSerializer` emits neither `photo_id` (the photo is addressed by the URL) nor `has_edits` — that flag only exists on `PhotoMetadataSummarySerializer`.

Beyond those, comparing `apps/frontend/src/api_client/photos/types.ts` against `PhotoMetadataSerializer.Meta.fields`:

- Three declared fields don't exist on the model at all: `flash`, `date_digitized`, `timezone`. The real fields are `flash_fired` (boolean, not string), `date_taken_subsec`, `date_modified`, `timezone_offset`.
- Ten emitted fields were missing entirely: `shutter_speed_seconds`, `serial_number`, `bit_depth`, `location_country`, `location_state`, `location_city`, `location_address`, and `edit_history`.
- `keywords` is a nullable `JSONField`, but was declared non-nullable — an unscanned photo gets `null`.

`MetadataFile` was wrong end to end: it declared `file_path` / `last_modified` / `last_synced`, none of which `MetadataFileSerializer` emits. It's nested under `sidecar_files`, so it had to be corrected for `PhotoMetadata` to parse at all. Same for `MetadataEdit`, which `edit_history` needs.

## Why it went unnoticed

`useFetchPhotoMetadataQuery` **cast** the response, while `fetchPhotoMetadata()` in `metadata.ts` **parses** it. Only the validating path ever raised, and it isn't the one the lightbox uses.

A second symptom fell out of this: `MetadataSection` gated its edit-history panel on `fullMetadata?.has_edits`, which was **always `undefined`** because the full serializer has no such field. The panel never auto-enabled from full metadata. It now derives that from `edit_history`.

## Changes

- Rewrote `PhotoMetadata`, `MetadataFile` and `MetadataEdit` to mirror their serializers field for field, with `MetadataFileTypeEnum` / `MetadataFileSourceEnum` for the two `TextChoices` sets.
- Made both call sites consistent: the metadata query, the history query and the three metadata mutations now delegate to the `api_client` functions in `metadata.ts`, which parse. No blind casts left on these paths.
- Revert edit ids are UUID strings rather than numbers (`revertMetadataEdit`, `useRevertMetadataEditMutation`).
- Added `types.test.ts` with realistic serializer payloads: a fully populated row, the near-empty row `_get_or_create_metadata` creates for an unscanned photo, nested `edit_history` / `sidecar_files`, and the paginated history envelope.

## Verification

Node 20.20.2:

```
cd apps/frontend && npx eslint --quiet "src/**/*.{js,jsx,ts,tsx}" && npx vitest --watch=false && npx vite build
```

- eslint: clean
- vitest: 38 passed (7 new)
- vite build: ✓

Also ran a differential `tsc --noEmit` against the base, since the tree carries pre-existing type errors: **668 before, 668 after, identical set** modulo line numbers. No new type errors.

### Note for reviewers

`MetadataSection.tsx` carries 4 of those pre-existing `tsc` errors, including a duplicate `getTimeAgo` implementation at lines 69 and 129. Left untouched here to keep the diff scoped, but worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
