### PR TITLE
fix(backend): schedule stuck-job cleanup and ignore aged queue blockers

### DIFF
--- a/apps/backend/api/api_util.py
+++ b/apps/backend/api/api_util.py
@@ -3,21 +3,9 @@ import random
 import stat
 
 from api.models import (
-    LongRunningJob,
     Photo,
 )
-from api.serializers.job import LongRunningJobSerializer
 from api.util import logger
-
-
-def get_current_job():
-    job_detail = None
-    running_job = (
-        LongRunningJob.objects.filter(finished=False).order_by("-started_at").first()
-    )
-    if running_job:
-        job_detail = LongRunningJobSerializer(running_job).data
-    return job_detail
 
 
 def shuffle(list):

--- a/apps/backend/api/models/long_running_job.py
+++ b/apps/backend/api/models/long_running_job.py
@@ -8,6 +8,8 @@ from api.models.user import User, get_deleted_user
 
 
 class LongRunningJob(models.Model):
+    STUCK_JOB_HOURS = 24
+
     JOB_SCAN_PHOTOS = 1
     JOB_GENERATE_AUTO_ALBUMS = 2
     JOB_GENERATE_AUTO_ALBUM_TITLES = 3
@@ -196,22 +198,28 @@ class LongRunningJob(models.Model):
         )
 
     @classmethod
-    def cleanup_stuck_jobs(cls, hours=24):
+    def cleanup_stuck_jobs(cls, hours=None):
         """
-        Mark jobs as failed if they've been running for too long.
+        Mark jobs as failed if they've been running (or queued) for too long.
 
-        Jobs that have started_at set but finished=False for longer than
-        the specified hours are considered stuck and will be marked as failed.
+        Jobs with finished=False are considered stuck when:
+        - started_at is set and older than the threshold, or
+        - started_at is null and queued_at is older than the threshold
+          (never-started orphans from crashed workers).
 
         Args:
-            hours: Number of hours after which a running job is considered stuck
+            hours: Hours after which a job is considered stuck.
+                Defaults to STUCK_JOB_HOURS.
 
         Returns:
             Number of jobs marked as failed
         """
+        if hours is None:
+            hours = cls.STUCK_JOB_HOURS
         cutoff = timezone.now() - timedelta(hours=hours)
