### PR TITLE
fix(frontend): make the WDYR debug integration actually enableable

### DIFF
--- a/apps/backend/CONTRIBUTING.md
+++ b/apps/backend/CONTRIBUTING.md
@@ -354,7 +354,9 @@ Press `Ctrl+P` followed by `Ctrl+Q` to detach without stopping the container.
 
 - Use React DevTools browser extension
 - Use Redux DevTools for state debugging
-- Enable WDYR by setting `WDYR=True` in your `.env`
+- Enable [WDYR](https://github.com/welldone-software/why-did-you-render), which logs why each
+  component re-rendered, by setting `VITE_APP_WDYR=true` in `deploy/compose/.env` and restarting
+  the frontend container. The value must be the lowercase string `true`.
 
 **API Documentation:**
 

--- a/apps/docs/docs/development/contribution/frontend/index.md
+++ b/apps/docs/docs/development/contribution/frontend/index.md
@@ -32,10 +32,24 @@ React provides a debug tool, which you can download
 ### WDYR
 
 [WDYR](https://github.com/welldone-software/why-did-you-render) explains to you why a component
-re-rendered. To activate it, set `VITE_APP_WDYR=true` in your `.env.development` — it has to be the
-literal string `true`. It is wired up in
+re-rendered, by logging the changed props and hooks to the browser console. It is wired up in
 [src/wdyr.ts](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/src/wdyr.ts) and only
 runs in development builds.
+
+Set `VITE_APP_WDYR` to the literal string `true` — any other value (`True`, `1`, unset) leaves it
+off. Where you set it depends on how you run the frontend:
+
+- **Local dev server** (`yarn start`) — add `VITE_APP_WDYR=true` to `apps/frontend/.env.development`.
+- **Docker dev stack** — add `VITE_APP_WDYR=true` to `deploy/compose/.env`, then recreate the
+  container so it picks up the new environment:
+
+  ```bash
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d frontend
+  ```
+
+Either way the dev server has to be restarted. WDYR needs its own JSX transform, which
+`vite.config.ts` only selects when the variable is set at startup, so flipping it mid-session has no
+effect.
 
 ### REST API
 

--- a/apps/docs/docs/development/dev-install.md
+++ b/apps/docs/docs/development/dev-install.md
@@ -235,7 +235,13 @@ In development mode, access `/api/silk` for request profiling and SQL query anal
 
 - **React DevTools**: Install the [browser extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
 - **Redux DevTools**: Install the [browser extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
-- **WDYR (Why Did You Render)**: Set `WDYR=True` in your `.env` to see component re-render reasons
+- **WDYR (Why Did You Render)**: Set `VITE_APP_WDYR=true` in `deploy/compose/.env` to log component
+  re-render reasons to the browser console. The value must be the lowercase string `true`; anything
+  else leaves WDYR off. Recreate the frontend container to pick up the change:
+
+  ```bash
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d frontend
+  ```
 
 ## Troubleshooting
 

--- a/apps/frontend/src/wdyr.ts
+++ b/apps/frontend/src/wdyr.ts
@@ -2,7 +2,7 @@
 import whyDidYouRender from "@welldone-software/why-did-you-render";
 import React from "react";
 
-if (import.meta.env.NODE_ENV === "development" && import.meta.env.VITE_APP_WDYR === "true") {
+if (import.meta.env.DEV && import.meta.env.VITE_APP_WDYR === "true") {
   whyDidYouRender(React, {
     trackAllPureComponents: true,
     trackHooks: true,

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -6,10 +6,20 @@ import { tanstackRouter } from '@tanstack/router-plugin/vite'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const publicUrl = env.PUBLIC_URL || env.VITE_PUBLIC_URL || '/';
-  
+
+  // Why Did You Render. Under the automatic JSX runtime, elements are created
+  // by jsxDEV() rather than React.createElement, so the React patch that
+  // src/wdyr.ts applies never sees them. WDYR ships a jsx-dev-runtime wrapper
+  // for exactly this; point the transform at it. Only when WDYR is actually
+  // switched on, so a normal dev server keeps the stock transform.
+  const wdyr = mode !== "production" && env.VITE_APP_WDYR === "true";
+
   return {
     base: publicUrl,
-    plugins: [tanstackRouter({target: "react", autoCodeSplitting: true}), react()],
+    plugins: [
+      tanstackRouter({target: "react", autoCodeSplitting: true}),
+      react(wdyr ? { jsxImportSource: "@welldone-software/why-did-you-render" } : {}),
+    ],
     appType: 'spa',
     server: {
       host: "0.0.0.0",

--- a/deploy/compose/docker-compose.dev.yml
+++ b/deploy/compose/docker-compose.dev.yml
@@ -24,6 +24,9 @@ services:
     environment:
       - DEBUG=1
       - WDS_SOCKET_PORT=0 # needed for Vite HMR behind the proxy
+      # Why Did You Render. Vite only forwards VITE_-prefixed variables to
+      # client code, so the name has to survive intact all the way through.
+      - VITE_APP_WDYR=${VITE_APP_WDYR:-false}
     build:
       context: ../..
       dockerfile: deploy/docker/frontend/Dockerfile.dev

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -72,4 +72,9 @@ dbHost=db
 # Where shall we store the backend and frontend code files.
 codedir=./librephotos/code
 
+# Why Did You Render — logs to the browser console the reason each React
+# component re-rendered. Only has an effect on the dev compose stack
+# (docker-compose.dev.yml), and only for the literal string "true".
+VITE_APP_WDYR=false
+
 pgAdminLocation=./


### PR DESCRIPTION
Why Did You Render could not be turned on at all. The enable path was broken in **three** independent places, so every documented invocation was a no-op.

## What was broken

**1. The dev guard never passed.** [`src/wdyr.ts`](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/src/wdyr.ts) guarded on `import.meta.env.NODE_ENV === "development"`. Vite never puts `NODE_ENV` on `import.meta.env` — it exposes `MODE`, `DEV` and `PROD` — so the expression was always `undefined` and `whyDidYouRender()` never ran, regardless of any env var. Now `import.meta.env.DEV`.

**2. Even once initialized, WDYR logged nothing.** This one only shows up if you actually run the tool. Under React's automatic JSX runtime, elements are created by `jsxDEV()` rather than `React.createElement`, so patching `React` intercepts nothing. WDYR ships a `jsx-dev-runtime` wrapper for exactly this case, and `vite.config.ts` never pointed at it. It now does — but only when WDYR is switched on in a non-production mode, so a normal dev server keeps the stock transform and pays nothing.

**3. The documented variable name did not exist.** The docs said to set `WDYR=True`; the code reads `VITE_APP_WDYR` and compares against the lowercase string `"true"`. Nothing in `deploy/` mapped a compose variable through to the frontend either, so the Docker dev flow could not reach it at any casing. `docker-compose.dev.yml` now forwards `VITE_APP_WDYR` to the frontend service, `librephotos.env` documents it, and the docs describe both the compose and the `yarn start` flow.

`apps/frontend/.env.development.example` already used the correct name and is left as the source of truth.

## Verification

Checked against a running dev server rather than by making the names match. `VITE_APP_WDYR=true` was supplied as a **process environment variable** — deliberately not via a `.env` file — because that is the same path the container uses.

**Enabled**, the app reports `DEV: true`, `MODE: "development"`, `VITE_APP_WDYR: "true"`, `NODE_ENV: undefined` (the original bug, observed rather than argued), `reactPatched: true`, and logs:

```
▸ Tracked
    Re-rendered because of props changes:
    ▸ props.payload — different objects that are equal by value
    ▸ Rendered by Probe
    Re-rendered because of hook changes: [hook useState result] {prev: 0} !== {next: 1}
```

confirming both `trackAllPureComponents` and `trackHooks`.

**Disabled**, the variable is absent from `import.meta.env`, React is left unpatched, and nothing is logged while the component still re-renders — so it is genuinely gated, not always-on.

Supporting this, Vite 7's `loadEnv` ends with `for (const key in process.env) if (prefixes.some(p => key.startsWith(p))) …`, so `VITE_`-prefixed container variables do reach `import.meta.env`; because that loop runs after the `.env`-file loop, the compose value also wins over a developer's mounted `.env.development`.

Build checks: production build succeeds, and with `VITE_APP_WDYR=true` forced during a production build the output bundle is **byte-identical** to the pre-change baseline (same content hash), so this is provably prod-neutral. ESLint clean on `wdyr.ts`.

## Notes for the reviewer

- **The container path is verified by mechanism, not by a live container.** The machine I worked on has Docker 19.03 with a non-functional daemon and only compose v1.24, which cannot parse this repo's existing `${httpPort:-3000}` interpolation. The compose syntax I added matches 20+ existing usages in the same files, but a smoke test on real hardware would be worth doing before merge.
- WDYR's library body ships in production bundles today, because `index.tsx` imports `./wdyr` unconditionally and the package is CommonJS. That is **pre-existing and untouched by this PR** (hence the byte-identical bundle) and wants a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
