### PR TITLE
docs: rewrite stale frontend contribution page

### DIFF
--- a/apps/docs/docs/development/contribution/frontend/index.md
+++ b/apps/docs/docs/development/contribution/frontend/index.md
@@ -1,60 +1,71 @@
 ---
 title: "👨‍💻 Frontend"
 excerpt: "Development Information regarding LibrePhotos Frontend."
-last_modified_at: 2021-05-31
+last_modified_at: 2026-07-22
 category: 5
 ---
 
-We developed our frontend with the following technologies:
+The frontend is a [React 18](https://react.dev/) single-page app, written in TypeScript and built
+with [Vite](https://vite.dev/). [Mantine](https://mantine.dev/) provides the UI components,
+[TanStack Router](https://tanstack.com/router) handles routing, and
+[TanStack Query](https://tanstack.com/query) handles server state.
 
-- React
-- Mantine
-- Redux / Redux Toolkit
-- Axios
+The full tech stack, the development commands (`yarn start`, `yarn test`, `yarn build`) and the code
+style conventions are documented in
+[apps/frontend/README.md](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/README.md),
+which lives next to the code. Please read that first — this page only covers what it does not:
+debugging, and how the source tree is laid out.
 
 ## ✨ Code Standards
 
-We also have here some git hooks. Please do a npm prepare and then the formatter and the linter are good to go. We use eslint and prettier to keep our code tidy
+We use ESLint and Prettier to keep our code tidy. Running `yarn install` also installs the git hooks
+(the `prepare` script runs `husky install`), so staged files are formatted and linted on every
+commit — there is no extra setup step.
 
 ## 🐛 Debugging
 
 ### React Debug Tool
 
-React provides a debug tool, which you can download [here](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=de)
-
-### Redux Debug Tool
-
-Redux also provides a debug tool, to debug the actions and states [here](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=de)
+React provides a debug tool, which you can download
+[here](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).
 
 ### WDYR
 
-[WDYR](https://github.com/welldone-software/why-did-you-render) explains to you why a component re-rendered. To activate it, add WDYR=True to your development .env. For more detail, look up the docs.
+[WDYR](https://github.com/welldone-software/why-did-you-render) explains to you why a component
+re-rendered. To activate it, set `VITE_APP_WDYR=true` in your `.env.development` — it has to be the
+literal string `true`. It is wired up in
+[src/wdyr.ts](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/src/wdyr.ts) and only
+runs in development builds.
 
 ### REST API
 
-Our Rest API is documented with [Swagger](https://swagger.io/) and [ReDoc](https://redocly.github.io/redoc/). After you
-start up LibrePhotos, you can find them under:
-
-```
-localhost:3000/api/swagger
-```
-
-```
-localhost:3000/api/redoc
-```
-
-Some APIs are not yet well documented, as the generation of the swagger API throws error [Link](https://github.com/LibrePhotos/librephotos/issues/485)
+Our REST API is documented with [Swagger](https://swagger.io/) and
+[ReDoc](https://redocly.github.io/redoc/). Once your development stack is up, both are served from
+the running instance — see [Development Installation](/docs/development/dev-install) for the URLs.
 
 ## 🏙️ Structure
 
-- You can find all the routes in [App.js](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/src/App.js).
-- The pages are in [layouts](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/layouts)
-- Pages should be split up into React Components, which you can find in
-  [components](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/components)
-- The API calls are made into split into actions, which you can find in
-  [actions](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/actions)
-- To handle the state for the whole page, we use Redux. You can find the states and reducers in
-  [reducers](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/reducers)
-- [api_client](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/api_client) is just a simple Axios
-  client
-- In [util](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/util) you can find miscellaneous functions.
+Everything below is relative to
+[apps/frontend/src](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src).
+
+- [routes](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/routes) holds the
+  pages. Routing is file-based: the path of a file determines its URL. Routes under `_protected`
+  require a logged-in user, routes under `public` do not, and `__root.tsx` is the shell they all
+  render into. `routeTree.gen.ts` is generated from this folder by the TanStack Router plugin —
+  never edit it by hand.
+- Pages should be split up into React components, which you can find in
+  [components](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/components),
+  grouped by feature.
+- [api_client](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/api_client)
+  is the API layer. `api.ts` defines `FetchClient`, a small wrapper around `fetch` that attaches the
+  access token and transparently refreshes it on a 401. Around it, one folder per domain (`photos`,
+  `albums`, `faces`, …) exports the TanStack Query hooks the components actually call, named
+  `useFetch…Query` and `use…Mutation`.
+- [hooks](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/hooks) and
+  [service](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/service) contain
+  cross-cutting hooks and helpers, such as authentication and notifications.
+- [locales](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/locales) holds the
+  translations, set up in `i18n.ts`. Translations are contributed through
+  [Weblate](https://hosted.weblate.org/engage/librephotos/) rather than edited directly.
+- In [util](https://github.com/LibrePhotos/librephotos/tree/dev/apps/frontend/src/util) you can find
+  miscellaneous functions.


### PR DESCRIPTION
The frontend contribution page still described a Redux/Axios architecture the frontend has not had for some time. It carried `last_modified_at: 2021-05-31`.

## Corrected

- **Stack** was listed as "React, Mantine, Redux / Redux Toolkit, Axios". Neither `redux`, `react-redux`, `@reduxjs/toolkit` nor `axios` is a dependency of `apps/frontend/package.json`. It is React 18 + TypeScript on Vite, with TanStack Router, TanStack Query and Mantine 8.
- **Structure** linked `src/App.js`, `src/actions`, `src/reducers` and `src/layouts` — none of which exist. Routing is file-based under `src/routes` (`_protected` vs `public`, plus the generated `routeTree.gen.ts`), components are grouped by feature, and `api_client` holds the `FetchClient` class with auth/refresh-token handling plus per-domain TanStack Query hooks — not "just a simple Axios client".
- **Git hooks** said to "do a npm prepare". The repo is yarn-based, and `yarn install` already runs `prepare` (`husky install`), so there is no separate step.
- **WDYR** said to set `WDYR=True`. `src/wdyr.ts` reads `VITE_APP_WDYR` and compares against the literal string `"true"` — which now matches the `.env.development.example` shipped in #1922.

## Trimmed rather than restated

`apps/frontend/README.md` is accurate, current, and sits next to the code. Restating it here is how this page drifted in the first place, so the page now links to it for the stack, commands and style conventions, and keeps only what the README does not cover: debugging and source layout.

Two sections were dropped rather than fixed:

- **Redux DevTools** — there is no redux, and no TanStack devtools package is installed to replace it, so nothing was invented in its place.
- **Swagger/ReDoc URLs** — already documented on the [Development Installation](https://docs.librephotos.com/docs/development/dev-install) page, which the section now links to. The endpoints themselves are still live, so the section stayed.

Also dropped the "some APIs are not yet well documented" caveat citing #485. It predates the backend's move to drf-spectacular and I could not verify it still holds; happy to restore it if it does.

## Verification

Docs-only, no code touched. Every repo path the page links to was confirmed to exist, and the internal `/docs/development/dev-install` link follows the same form as the existing cross-links that CI already builds (default `docs` route base, no `routeBasePath` override). I did not run `yarn build` in `apps/docs` locally — `node_modules` was absent — so the Docusaurus build in CI is the real check here, given `onBrokenLinks: "throw"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