-        stuck_jobs = cls.objects.filter(
-            finished=False, started_at__isnull=False, started_at__lt=cutoff
+        stuck_jobs = cls.objects.filter(finished=False).filter(
+            models.Q(started_at__isnull=False, started_at__lt=cutoff)
+            | models.Q(started_at__isnull=True, queued_at__lt=cutoff)
         )
         count = stuck_jobs.count()
         stuck_jobs.update(

--- a/apps/backend/api/tests/test_cleanup_stuck_jobs.py
+++ b/apps/backend/api/tests/test_cleanup_stuck_jobs.py
@@ -1,0 +1,85 @@
+"""Tests for ``LongRunningJob.cleanup_stuck_jobs``.
+
+Orphaned unfinished rows (worker OOM, container restart, uncaught exceptions)
+must be marked failed after the stuck threshold so they stop blocking
+``GET /api/rqavailable/``. See issue #1919.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from api.models import LongRunningJob
+from api.tests.utils import create_test_user
+
+J = LongRunningJob
+
+
+class CleanupStuckJobsTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    def _job(
+        self,
+        *,
+        hours_ago=0,
+        started=True,
+        finished=False,
+        job_type=J.JOB_SCAN_PHOTOS,
+    ):
+        now = timezone.now()
+        queued_at = now - timedelta(hours=hours_ago)
+        started_at = queued_at if started else None
+        return J.objects.create(
+            started_by=self.user,
+            job_id=str(uuid.uuid4()),
+            job_type=job_type,
+            finished=finished,
+            failed=False,
+            queued_at=queued_at,
+            started_at=started_at,
+        )
+
+    def test_marks_old_started_unfinished_job_as_failed(self):
+        stuck = self._job(hours_ago=J.STUCK_JOB_HOURS + 1, started=True)
+        count = J.cleanup_stuck_jobs()
+        self.assertEqual(count, 1)
+        stuck.refresh_from_db()
+        self.assertTrue(stuck.finished)
+        self.assertTrue(stuck.failed)
+        self.assertIsNotNone(stuck.finished_at)
+        self.assertEqual(stuck.result["status"], "failed")
+
+    def test_leaves_recent_unfinished_job_untouched(self):
+        recent = self._job(hours_ago=1, started=True)
+        count = J.cleanup_stuck_jobs()
+        self.assertEqual(count, 0)
+        recent.refresh_from_db()
+        self.assertFalse(recent.finished)
+        self.assertFalse(recent.failed)
+
+    def test_marks_never_started_orphan_as_failed(self):
+        orphan = self._job(
+            hours_ago=J.STUCK_JOB_HOURS + 1, started=False, finished=False
+        )
+        count = J.cleanup_stuck_jobs()
+        self.assertEqual(count, 1)
+        orphan.refresh_from_db()
+        self.assertTrue(orphan.finished)
+        self.assertTrue(orphan.failed)
+
+    def test_leaves_recent_never_started_job_untouched(self):
+        queued = self._job(hours_ago=1, started=False)
+        count = J.cleanup_stuck_jobs()
+        self.assertEqual(count, 0)
+        queued.refresh_from_db()
+        self.assertFalse(queued.finished)
+
+    def test_respects_custom_hours_threshold(self):
+        mid = self._job(hours_ago=5, started=True)
+        count = J.cleanup_stuck_jobs(hours=3)
+        self.assertEqual(count, 1)
+        mid.refresh_from_db()
+        self.assertTrue(mid.failed)

--- a/apps/backend/api/tests/test_queue_availability_stuck.py
+++ b/apps/backend/api/tests/test_queue_availability_stuck.py
@@ -1,0 +1,66 @@
+"""Queue availability must ignore unfinished jobs past the stuck threshold.
+
+``GET /api/rqavailable/`` used to treat any ``finished=False`` row as busy,
+so orphaned jobs blocked every heavyweight action forever. Age filtering
+matches ``LongRunningJob.cleanup_stuck_jobs`` / ``STUCK_JOB_HOURS``. See #1919.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.models import LongRunningJob
+from api.tests.utils import create_test_user
+
+J = LongRunningJob
+RQ_AVAILABLE_URL = "/api/rqavailable/"
+
+
+class QueueAvailabilityStuckJobsTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _unfinished_job(self, *, hours_ago, started=True):
+        now = timezone.now()
+        queued_at = now - timedelta(hours=hours_ago)
+        return J.objects.create(
+            started_by=self.user,
+            job_id=str(uuid.uuid4()),
+            job_type=J.JOB_SCAN_PHOTOS,
+            finished=False,
+            failed=False,
+            queued_at=queued_at,
+            started_at=queued_at if started else None,
+        )
+
+    def test_recent_unfinished_job_blocks_queue(self):
+        self._unfinished_job(hours_ago=1, started=True)
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["queue_can_accept_job"])
+        self.assertIsNotNone(response.data["job_detail"])
+
+    def test_stuck_started_job_does_not_block_queue(self):
+        self._unfinished_job(hours_ago=J.STUCK_JOB_HOURS + 1, started=True)
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["queue_can_accept_job"])
+        self.assertIsNone(response.data["job_detail"])
+
+    def test_stuck_never_started_job_does_not_block_queue(self):
+        self._unfinished_job(hours_ago=J.STUCK_JOB_HOURS + 1, started=False)
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["queue_can_accept_job"])
+        self.assertIsNone(response.data["job_detail"])
+
+    def test_empty_queue_accepts_jobs(self):
+        response = self.client.get(RQ_AVAILABLE_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["queue_can_accept_job"])
+        self.assertIsNone(response.data["job_detail"])

