### PR TITLE
feat(backend): healthcheck endpoints for k8s probes

### DIFF
--- a/apps/backend/api/tests/test_healthz.py
+++ b/apps/backend/api/tests/test_healthz.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from django.db.utils import OperationalError
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class HealthzTest(TestCase):
+    """Every probe has to answer without credentials - that is the whole point,
+    so no call in here is authenticated."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_liveness_should_be_reachable_unauthenticated(self):
+        response = self.client.get("/api/healthz")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", response.json()["status"])
+
+    def test_liveness_should_accept_a_trailing_slash(self):
+        response = self.client.get("/api/healthz/")
+        self.assertEqual(200, response.status_code)
+
+    def test_liveness_should_not_query_the_database(self):
+        with self.assertNumQueries(0):
+            response = self.client.get("/api/healthz")
+        self.assertEqual(200, response.status_code)
+
+    def test_liveness_should_stay_up_when_the_database_is_down(self):
+        with patch("api.views.health.connections") as connections:
+            connections.__getitem__.return_value.cursor.side_effect = OperationalError(
+                "connection refused"
+            )
+            response = self.client.get("/api/healthz")
+        self.assertEqual(200, response.status_code)
+
+    def test_postgresql_should_be_reachable_unauthenticated(self):
+        response = self.client.get("/api/healthz/postgresql")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", response.json()["status"])
+
+    def test_postgresql_should_fail_when_the_database_is_down(self):
+        with patch("api.views.health.connections") as connections:
+            connections.__getitem__.return_value.cursor.side_effect = OperationalError(
+                "connection refused"
+            )
+            response = self.client.get("/api/healthz/postgresql")
+        self.assertEqual(503, response.status_code)
+        self.assertEqual("error", response.json()["status"])
+
+    def test_postgresql_should_not_leak_the_underlying_error(self):
+        with patch("api.views.health.connections") as connections:
+            connections.__getitem__.return_value.cursor.side_effect = OperationalError(
+                'connection to server at "db", user "docker" failed'
+            )
+            response = self.client.get("/api/healthz/postgresql")
+        self.assertNotIn("docker", response.json()["error"])
+
+    def test_queue_should_be_reachable_unauthenticated(self):
+        response = self.client.get("/api/healthz/queue")
+        data = response.json()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", data["status"])
+        self.assertEqual(0, data["queued"])
+
+    def test_queue_should_fail_when_the_broker_is_unreachable(self):
+        with patch(
+            "api.views.health.get_broker",
+            side_effect=OperationalError("no such table: django_q_ormq"),
+        ):
+            response = self.client.get("/api/healthz/queue")
+        self.assertEqual(503, response.status_code)
+        self.assertEqual("error", response.json()["status"])
+
+    def test_ready_should_be_reachable_unauthenticated(self):
+        response = self.client.get("/api/healthz/ready")
+        data = response.json()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", data["status"])
+        self.assertEqual("ok", data["checks"]["postgresql"]["status"])
+        self.assertEqual("ok", data["checks"]["queue"]["status"])
+
+    def test_ready_should_fail_when_the_database_is_down(self):
+        with patch("api.views.health.connections") as connections:
+            connections.__getitem__.return_value.cursor.side_effect = OperationalError(
+                "connection refused"
+            )
+            response = self.client.get("/api/healthz/ready")
+        data = response.json()
+        self.assertEqual(503, response.status_code)
+        self.assertEqual("error", data["status"])
+        self.assertEqual("error", data["checks"]["postgresql"]["status"])
+
+    def test_ready_should_fail_when_the_broker_is_unreachable(self):
+        with patch(
+            "api.views.health.get_broker",
+            side_effect=OperationalError("no such table: django_q_ormq"),
+        ):
+            response = self.client.get("/api/healthz/ready")
+        data = response.json()
+        self.assertEqual(503, response.status_code)
+        self.assertEqual("error", data["status"])
+        self.assertEqual("ok", data["checks"]["postgresql"]["status"])
+        self.assertEqual("error", data["checks"]["queue"]["status"])

--- a/apps/backend/api/tests/test_healthz.py
+++ b/apps/backend/api/tests/test_healthz.py
@@ -27,10 +27,13 @@ class HealthzTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_liveness_should_stay_up_when_the_database_is_down(self):
-        with patch("api.views.health.connections") as connections:
-            connections.__getitem__.return_value.cursor.side_effect = OperationalError(
-                "connection refused"
-            )
+        # Patched on the backend rather than on the view's own import of
+        # connections, so that every route to the database raises, the ORM
+        # included.
+        with patch(
+            "django.db.backends.base.base.BaseDatabaseWrapper.ensure_connection",
+            side_effect=OperationalError("connection refused"),
+        ):
             response = self.client.get("/api/healthz")
         self.assertEqual(200, response.status_code)
 
@@ -61,7 +64,10 @@ class HealthzTest(TestCase):
         data = response.json()
         self.assertEqual(200, response.status_code)
         self.assertEqual("ok", data["status"])
-        self.assertEqual(0, data["queued"])
+
+    def test_queue_should_not_report_the_backlog_depth(self):
+        response = self.client.get("/api/healthz/queue")
+        self.assertNotIn("queued", response.json())
 
     def test_queue_should_fail_when_the_broker_is_unreachable(self):
         with patch(

--- a/apps/backend/api/views/health.py
+++ b/apps/backend/api/views/health.py
@@ -1,0 +1,84 @@
+from django.db import connections
+from django_q.brokers import get_broker
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.util import logger
+
+
+def _check_postgresql():
+    """Round-trip the cheapest possible statement to prove the database answers."""
+    try:
+        with connections["default"].cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+    except Exception as e:
+        logger.warning("Healthcheck: database unreachable: %s", e)
+        return {"status": "error", "error": "database unreachable"}
+    return {"status": "ok"}
+
+
+def _check_queue():
+    """Count the queued tasks. django-q2 keeps its queue in the database (ORM broker),
+    so this covers both the broker configuration and the django_q tables."""
+    try:
+        queued = get_broker().queue_size()
+    except Exception as e:
+        logger.warning("Healthcheck: queue broker unreachable: %s", e)
+        return {"status": "error", "error": "queue broker unreachable"}
+    return {"status": "ok", "queued": queued}
+
+
+def _http_status(*results):
+    if all(result["status"] == "ok" for result in results):
+        return status.HTTP_200_OK
+    return status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+class HealthCheckView(APIView):
+    """Probes are called by kubelet and by the container healthchecks, which never
+    carry credentials - so authentication is switched off rather than merely
+    optional, to keep a stray Authorization header from hitting the database."""
+
+    authentication_classes = ()
+    permission_classes = (AllowAny,)
+
+
+class HealthzView(HealthCheckView):
+    """Liveness. 200 as long as the process can serve a request. Deliberately does
+    not touch the database: a database outage must not get the pod killed."""
+
+    def get(self, request, format=None):
+        return Response({"status": "ok"})
+
+
+class HealthzPostgresqlView(HealthCheckView):
+    def get(self, request, format=None):
+        result = _check_postgresql()
+        return Response(result, status=_http_status(result))
+
+
+class HealthzQueueView(HealthCheckView):
+    def get(self, request, format=None):
+        result = _check_queue()
+        return Response(result, status=_http_status(result))
+
+
+class HealthzReadyView(HealthCheckView):
+    """Readiness. 200 only once every dependency answers."""
+
+    def get(self, request, format=None):
+        checks = {
+            "postgresql": _check_postgresql(),
+            "queue": _check_queue(),
+        }
+        http_status = _http_status(*checks.values())
+        return Response(
+            {
+                "status": "ok" if http_status == status.HTTP_200_OK else "error",
+                "checks": checks,
+            },
+            status=http_status,
+        )

--- a/apps/backend/api/views/health.py
+++ b/apps/backend/api/views/health.py
@@ -22,13 +22,15 @@ def _check_postgresql():
 
 def _check_queue():
     """Count the queued tasks. django-q2 keeps its queue in the database (ORM broker),
