### PR TITLE
fix(frontend): replace invalid Mantine v6 `justify="apart"` on Group

### DIFF
--- a/apps/frontend/src/components/CountStats.tsx
+++ b/apps/frontend/src/components/CountStats.tsx
@@ -23,7 +23,7 @@ export function CountStats() {
       {/* Photos & Days combined */}
       <Grid.Col span={{ base: 6, sm: 6, md: 3 }}>
         <Card withBorder p="xs">
-          <Group justify="left" gap="xs">
+          <Group justify="flex-start" gap="xs">
             <Photo size={40} strokeWidth={1} />
             <div>
               <Text c="dimmed" size="xs">
@@ -47,7 +47,7 @@ export function CountStats() {
         <HoverCard width={200} shadow="md" withinPortal withArrow>
           <HoverCard.Target>
             <Card withBorder p="xs">
-              <Group justify="left" gap="xs">
+              <Group justify="flex-start" gap="xs">
                 <Users size={40} strokeWidth={1} />
                 <div>
                   <Text c="dimmed" size="xs">
@@ -102,7 +102,7 @@ export function CountStats() {
       {/* Events */}
       <Grid.Col span={{ base: 6, sm: 6, md: 3 }}>
         <Card withBorder p="xs">
-          <Group justify="left" gap="xs">
+          <Group justify="flex-start" gap="xs">
             <SettingsAutomation size={40} strokeWidth={1} />
             <div>
               <Text c="dimmed" size="xs">

--- a/apps/frontend/src/components/facedashboard/TabComponent.tsx
+++ b/apps/frontend/src/components/facedashboard/TabComponent.tsx
@@ -18,7 +18,7 @@ export function TabComponent({ fetchingLabeledFacesList, fetchingInferredFacesLi
   const { tab: activeTab } = routeApi.useSearch();
 
   return (
-    <Group justify="apart">
+    <Group justify="space-between">
       <Tabs
         defaultValue={activeTab}
         value={activeTab}

--- a/apps/frontend/src/components/lightbox/CameraInfoComponent.tsx
+++ b/apps/frontend/src/components/lightbox/CameraInfoComponent.tsx
@@ -11,7 +11,7 @@ export function CameraInfoComponent({ photoDetail }: { photoDetail: PhotoType })
   if (!photoDetail.camera) return null;
 
   return (
-    <Group justify="apart">
+    <Group justify="space-between">
       <Group justify="left">
         <Camera />
         <div>

--- a/apps/frontend/src/components/lightbox/CameraInfoComponent.tsx
+++ b/apps/frontend/src/components/lightbox/CameraInfoComponent.tsx
@@ -12,7 +12,7 @@ export function CameraInfoComponent({ photoDetail }: { photoDetail: PhotoType })
 
   return (
     <Group justify="space-between">
-      <Group justify="left">
+      <Group justify="flex-start">
         <Camera />
         <div>
           <Text fw={800}>{photoDetail.camera?.toString()}</Text>

--- a/apps/frontend/src/components/lightbox/VersionComponent.tsx
+++ b/apps/frontend/src/components/lightbox/VersionComponent.tsx
@@ -214,7 +214,7 @@ export function VersionComponent(props: Readonly<{ photoDetail: PhotoType; isPub
 
   return (
     <div>
-      <Stack align="left">
+      <Stack align="flex-start">
         {/* Basic photo information with file variants toggle */}
         <PhotoInfoSection photoDetail={photoDetail} t={t} />
 

--- a/apps/frontend/src/components/lightbox/VersionComponent.tsx
+++ b/apps/frontend/src/components/lightbox/VersionComponent.tsx
@@ -41,7 +41,7 @@ function PhotoInfoSection({
   return (
     <Stack gap="xs">
       <Group justify="space-between">
-        <Group justify="left">
+        <Group justify="flex-start">
           <Photo />
           <div>
             <Anchor href={`${serverAddress}/media/photos/${photoDetail.image_hash}`} target="_blank">
@@ -113,7 +113,7 @@ export function CameraInfoSection({ photoDetail }: { photoDetail: Partial<PhotoT
 
   return (
     <Group justify="space-between">
-      <Group justify="left">
+      <Group justify="flex-start">
         <Camera />
         <div>
           <Text fw={800}>{photoDetail.camera?.toString()}</Text>

--- a/apps/frontend/src/components/lightbox/VersionComponent.tsx
+++ b/apps/frontend/src/components/lightbox/VersionComponent.tsx
@@ -40,7 +40,7 @@ function PhotoInfoSection({
 
   return (
     <Stack gap="xs">
-      <Group justify="apart">
+      <Group justify="space-between">
         <Group justify="left">
           <Photo />
           <div>
@@ -112,7 +112,7 @@ export function CameraInfoSection({ photoDetail }: { photoDetail: Partial<PhotoT
   if (!photoDetail.camera) return null;
 
   return (
-    <Group justify="apart">
+    <Group justify="space-between">
       <Group justify="left">
         <Camera />
         <div>

--- a/apps/frontend/src/components/photolist/DefaultHeader.tsx
+++ b/apps/frontend/src/components/photolist/DefaultHeader.tsx
@@ -162,7 +162,7 @@ export function DefaultHeader(props: Props) {
 
   return (
     <div>
-      <Group justify="apart">
+      <Group justify="space-between">
         <Group justify="left">
           {icon}
           <div>

--- a/apps/frontend/src/components/photolist/DefaultHeader.tsx
+++ b/apps/frontend/src/components/photolist/DefaultHeader.tsx
@@ -163,7 +163,7 @@ export function DefaultHeader(props: Props) {
   return (
     <div>
       <Group justify="space-between">
-        <Group justify="left">
+        <Group justify="flex-start">
           {icon}
           <div>
             {auth?.access && isMenuView() ? (
@@ -231,7 +231,7 @@ export function DefaultHeader(props: Props) {
           </div>
         </Group>
         {(!hasEmptyState || numPhotosetItems > 0) && (dayHeaderPrefix || date) && (
-          <Group justify="right" wrap="nowrap">
+          <Group justify="flex-end" wrap="nowrap">
             <Text style={{ whiteSpace: "nowrap" }}>
               <b>
                 {dayHeaderPrefix}

--- a/apps/frontend/src/components/sharing/ModalPhotosShare.tsx
+++ b/apps/frontend/src/components/sharing/ModalPhotosShare.tsx
@@ -111,7 +111,7 @@ export function ModalPhotosShare(props: Props) {
                 }
                 const avatar = item.avatar ? item.avatar_url : "/unknown_user.jpg";
                 return (
-                  <Group justify="apart" key={item.id}>
+                  <Group justify="space-between" key={item.id}>
                     <Group>
                       <Avatar radius="xl" size={50} src={avatar} />
                       <div>

--- a/apps/frontend/src/components/sharing/UserEntry.tsx
+++ b/apps/frontend/src/components/sharing/UserEntry.tsx
@@ -33,7 +33,7 @@ export function UserEntry(props: UserEntryProps) {
   const { mutate: shareAlbum } = useShareUserAlbumMutation();
 
   return (
-    <Group justify="apart" key={user.id}>
+    <Group justify="space-between" key={user.id}>
       <Group>
         <Avatar radius="xl" size={50} src={getAvatar(user)} />
         <div>

--- a/apps/frontend/src/routes/_protected/album/events.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/events.index.tsx
@@ -77,7 +77,7 @@ export function AlbumAuto() {
           </div>
         </div>
         <Group justify="space-between">
-          <Flex gap={0} justify="left" direction="column" px={8}>
+          <Flex gap={0} justify="flex-start" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.title}>
               {album.title}
             </Text>

--- a/apps/frontend/src/routes/_protected/album/events.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/events.index.tsx
@@ -76,7 +76,7 @@ export function AlbumAuto() {
             </Menu>
           </div>
         </div>
-        <Group justify="apart">
+        <Group justify="space-between">
           <Flex gap={0} justify="left" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.title}>
               {album.title}

--- a/apps/frontend/src/routes/_protected/album/index.tsx
+++ b/apps/frontend/src/routes/_protected/album/index.tsx
@@ -117,7 +117,7 @@ export function AlbumExplore() {
 
   return (
     <Box p={10}>
-      <Group justify="left" mb="md">
+      <Group justify="flex-start" mb="md">
         <IconAlbum size={40} stroke={1.5} />
         <div>
           <Title order={2}>{t("explore.title")}</Title>

--- a/apps/frontend/src/routes/_protected/album/persons.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/persons.index.tsx
@@ -111,7 +111,7 @@ export function AlbumPeople() {
             </Menu>
           </div>
         </div>
-        <Group justify="apart">
+        <Group justify="space-between">
           <Flex gap={0} justify="left" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.name}>
               {album.name}

--- a/apps/frontend/src/routes/_protected/album/persons.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/persons.index.tsx
@@ -112,7 +112,7 @@ export function AlbumPeople() {
           </div>
         </div>
         <Group justify="space-between">
-          <Flex gap={0} justify="left" direction="column" px={8}>
+          <Flex gap={0} justify="flex-start" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.name}>
               {album.name}
             </Text>

--- a/apps/frontend/src/routes/_protected/album/things.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/things.index.tsx
@@ -41,7 +41,7 @@ export function AlbumThing() {
             </Link>
           ))}
         </div>
-        <Group justify="apart">
+        <Group justify="space-between">
           <Flex gap={0} justify="left" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.title}>
               {album.title}

--- a/apps/frontend/src/routes/_protected/album/things.index.tsx
+++ b/apps/frontend/src/routes/_protected/album/things.index.tsx
@@ -42,7 +42,7 @@ export function AlbumThing() {
           ))}
         </div>
         <Group justify="space-between">
-          <Flex gap={0} justify="left" direction="column" px={8}>
+          <Flex gap={0} justify="flex-start" direction="column" px={8}>
             <Text size="sm" fw={500} lineClamp={1} title={album.title}>
               {album.title}
             </Text>

--- a/apps/frontend/src/routes/_protected/sharing/index.tsx
+++ b/apps/frontend/src/routes/_protected/sharing/index.tsx
@@ -80,7 +80,7 @@ export function SharingExplore() {
 
   return (
     <Box p={10}>
-      <Group justify="left" mb="md">
+      <Group justify="flex-start" mb="md">
         <IconUsers size={40} stroke={1.5} />
         <div>
           <Title order={2}>{t("sidemenu.sharing")}</Title>


### PR DESCRIPTION
## What

`apart` was the Mantine **v6** `Group position` value. Since v7 (this repo is on `@mantine/core` **8.3.18**) `justify` is forwarded verbatim into the `--group-justify` CSS variable and consumed as `justify-content`, where `apart` is not a valid keyword:

```js
// @mantine/core/esm/components/Group/Group.mjs
"--group-justify": justify,
```

The declaration is therefore invalid at computed-value time, so `justify-content` falls back to its initial `normal` — i.e. `flex-start` in a flex container.

## Why it was never caught

`GroupProps["justify"]` is typed as `React.CSSProperties["justifyContent"]`, and csstype widens that with `(string & {})` — so **any string typechecks**. Neither `tsc` nor ESLint can find this class of bug; it only shows up visually.

## What actually rendered wrong

Of the 10 `justify="apart"` sites, **7 have a single child**, so `justify` had nothing to distribute and they rendered identically either way. They are corrected regardless, so the value is no longer a trap the moment a second child is added.

The three that were visibly wrong:

| Site | Symptom |
|---|---|
| `DefaultHeader.tsx` | Date sat next to the title instead of at the header's right edge |
| `ModalPhotosShare.tsx` | Share/unshare icons packed against the username |
| `UserEntry.tsx` | Share toggle packed against the username |

## Commits

1. **`justify="apart"` → `space-between`** — the actual fix, 10 sites.
2. **Normalize `justify="left"`/`"right"` → `flex-start`/`flex-end`** — no rendering change. `justify-content` *does* accept `left`/`right` per CSS Box Alignment, so these 13 sites were never broken, just v6-era naming. Normalizing means every remaining `justify` value in the tree is a literal `justify-content` keyword, so invalid ones stand out on sight.
3. **`Stack align="left"` → `flex-start`** — a real find. Unlike `justify-content`, `align-items` has **no** `left` keyword, so this was invalid and fell back to `stretch`. **This one does change rendering:** the lightbox metadata column and its "Show more" button now shrink to content width instead of spanning the panel. Worth a look in review.

## Also swept, no action needed

- `spacing=` — 10 hits, all on `SimpleGrid`, still valid in v8.
- `position=` — all `Tooltip`/`Menu` floating position. Valid.
- `<Group grow>` — 4 sites, all legitimate. (`Profile.tsx:114` pairs `grow` with `justify="center"`, which is redundant since grown children leave no free space, but harmless.)

## Note

There is an 11th `justify="apart"` on `feat/user-defined-tags` (`routes/_protected/album/tags.index.tsx`) — the tag tile's name block and kebab menu. That file does not exist on `dev`, so **it has to be fixed in the tags PR**, not here.

## Test plan

- ESLint clean on all 12 changed files.
- No test file references any of the changed components.
- Rendering verified by reading each JSX tree to establish child counts; the `space-between` vs `flex-start` distinction only bites where a Group has ≥2 children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