--- a/apps/backend/api/views/jobs.py
+++ b/apps/backend/api/views/jobs.py
@@ -1,4 +1,7 @@
-from django.db.models import Prefetch
+from datetime import timedelta
+
+from django.db.models import Prefetch, Q
+from django.utils import timezone
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -77,8 +80,18 @@ class QueueAvailabilityView(APIView):
     def get(self, request, format=None):
         job_detail = None
 
+        # Ignore unfinished rows past the stuck-job threshold so orphaned jobs
+        # (OOM, restart, uncaught exception) do not block the queue forever
+        # while waiting for the hourly cleanup schedule to fire. See #1919.
+        cutoff = timezone.now() - timedelta(hours=LongRunningJob.STUCK_JOB_HOURS)
         running_job = (
-            LongRunningJob.objects.filter(finished=False).order_by("-started_at").last()
+            LongRunningJob.objects.filter(finished=False)
+            .filter(
+                Q(started_at__gte=cutoff)
+                | Q(started_at__isnull=True, queued_at__gte=cutoff)
+            )
+            .order_by("-started_at")
+            .last()
         )
         if running_job:
             job_detail = LongRunningJobSerializer(running_job).data

--- a/deploy/docker/backend-gpu/entrypoint.sh
+++ b/deploy/docker/backend-gpu/entrypoint.sh
@@ -26,6 +26,7 @@ python manage.py showmigrations | tee /logs/show_migrate.log
 python manage.py collectstatic --no-input
 python manage.py start_service all
 python manage.py start_cleaning_service
+python manage.py start_job_cleanup_service
 python manage.py clear_cache 
 python manage.py build_similarity_index 2>&1 | tee /logs/command_build_similarity_index.log
 

--- a/deploy/docker/backend/entrypoint.sh
+++ b/deploy/docker/backend/entrypoint.sh
@@ -25,6 +25,7 @@ python manage.py showmigrations | tee /logs/show_migrate.log
 python manage.py collectstatic --no-input
 python manage.py start_service all
 python manage.py start_cleaning_service
+python manage.py start_job_cleanup_service
 python manage.py clear_cache 
 python manage.py build_similarity_index 2>&1 | tee /logs/command_build_similarity_index.log
 

--- a/deploy/docker/unified/entrypoint.sh
+++ b/deploy/docker/unified/entrypoint.sh
@@ -80,6 +80,7 @@ echo "Starting Django server..."
 
 python manage.py start_service all
 python manage.py start_cleaning_service
+python manage.py start_job_cleanup_service
 python manage.py clear_cache 
 python manage.py build_similarity_index 2>&1 | tee /logs/command_build_similarity_index.log
 python manage.py qcluster 2>&1 | tee /logs/qcluster.log &


### PR DESCRIPTION
Closes #1919

Orphaned `LongRunningJob` rows with `finished=False` (OOM, restart, uncaught exception) left `/api/rqavailable/` reporting busy forever, which greys out every heavyweight Library action for the whole instance. The reaper already existed (`cleanup_stuck_jobs` / `cleanup_old_jobs` via `start_job_cleanup_service`) but no Docker entrypoint ever scheduled it.

## What

- Call `python manage.py start_job_cleanup_service` next to `start_cleaning_service` in:
  - `deploy/docker/backend/entrypoint.sh`
  - `deploy/docker/backend-gpu/entrypoint.sh`
  - `deploy/docker/unified/entrypoint.sh`
- Introduce `LongRunningJob.STUCK_JOB_HOURS` (24) and teach `cleanup_stuck_jobs` to also fail never-started orphans (`started_at` null, `queued_at` past the cutoff).
- Make `QueueAvailabilityView` ignore unfinished rows past that same threshold so the queue unblocks even before the hourly schedule fires.
- Delete unused `get_current_job()` from `api/api_util.py`.

Compose/k8s do not invoke these management commands; they rely on the entrypoints. The cancel UI from #1104 is left alone.

## Verification

- `ruff check` / `ruff format --check` clean on touched Python files
- 15 tests green under `librephotos.settings.test_sqlite`:
  - `api.tests.test_cleanup_stuck_jobs` (new)
  - `api.tests.test_queue_availability_stuck` (new)
  - `api.tests.test_cleanup_old_jobs_baseline`