-    so this covers both the broker configuration and the django_q tables."""
+    so this covers both the broker configuration and the django_q tables. The count
+    itself stays out of the response: these endpoints are unauthenticated, and a
+    backlog rising and falling tells a bystander when a scan is running."""
     try:
-        queued = get_broker().queue_size()
+        get_broker().queue_size()
     except Exception as e:
         logger.warning("Healthcheck: queue broker unreachable: %s", e)
         return {"status": "error", "error": "queue broker unreachable"}
-    return {"status": "ok", "queued": queued}
+    return {"status": "ok"}
 
 
 def _http_status(*results):

--- a/apps/backend/librephotos/urls.py
+++ b/apps/backend/librephotos/urls.py
@@ -42,6 +42,7 @@ from api.views import (
     email_config,
     faces,
     geocode,
+    health,
     jobs,
     password_reset,
     photo_metadata,
@@ -216,6 +217,13 @@ router.register(r"api/services", services.ServiceViewSet, basename="service")
 
 urlpatterns = [
     re_path(r"^", include(router.urls)),
+    # Health probes - unauthenticated, and under /api/ because the proxy only
+    # forwards ^/(api|media)/ to the backend. Must stay ahead of the
+    # SERVE_FRONTEND catch-all at the bottom of this file.
+    re_path(r"^api/healthz/postgresql/?$", health.HealthzPostgresqlView.as_view()),
+    re_path(r"^api/healthz/queue/?$", health.HealthzQueueView.as_view()),
+    re_path(r"^api/healthz/ready/?$", health.HealthzReadyView.as_view()),
+    re_path(r"^api/healthz/?$", health.HealthzView.as_view()),
     re_path(r"^api/django-admin/", admin.site.urls),
     re_path(r"^api/sitesettings", views.SiteSettingsView.as_view()),
     re_path(r"^api/email-config/test/?$", email_config.EmailTestView.as_view()),

--- a/deploy/compose/docker-compose.e2e.yml
+++ b/deploy/compose/docker-compose.e2e.yml
@@ -112,7 +112,7 @@ services:
       - ALLOW_UPLOAD=${allowUpload:-true}
       - DEBUG=1
     healthcheck:
-      test: curl -sI localhost:8001 | grep HTTP | grep 401
+      test: curl -fsS localhost:8001/api/healthz
       interval: 5s
       timeout: 5s
       retries: 24

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -33,13 +33,18 @@ The backend exposes four unauthenticated endpoints. They live under `/api/` beca
 
 | Endpoint | Meaning |
 | --- | --- |
-| `/api/healthz` | The process is up. Never touches the database, so a database outage does not get the pod killed. Used as the liveness probe. |
+| `/api/healthz` | The process is up. Never touches the database, so a database outage does not get the pod killed. Used as the startup and liveness probes. |
 | `/api/healthz/postgresql` | PostgreSQL answers a trivial query. |
 | `/api/healthz/queue` | The django-q2 broker is reachable. |
 | `/api/healthz/ready` | Both of the above are healthy. Used as the readiness probe. |
 
 Unhealthy checks answer `503`. Note that the probes in `backend.yaml` override the `Host` header, because kubelet
 otherwise sends the Pod IP, which is not in the backend's `ALLOWED_HOSTS`.
+
+The backend runs migrations and starts its services before it serves anything, so the startup probe allows ten
+minutes for the first request to succeed; raise its `failureThreshold` if your host is slower than that. The
+readiness probe is deliberately slow to give up, because the proxy container that serves the frontend shares the
+backend's Pod: marking the backend NotReady also removes the frontend from the `proxy` Service.
 
 # Upgrading
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -26,6 +26,21 @@ kubectl -nlibrephotos port-forward svc/proxy 55555:80
 ```
 Then open `http://localhost:55555` in your browser and log in as `admin`.
 
+# Health probes
+
+The backend exposes four unauthenticated endpoints. They live under `/api/` because the proxy only forwards
+`/api/` and `/media/` to the backend.
+
+| Endpoint | Meaning |
+| --- | --- |
+| `/api/healthz` | The process is up. Never touches the database, so a database outage does not get the pod killed. Used as the liveness probe. |
+| `/api/healthz/postgresql` | PostgreSQL answers a trivial query. |
+| `/api/healthz/queue` | The django-q2 broker is reachable. |
+| `/api/healthz/ready` | Both of the above are healthy. Used as the readiness probe. |
+
+Unhealthy checks answer `503`. Note that the probes in `backend.yaml` override the `Host` header, because kubelet
+otherwise sends the Pod IP, which is not in the backend's `ALLOWED_HOSTS`.
+
 # Upgrading
 
 Change the values in `kustomization.yaml`, in the `images` section, to point to the latest versions. Then just rerun

--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -29,6 +29,30 @@ spec:
         ports:
         - name: backend
           containerPort: 8001
+        # kubelet sends the pod IP as the Host header, which is not in the
+        # backend's ALLOWED_HOSTS and would be answered with a 400.
+        livenessProbe:
+          httpGet:
+            path: /api/healthz
+            port: backend
+            httpHeaders:
+            - name: Host
+              value: localhost
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /api/healthz/ready
+            port: backend
+            httpHeaders:
+            - name: Host
+              value: localhost
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - name: photos
           mountPath: /data

--- a/deploy/k8s/backend.yaml
+++ b/deploy/k8s/backend.yaml
@@ -31,6 +31,22 @@ spec:
           containerPort: 8001
         # kubelet sends the pod IP as the Host header, which is not in the
         # backend's ALLOWED_HOSTS and would be answered with a 400.
+        #
+        # The entrypoint runs migrations, collectstatic and the service startup
+        # before gunicorn binds, which on a first install or a CPU-limited host
+        # takes minutes. kubelet holds the other two probes off until this one
+        # succeeds, so a slow boot cannot be mistaken for a wedged process and
+        # restarted into a loop.
+        startupProbe:
+          httpGet:
+            path: /api/healthz
+            port: backend
+            httpHeaders:
+            - name: Host
+              value: localhost
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 60
         livenessProbe:
           httpGet:
             path: /api/healthz
@@ -38,10 +54,13 @@ spec:
             httpHeaders:
             - name: Host
               value: localhost
-          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+        # Deliberately slow to give up: the proxy container that serves the
+        # frontend shares this pod, so a NotReady backend also empties the
+        # endpoints of the proxy Service and takes the whole site down instead
+        # of only the API. Ride out a short database outage rather than that.
         readinessProbe:
           httpGet:
             path: /api/healthz/ready
@@ -49,10 +68,9 @@ spec:
             httpHeaders:
             - name: Host
               value: localhost
-          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
-          failureThreshold: 3
+          failureThreshold: 6
         volumeMounts:
         - name: photos
           mountPath: /data


### PR DESCRIPTION
Closes #495

Adds unauthenticated health endpoints so Kubernetes (and the Compose healthchecks) can probe the backend directly.

## Endpoints

| Route | Purpose |
|---|---|
| `GET /api/healthz` | Liveness. 200 while the process can serve a request. **Deliberately does not touch the database** — a DB outage must not get the pod killed. |
| `GET /api/healthz/postgresql` | 200 if `SELECT 1` round-trips, else 503. |
| `GET /api/healthz/queue` | 200 if the django-q2 broker answers, else 503. |
| `GET /api/healthz/ready` | Readiness. 200 only if both dependencies answer; reports per-check detail. |

## Two deviations from the issue text, both deliberate

**No `/healthz/redis`.** There is no Redis in this stack — it was [deprecated in favour of django-q2](https://github.com/LibrePhotos/librephotos/blob/dev/apps/docs/blog/2023-08-01-2023w31.md) in 2023. There is no `CACHES` setting, no redis service in any compose file, and no redis dependency; `Q_CLUSTER` uses `"orm": "default"`, i.e. the Postgres broker. A redis probe would assert nothing, so `/healthz/queue` checks the actual queue backend instead.

**Mounted under `/api/`, not at the root.** The proxy only forwards `^/(api|media)/` to the backend (`deploy/proxy/nginx.conf`), so a bare `/healthz` would hit the *frontend* container. Keeping it under `/api/` means no proxy change is needed. Happy to add a root alias plus an nginx `location` block if you'd rather match the issue literally.

## Also included

- **`deploy/k8s/backend.yaml` had no probes at all** — this was the motivating gap. Added `startupProbe` (10 min budget: the entrypoint runs 132 migrations, `collectstatic` and service startup before gunicorn binds, and `maxSurge: 0` means the old pod is already gone), plus liveness and readiness.
- `docker-compose.e2e.yml` previously proved the backend was up by asserting it got an HTTP response — in practice a `401`. Now it curls `/api/healthz`.

## Trade-off worth your call

Readiness gates the whole pod, and the `proxy` Service selects `app: backend` while the ingress routes `/` at it. So a >60s database outage marks the pod NotReady and takes the SPA offline, not just the API. `failureThreshold` is raised to 6 to blunt this. Pointing readiness at `/api/healthz`, or moving it to the proxy container, would remove it entirely — but that changes the probe semantics the issue asked for, so I left the decision to you. Noted in `deploy/k8s/README.md`.

## Verification

- `ruff check` + `ruff format --check`: clean
- `api.tests.test_healthz` — 13 new tests, all passing; 69 including `test_authz_scoping`, `test_api_robustness`, `test_background_tasks`
- Tests assert the endpoints work **unauthenticated** (that's the point), that liveness issues no queries, and that each dependency check returns 503 when its backend is down
- The liveness test was mutation-checked: making the view touch the ORM makes it fail, so it isn't vacuous
- `deploy/k8s/backend.yaml` and the e2e compose file both re-parsed as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)