### PR TITLE
feat(frontend): offer recently tagged people in the face tagging popup

### DIFF
--- a/apps/frontend/src/__repro__/issue_644.test.tsx
+++ b/apps/frontend/src/__repro__/issue_644.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Repro for https://github.com/LibrePhotos/librephotos/issues/644
+ * "Add recently used people to the face tagging popup"
+ *
+ *   "when tagging faces it's usually the same 4-5 people over and over, but the
+ *    popup only offers the full alphabetical list - you either scroll to the
+ *    name or type it again for every single face."
+ *
+ * src/components/modals/ModalPersonEdit.tsx renders `useFetchPeopleAlbumsQuery()`
+ * straight into one long scrolling Stack ordered by name, so the cost of picking
+ * a person is the same on the hundredth tag as it is on the first.
+ *
+ * The shortcut list has to be fed from the mutation, not from the modal: the
+ * modal is only one of several tagging entry points (the faces dashboard header,
+ * the lightbox sidebar and the person detail row all label faces without ever
+ * opening it), and they all funnel through useSetFacesPersonLabelMutation.
+ *
+ * Faces carry a numeric `person` id while useFetchPeopleAlbumsQuery coerces the
+ * same id to a string, so the MRU has to normalize before it can resolve an
+ * entry back to a person.
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetFacesPersonLabelMutation } from "../api_client/faces/hooks/useSetFacesPersonLabelMutation";
+import { ModalPersonEdit } from "../components/modals/ModalPersonEdit";
+import i18n from "../i18n";
+import {
+  getRecentlyTaggedPeopleIds,
+  RECENTLY_TAGGED_PEOPLE_LIMIT,
+  recordRecentlyTaggedPerson,
+  resolveRecentlyTaggedPeople,
+  withMostRecentlyTagged,
+} from "../util/recentlyTaggedPeople";
+
+const stubs = vi.hoisted(() => ({
+  // Alphabetical, the way the query hands them over. Ids are strings here and
+  // numbers on the faces the API returns.
+  people: [
+    { id: "1", name: "Alice", video: false, face_count: 12, face_photo_url: "/alice", face_url: "/alice" },
+    { id: "2", name: "Bob", video: false, face_count: 8, face_photo_url: "/bob", face_url: "/bob" },
+    { id: "3", name: "Charlie", video: false, face_count: 3, face_photo_url: "/charlie", face_url: "/charlie" },
+  ],
+  setFacesPersonLabel: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("../api_client/apiClient", () => ({ serverAddress: "" }));
+vi.mock("../service/notifications", () => ({ notification: new Proxy({}, { get: () => () => {} }) }));
+vi.mock("../api_client/albums/hooks", () => ({ useFetchPeopleAlbumsQuery: () => ({ data: stubs.people }) }));
+// The barrel the modal imports from - the mutation test below pulls the real
+// hook straight out of its own module instead.
+vi.mock("../api_client/faces", () => ({
+  useSetFacesPersonLabelMutation: () => ({ mutate: stubs.setFacesPersonLabel }),
+}));
+vi.mock("../api_client/api", () => ({
+  fetchClient: { post: stubs.post },
+  queryClient: { invalidateQueries: () => {} },
+}));
+
+beforeAll(async () => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore - jsdom has no ResizeObserver, the modal's ScrollArea needs it
+  globalThis.ResizeObserver = class {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  };
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage("en");
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  stubs.setFacesPersonLabel.mockReset();
+});
+
+/** The modal renders into a portal, so everything below reads from the document. */
+function recentlyTaggedSection(): HTMLElement | null {
+  const heading = Array.from(document.querySelectorAll("h5")).find(h => h.textContent === "Recently tagged");
+  return (heading?.nextElementSibling as HTMLElement | null) ?? null;
+}
+
+function namesOf(root: ParentNode | null): string[] {
+  return Array.from(root?.querySelectorAll("h4") ?? []).map(title => title.textContent ?? "");
+}
+
+/** React tracks the previous value on the node itself, so plain assignment is swallowed. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function renderModal(seededIds: string[]) {
+  if (seededIds.length > 0) {
+    localStorage.setItem("recentlyTaggedPeople", JSON.stringify(seededIds));
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <ModalPersonEdit isOpen onRequestClose={() => {}} selectedFaces={[{ face_id: 42, face_url: "/face42" }]} />
+      </MantineProvider>
+    );
+  });
+  return {
+    async type(filter: string) {
+      const input = document.querySelector("input") as HTMLInputElement;
+      await act(async () => {
+        setInputValue(input, filter);
+      });
+    },
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("issue 644 - recently tagged people in the face tagging popup", () => {
+  describe("the MRU list", () => {
+    it("keeps the most recently tagged person first", () => {
+      recordRecentlyTaggedPerson("1");
+      recordRecentlyTaggedPerson("2");
+      recordRecentlyTaggedPerson("3");
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual(["3", "2", "1"]);
+    });
+
+    it("moves a person back to the front instead of listing them twice", () => {
+      recordRecentlyTaggedPerson("1");
+      recordRecentlyTaggedPerson("2");
+      recordRecentlyTaggedPerson("1");
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual(["1", "2"]);
+    });
+
+    it("drops the oldest entry once it is full", () => {
+      const ids = Array.from({ length: RECENTLY_TAGGED_PEOPLE_LIMIT + 3 }, (_, i) => String(i));
+      ids.forEach(recordRecentlyTaggedPerson);
+
+      const stored = getRecentlyTaggedPeopleIds();
+      expect(stored).toHaveLength(RECENTLY_TAGGED_PEOPLE_LIMIT);
+      expect(stored).toEqual(ids.slice(-RECENTLY_TAGGED_PEOPLE_LIMIT).reverse());
+    });
+
+    it("normalizes the numeric person id the faces API returns", () => {
+      recordRecentlyTaggedPerson(7);
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual(["7"]);
+      expect(withMostRecentlyTagged(["7"], "7")).toEqual(["7"]);
+    });
+
+    it("ignores a face that was pushed back to no person at all", () => {
+      recordRecentlyTaggedPerson(null);
+      recordRecentlyTaggedPerson(undefined);
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual([]);
+    });
+
+    it("survives a corrupted localStorage entry", () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      localStorage.setItem("recentlyTaggedPeople", "{not json");
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual([]);
+      consoleError.mockRestore();
+    });
+
+    it("drops ids of people the server no longer knows about", () => {
+      // "99" was deleted or merged away; rendering it would show a stale name.
+      const resolved = resolveRecentlyTaggedPeople(["3", "99", "1"], stubs.people);
+
+      expect(resolved.map(person => person.name)).toEqual(["Charlie", "Alice"]);
+    });
+  });
+
+  describe("the popup", () => {
+    it("offers the recently tagged people above the full list", async () => {
+      const modal = await renderModal(["3", "1"]);
+
+      expect(namesOf(recentlyTaggedSection())).toEqual(["Charlie", "Alice"]);
+      // The alphabetical list is still there, unchanged.
+      expect(namesOf(document.body).slice(-3)).toEqual(["Alice", "Bob", "Charlie"]);
+
+      await modal.unmount();
+    });
+
+    it("labels the selection when a recently tagged person is picked", async () => {
+      const modal = await renderModal(["3"]);
+
+      const row = recentlyTaggedSection()?.querySelector("button") as HTMLButtonElement;
+      await act(async () => {
+        row.click();
+      });
+
+      expect(stubs.setFacesPersonLabel).toHaveBeenCalledWith({ faceIds: [42], personName: "Charlie" });
+
+      await modal.unmount();
+    });
+
+    it("shows nothing extra before the first face has been tagged", async () => {
+      const modal = await renderModal([]);
+
+      expect(recentlyTaggedSection()).toBeNull();
+
+      await modal.unmount();
+    });
+
+    it("gets out of the way once the user starts searching", async () => {
+      const modal = await renderModal(["3", "1"]);
+      expect(recentlyTaggedSection()).not.toBeNull();
+
+      await modal.type("alice");
+
+      expect(recentlyTaggedSection()).toBeNull();
+      expect(namesOf(document.body)).toEqual(["Alice"]);
+
+      await modal.unmount();
+    });
+  });
+
+  describe("recording the pick", () => {
+    it("records tagging that never goes through the popup", async () => {
+      // The faces dashboard header, the lightbox sidebar and the person detail
+      // row all label faces on their own; they only share this mutation.
+      stubs.post.mockResolvedValue({
+        status: true,
+        results: [
+          {
+            id: 42,
+            image: null,
+            face_url: null,
+            photo: "somehash",
+            person_label_probability: 1,
+            person: 3,
+            person_name: "Charlie",
+          },
+        ],
+        updated: [],
+        not_updated: [],
+      });
+
+      let tag: (() => Promise<unknown>) | undefined;
+      function Harness() {
+        const { mutateAsync } = useSetFacesPersonLabelMutation();
+        tag = () => mutateAsync({ faceIds: [42], personName: "Charlie" });
+        return null;
+      }
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={new QueryClient()}>
+            <Harness />
+          </QueryClientProvider>
+        );
+      });
+
+      await act(async () => {
+        await tag!();
+      });
+
+      expect(getRecentlyTaggedPeopleIds()).toEqual(["3"]);
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    });
+  });
+});

--- a/apps/frontend/src/__repro__/issue_644.test.tsx
+++ b/apps/frontend/src/__repro__/issue_644.test.tsx
@@ -22,7 +22,7 @@
 import "@mantine/core/styles.css";
 import { MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import React, { act } from "react";
+import React, { act, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSetFacesPersonLabelMutation } from "../api_client/faces/hooks/useSetFacesPersonLabelMutation";
@@ -101,6 +101,16 @@ function namesOf(root: ParentNode | null): string[] {
   return Array.from(root?.querySelectorAll("h4") ?? []).map(title => title.textContent ?? "");
 }
 
+function personRow(name: string): HTMLButtonElement {
+  return Array.from(document.querySelectorAll("button")).find(
+    button => button.querySelector("h4")?.textContent === name
+  ) as HTMLButtonElement;
+}
+
+function filterInput(): HTMLInputElement {
+  return document.querySelector("input") as HTMLInputElement;
+}
+
 /** React tracks the previous value on the node itself, so plain assignment is swallowed. */
 function setInputValue(input: HTMLInputElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
@@ -115,18 +125,36 @@ async function renderModal(seededIds: string[]) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
+  // The dashboard and the lightbox both render the modal unconditionally and only
+  // flip `isOpen`, so whatever the user typed outlives a close.
+  let setOpen: (open: boolean) => void = () => {};
+  function Harness() {
+    const [isOpen, setIsOpen] = useState(true);
+    setOpen = setIsOpen;
+    return (
+      <ModalPersonEdit
+        isOpen={isOpen}
+        onRequestClose={() => setIsOpen(false)}
+        selectedFaces={[{ face_id: 42, face_url: "/face42" }]}
+      />
+    );
+  }
   await act(async () => {
     root.render(
       <MantineProvider>
-        <ModalPersonEdit isOpen onRequestClose={() => {}} selectedFaces={[{ face_id: 42, face_url: "/face42" }]} />
+        <Harness />
       </MantineProvider>
     );
   });
   return {
     async type(filter: string) {
-      const input = document.querySelector("input") as HTMLInputElement;
       await act(async () => {
-        setInputValue(input, filter);
+        setInputValue(filterInput(), filter);
+      });
+    },
+    async reopen() {
+      await act(async () => {
+        setOpen(true);
       });
     },
     async unmount() {
@@ -235,6 +263,21 @@ describe("issue 644 - recently tagged people in the face tagging popup", () => {
 
       expect(recentlyTaggedSection()).toBeNull();
       expect(namesOf(document.body)).toEqual(["Alice"]);
+
+      await modal.unmount();
+    });
+
+    it("comes back on the next face after a pick made while filtering", async () => {
+      const modal = await renderModal(["3", "1"]);
+      await modal.type("cha");
+
+      await act(async () => {
+        personRow("Charlie").click();
+      });
+      await modal.reopen();
+
+      expect(namesOf(recentlyTaggedSection())).toEqual(["Charlie", "Alice"]);
+      expect(filterInput().value).toBe("");
 
       await modal.unmount();
     });

--- a/apps/frontend/src/api_client/faces/hooks/useSetFacesPersonLabelMutation.ts
+++ b/apps/frontend/src/api_client/faces/hooks/useSetFacesPersonLabelMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { z } from "zod";
 import { notification } from "../../../service/notifications";
+import { recordRecentlyTaggedPerson } from "../../../util/recentlyTaggedPeople";
 import { parseWithNotification } from "../../../util/zodUtils";
 import { PeopleAlbumsQueryKeys } from "../../albums/hooks/useFetchPeopleAlbumsQuery";
 import { fetchClient, queryClient } from "../../api";
@@ -43,7 +44,12 @@ const setFacesPersonLabel = (data: SetFacesLabelRequest) =>
 export const useSetFacesPersonLabelMutation = () =>
   useMutation({
     mutationFn: setFacesPersonLabel,
-    onSuccess: () => {
+    onSuccess: data => {
+      // Every tagging path funnels through this mutation, so this is the one
+      // place that sees all of them. `person` is null when faces are pushed back
+      // to "Unknown - Other", which is not a pick worth remembering.
+      recordRecentlyTaggedPerson(data.results[0]?.person);
+
       // Add a small delay to ensure backend processing is complete
       setTimeout(() => {
         // Invalidate all face-related queries

--- a/apps/frontend/src/components/modals/ModalPersonEdit.tsx
+++ b/apps/frontend/src/components/modals/ModalPersonEdit.tsx
@@ -17,8 +17,10 @@ import { useMediaQuery } from "@mantine/hooks";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFetchPeopleAlbumsQuery } from "../../api_client/albums/hooks";
+import type { Person } from "../../api_client/albums/hooks/useFetchPeopleAlbumsQuery";
 import { serverAddress } from "../../api_client/apiClient";
 import { useSetFacesPersonLabelMutation } from "../../api_client/faces";
+import { useRecentlyTaggedPeople } from "../../hooks/useRecentlyTaggedPeople";
 import { fuzzyMatch } from "../../util/util";
 
 type Props = Readonly<{
@@ -28,13 +30,51 @@ type Props = Readonly<{
   selectedFaces: any[];
 }>;
 
+type PersonRowProps = Readonly<{
+  person: Person;
+  onSelect: (person: Person) => void;
+}>;
+
+function PersonRow({ person, onSelect }: PersonRowProps) {
+  const theme = useMantineTheme();
+  const colorScheme = useComputedColorScheme();
+  const { t } = useTranslation();
+
+  return (
+    <UnstyledButton
+      style={{
+        display: "block",
+        borderRadius: theme.radius.xl,
+        backgroundColor: colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
+      }}
+      onClick={() => onSelect(person)}
+    >
+      <Group>
+        <Avatar radius="xl" size={60} src={serverAddress + person.face_url} />
+        <div>
+          <Title
+            style={{ width: "250px", textOverflow: "ellipsis", whiteSpace: "nowrap", overflow: "hidden" }}
+            order={4}
+          >
+            {person.name}
+          </Title>
+          <Text size="sm" c="dimmed">
+            {t("numberofphotos", {
+              number: person.face_count,
+            })}
+          </Text>
+        </div>
+      </Group>
+    </UnstyledButton>
+  );
+}
+
 export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGroups = () => {} }: Props) {
   const [newPersonName, setNewPersonName] = useState("");
   const matches = useMediaQuery("(min-width: 700px)");
-  const theme = useMantineTheme();
-  const colorScheme = useComputedColorScheme();
   const { data: people } = useFetchPeopleAlbumsQuery();
   const { mutate: setFacesPersonLabel } = useSetFacesPersonLabelMutation();
+  const recentlyTaggedPeople = useRecentlyTaggedPeople(people);
 
   const { t } = useTranslation();
 
@@ -44,11 +84,19 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
     filteredPeopleList = people?.filter(el => fuzzyMatch(newPersonName, el.name));
   }
 
+  // Once the user is searching, a fixed shortcut list is only noise.
+  const showRecentlyTagged = newPersonName.length === 0 && recentlyTaggedPeople.length > 0;
+
   const selectedImageIDs = selectedFaces.map(face => face.face_url);
   const selectedFaceIDs = selectedFaces.map(face => face.face_id);
 
   function personExist(name: string) {
     return people?.map(person => person.name.toLowerCase().trim()).includes(name.toLowerCase().trim());
+  }
+
+  function labelSelectedFacesAs(person: Person) {
+    setFacesPersonLabel({ faceIds: selectedFaceIDs, personName: person.name });
+    onRequestClose();
   }
 
   return (
@@ -103,6 +151,17 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
           </Button>
         </Group>
         <Divider />
+        {showRecentlyTagged && (
+          <>
+            <Title order={5}>{t("personedit.recentlytagged")}</Title>
+            <Stack>
+              {recentlyTaggedPeople.map(item => (
+                <PersonRow key={item.id} person={item} onSelect={labelSelectedFacesAs} />
+              ))}
+            </Stack>
+            <Divider />
+          </>
+        )}
         <Stack
           style={{
             height: matches ? "50vh" : "25vh",
@@ -111,37 +170,7 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
         >
           {filteredPeopleList &&
             filteredPeopleList.length > 0 &&
-            filteredPeopleList?.map(item => (
-              <UnstyledButton
-                key={item.id}
-                style={{
-                  display: "block",
-                  borderRadius: theme.radius.xl,
-                  backgroundColor: colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
-                }}
-                onClick={() => {
-                  setFacesPersonLabel({ faceIds: selectedFaceIDs, personName: item.name });
-                  onRequestClose();
-                }}
-              >
-                <Group key={item.id}>
-                  <Avatar radius="xl" size={60} src={serverAddress + item.face_url} />
-                  <div>
-                    <Title
-                      style={{ width: "250px", textOverflow: "ellipsis", whiteSpace: "nowrap", overflow: "hidden" }}
-                      order={4}
-                    >
-                      {item.name}
-                    </Title>
-                    <Text size="sm" c="dimmed">
-                      {t("numberofphotos", {
-                        number: item.face_count,
-                      })}
-                    </Text>
-                  </div>
-                </Group>
-              </UnstyledButton>
-            ))}
+            filteredPeopleList?.map(item => <PersonRow key={item.id} person={item} onSelect={labelSelectedFacesAs} />)}
         </Stack>
       </Stack>
     </Modal>

--- a/apps/frontend/src/components/modals/ModalPersonEdit.tsx
+++ b/apps/frontend/src/components/modals/ModalPersonEdit.tsx
@@ -97,6 +97,7 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
   function labelSelectedFacesAs(person: Person) {
     setFacesPersonLabel({ faceIds: selectedFaceIDs, personName: person.name });
     onRequestClose();
+    setNewPersonName("");
   }
 
   return (
@@ -130,6 +131,7 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
             error={
               personExist(newPersonName) ? t("personalbum.personalreadyexists", { name: newPersonName.trim() }) : ""
             }
+            value={newPersonName}
             onChange={v => {
               setNewPersonName(v.currentTarget.value);
             }}
@@ -151,23 +153,23 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
           </Button>
         </Group>
         <Divider />
-        {showRecentlyTagged && (
-          <>
-            <Title order={5}>{t("personedit.recentlytagged")}</Title>
-            <Stack>
-              {recentlyTaggedPeople.map(item => (
-                <PersonRow key={item.id} person={item} onSelect={labelSelectedFacesAs} />
-              ))}
-            </Stack>
-            <Divider />
-          </>
-        )}
         <Stack
           style={{
             height: matches ? "50vh" : "25vh",
             overflowY: "scroll",
           }}
         >
+          {showRecentlyTagged && (
+            <>
+              <Title order={5}>{t("personedit.recentlytagged")}</Title>
+              <Stack>
+                {recentlyTaggedPeople.map(item => (
+                  <PersonRow key={item.id} person={item} onSelect={labelSelectedFacesAs} />
+                ))}
+              </Stack>
+              <Divider />
+            </>
+          )}
           {filteredPeopleList &&
             filteredPeopleList.length > 0 &&
             filteredPeopleList?.map(item => <PersonRow key={item.id} person={item} onSelect={labelSelectedFacesAs} />)}

--- a/apps/frontend/src/hooks/useRecentlyTaggedPeople.ts
+++ b/apps/frontend/src/hooks/useRecentlyTaggedPeople.ts
@@ -1,0 +1,18 @@
+import { useEffect, useMemo, useState } from "react";
+import type { People } from "../api_client/albums/hooks/useFetchPeopleAlbumsQuery";
+import {
+  getRecentlyTaggedPeopleIds,
+  resolveRecentlyTaggedPeople,
+  subscribeToRecentlyTaggedPeople,
+} from "../util/recentlyTaggedPeople";
+
+// The people the user tagged most recently, most recent first. The list is fed
+// by useSetFacesPersonLabelMutation, so it picks up every tagging path in the
+// app, not just the ones that happen next to this hook.
+export function useRecentlyTaggedPeople(people: People | undefined): People {
+  const [ids, setIds] = useState(getRecentlyTaggedPeopleIds);
+
+  useEffect(() => subscribeToRecentlyTaggedPeople(() => setIds(getRecentlyTaggedPeopleIds())), []);
+
+  return useMemo(() => resolveRecentlyTaggedPeople(ids, people), [ids, people]);
+}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -896,7 +896,8 @@
     "numberselected": "Label selected {{number}} face(s) as…",
     "newperson": "New person",
     "personname": "Person Name",
-    "addperson": "Add Person"
+    "addperson": "Add Person",
+    "recentlytagged": "Recently tagged"
   },
   "facesdashboard": {
     "numberoffaces": "{{number}} Faces",

--- a/apps/frontend/src/util/recentlyTaggedPeople.ts
+++ b/apps/frontend/src/util/recentlyTaggedPeople.ts
@@ -1,0 +1,67 @@
+import type { People } from "../api_client/albums/hooks/useFetchPeopleAlbumsQuery";
+
+const STORAGE_KEY = "recentlyTaggedPeople";
+
+// How many people the "Recently tagged" shortcut keeps around.
+export const RECENTLY_TAGGED_PEOPLE_LIMIT = 5;
+
+// Faces carry a numeric person id, people albums coerce the same id to a string.
+// The MRU stores strings and normalizes at the boundary.
+export type RecentlyTaggedPersonId = string;
+
+const listeners = new Set<() => void>();
+
+// Reads the MRU, most recently tagged person first.
+export function getRecentlyTaggedPeopleIds(): RecentlyTaggedPersonId[] {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    const parsed = saved ? JSON.parse(saved) : [];
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("Error loading recently tagged people from localStorage:", e);
+    return [];
+  }
+}
+
+export function subscribeToRecentlyTaggedPeople(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Moves `id` to the front, keeping the rest in order and dropping the oldest
+// entries once the list is full.
+export function withMostRecentlyTagged(
+  ids: RecentlyTaggedPersonId[],
+  id: RecentlyTaggedPersonId,
+  limit: number = RECENTLY_TAGGED_PEOPLE_LIMIT
+): RecentlyTaggedPersonId[] {
+  return [id, ...ids.filter(existing => existing !== id)].slice(0, limit);
+}
+
+export function recordRecentlyTaggedPerson(personId: string | number | null | undefined) {
+  if (personId === null || personId === undefined || personId === "") {
+    return;
+  }
+
+  const ids = withMostRecentlyTagged(getRecentlyTaggedPeopleIds(), personId.toString());
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("Error saving recently tagged people to localStorage:", e);
+  }
+  listeners.forEach(listener => listener());
+}
+
+// Resolves the stored ids against the people the server currently knows about.
+// Entries that no longer exist (deleted or merged people) are dropped instead of
+// rendered with a stale name.
+export function resolveRecentlyTaggedPeople(ids: RecentlyTaggedPersonId[], people: People | undefined): People {
+  if (!people) {
+    return [];
+  }
+  return ids.map(id => people.find(person => person.id === id)).filter((person): person is People[number] => !!person);
+}


### PR DESCRIPTION
Closes #644

Tagging a run of photos meant scrolling the alphabetical list or retyping the same few names each time. The popup now leads with the people you last tagged.

<!-- SCREENSHOT: 644-recent.png -->

Empty on first run, so nothing changes until you've actually tagged someone:

<!-- SCREENSHOT: 644-empty.png -->

## The MRU is recorded centrally, not in the modal

Every tagging path in the app funnels through one hook, `useSetFacesPersonLabelMutation` — the faces page bulk action, the group header, the lightbox sidebar, and the popup itself. Recording the pick in its `onSuccess` means all of them feed the list. Doing it inside the modal would have missed most real tagging.

## Details

- Most-recent-first, deduplicated, capped at 5
- Persisted in `localStorage`, following the existing `useTabScrollPositions` pattern, with `JSON.parse` guarded
- Hidden entirely when empty, and while a search filter is active — once you're searching, a fixed list is noise
- Entries are resolved against the live people list each render, so deleted or merged people are dropped rather than rendered stale
- The row markup is shared with the main list rather than duplicated

One trap worth noting: `useFetchPeopleAlbumsQuery` coerces person `id` to a **string**, while faces carry a numeric `person` id. The MRU normalises at the boundary — without that, lookups miss silently and the section just never appears.

## Verification

- eslint, vitest, `vite build` all pass on Node 20.20.2 (CI's pinned version)
- 44 frontend tests pass, up from 31 — 13 new in `src/__repro__/issue_644.test.tsx`
- The MRU logic is pure and unit-tested directly: ordering, cap, dedupe on re-tag, and dropping ids the server no longer knows about
- Screenshots are a component preview rendering the real `ModalPersonEdit` against stubbed API hooks — Docker wasn't available for a full instance, so they are not live-app captures. Clicking a person in the preview does move them to the top of the list, driven by the real `recordRecentlyTaggedPerson` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)