### PR TITLE
ci: add a backend test job, and fix the tests that blocked it

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,0 +1,52 @@
+name: test-backend
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'apps/backend/**'
+      - '.github/workflows/test-backend.yml'
+  pull_request:
+    paths:
+      - 'apps/backend/**'
+      - '.github/workflows/test-backend.yml'
+
+jobs:
+  django:
+    runs-on: ubuntu-latest
+    # Measured on ubuntu-latest: ~5.5 min to install, ~2 min for the suite.
+    # 30 leaves room for a slow runner without letting a hang burn an hour.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # 3.11 here, but 3.14 in lint-backend.yml: ruff only parses the code
+          # while the tests import and execute it, so this must be a version the
+          # dependencies actually support. pyproject sets target-version = "py311".
+          python-version: "3.11"
+
+      - name: Install dependencies
+        working-directory: apps/backend
+        # The virtualenv is required, not tidiness. scripts/setup_test_env.sh
+        # falls back to `pip install --user` when VIRTUAL_ENV is unset, which
+        # puts the packages under $HOME. api/tests/test_repro_issue_907.py spawns
+        # a probe subprocess with HOME repointed at a sandbox (that is the whole
+        # point of the test: proving the matplotlib cache does not follow it),
+        # so a --user install is invisible to the probe and it dies with
+        # "ModuleNotFoundError: No module named 'django'".
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          bash scripts/setup_test_env.sh
+
+      - name: Run tests
+        working-directory: apps/backend
+        env:
+          BASE_LOGS: /tmp/librephotos/logs
+          BASE_DATA: /tmp/librephotos
+          SECRET_KEY: test-secret-key
+          DJANGO_SETTINGS_MODULE: librephotos.settings.test_sqlite
+        run: |
+          . .venv/bin/activate
+          python manage.py test api.tests

--- a/apps/backend/api/tests/test_dirtree.py
+++ b/apps/backend/api/tests/test_dirtree.py
@@ -1,3 +1,6 @@
+import os
+
+from django.conf import settings
 from django.test import TestCase
 from pyfakefs.fake_filesystem_unittest import Patcher
 from rest_framework.test import APIClient
@@ -20,8 +23,15 @@ class DirTreeTest(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_should_retrieve_dir_listing_by_path(self):
+        # The view only accepts paths inside settings.DATA_ROOT, and DATA_ROOT is
+        # os.path.join(BASE_DATA, "data") - "/data" only when BASE_DATA is unset
+        # or "/", i.e. inside the container. Ask for the real data root instead of
+        # the containerised spelling of it.
+        os.makedirs(settings.DATA_ROOT, exist_ok=True)
         self.client.force_authenticate(user=self.admin)
-        response = self.client.get("/api/dirtree/?path=/data")
+        # Pass the path as query data so the client url-encodes it: outside the
+        # container DATA_ROOT can contain characters that are not query-safe.
+        response = self.client.get("/api/dirtree/", {"path": settings.DATA_ROOT})
         self.assertEqual(200, response.status_code)
 
     def test_should_fail_when_listing_with_invalid_path(self):
@@ -34,12 +44,20 @@ class DirTreeTest(TestCase):
         )
 
     def test_children_list_should_be_alphabetical_case_insensitive(self):
+        # The view lists settings.DATA_ROOT, which is only "/data" inside the
+        # container, so the fixture directories have to be created under the
+        # configured data root. Read it before entering the Patcher: inside it
+        # every path lookup goes to the fake filesystem, and settings must not be
+        # resolved for the first time against a filesystem that has no real files.
+        data_root = settings.DATA_ROOT
+
         with Patcher() as patcher:
-            patcher.fs.create_dir("/data")
-            patcher.fs.create_dir("/data/Z")
-            patcher.fs.create_dir("/data/a")
-            patcher.fs.create_dir("/data/X")
-            patcher.fs.create_dir("/data/b")
+            # The fake filesystem starts out empty, so these have to be created
+            # through patcher.fs rather than on disk beforehand - anything the
+            # real filesystem holds is invisible in here.
+            patcher.fs.create_dir(data_root)
+            for name in ("Z", "a", "X", "b"):
+                patcher.fs.create_dir(os.path.join(data_root, name))
 
             self.client.force_authenticate(user=self.admin)
             response = self.client.get("/api/dirtree/")

--- a/apps/backend/api/tests/test_face_recognition_client.py
+++ b/apps/backend/api/tests/test_face_recognition_client.py
@@ -59,6 +59,7 @@ class FaceRecognitionClientTest(SimpleTestCase):
 
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "text/html"}
         mock_response.text = "<html>service error</html>"
         mock_response.raise_for_status.return_value = None
         mock_response.json.side_effect = ValueError("invalid json")
@@ -69,4 +70,9 @@ class FaceRecognitionClientTest(SimpleTestCase):
 
         self.assertIn("http://localhost:8005/face-locations", str(context.exception))
         self.assertIn("status 200", str(context.exception))
-        self.assertIn("<html>service error</html>", str(context.exception))
+        # The body has to reach the message so an operator can see what the
+        # service actually replied with, but an HTML error page is reduced to
+        # its visible text first — dumping a whole Flask 500 page into the log
+        # line is what _get_response_preview exists to prevent.
+        self.assertIn("service error", str(context.exception))
+        self.assertNotIn("<html>", str(context.exception))

--- a/apps/backend/api/tests/test_setup_directory.py
+++ b/apps/backend/api/tests/test_setup_directory.py
@@ -1,3 +1,6 @@
+import os
+
+from django.conf import settings
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -15,10 +18,15 @@ class SetupDirectoryTestCase(TestCase):
         )
 
     def test_setup_directory(self):
+        # UserSerializer.update accepts a scan directory only if it is inside
+        # settings.DATA_ROOT *and* exists on disk. DATA_ROOT is
+        # os.path.join(BASE_DATA, "data"), so "/data" is only correct inside the
+        # container; use the configured root and make sure it is really there.
+        os.makedirs(settings.DATA_ROOT, exist_ok=True)
         self.client.force_authenticate(user=self.admin)
         response = self.client.patch(
             f"/api/manage/user/{self.admin.id}/",
-            {"scan_directory": "/data"},
+            {"scan_directory": settings.DATA_ROOT},
         )
         self.assertEqual(response.status_code, 200)
 

--- a/apps/backend/api/tests/test_stack_review.py
+++ b/apps/backend/api/tests/test_stack_review.py
@@ -17,6 +17,7 @@ reviewable because:
 """
 
 import uuid
+from datetime import timedelta
 
 from django.test import TestCase
 from django.utils import timezone
@@ -121,6 +122,19 @@ class StackReviewModelTestCase(TestCase):
             stack=stack2,
             reviewer=self.user,
         )
+        # Space the two timestamps out by hand. created_at is auto_now_add, so
+        # back-to-back creates can land in the same clock tick, and the model
+        # orders on created_at alone - its pk is a random UUID, so it is no
+        # tiebreak - which left this test resolving a tie by coin flip. Use
+        # queryset.update() because auto_now_add ignores an assigned value.
+        now = timezone.now()
+        StackReview.objects.filter(pk=review1.pk).update(
+            created_at=now - timedelta(minutes=1)
+        )
+        StackReview.objects.filter(pk=review2.pk).update(created_at=now)
+        review1.refresh_from_db()
+        review2.refresh_from_db()
+
         reviews = list(StackReview.objects.all())
         # review2 was created later, should come first
         self.assertEqual(reviews[0], review2)


### PR DESCRIPTION
Follow-up to #1934, which had to drop its test job for exactly this reason.

Nothing has ever run the Django suite on a pull request — `.github/workflows/` holds only `lint-*`, `image-*`, `docs` and `mobile-cd`. The job can't just be added, because **five tests fail on `dev`**. Four baked in a deployment-specific path; the fifth is a coin flip.

## The four path-dependent tests

`DATA_ROOT` is `os.path.join(BASE_DATA, "data")`, so the literal `"/data"` is only correct when `BASE_DATA` is unset or `/` — i.e. inside the container. Under the invocation `apps/backend/CLAUDE.md` and `scripts/setup_test_env.sh` document, `DATA_ROOT` is `/tmp/librephotos/data` and these break:

- `test_dirtree.test_should_retrieve_dir_listing_by_path` — asks for `/data`, gets 403 because it really is outside the allowed directory
- `test_dirtree.test_children_list_should_be_alphabetical_case_insensitive` — builds its pyfakefs fixtures at `/data`, so the view lists an empty `DATA_ROOT` and the assertion dies on `IndexError`
- `test_setup_directory.test_setup_directory` — `UserSerializer.update` requires the scan directory to be inside `DATA_ROOT` *and* to exist

All three now derive the path from `settings.DATA_ROOT`, which is correct in both environments — in Docker it evaluates to exactly the `/data` they used to hardcode, so nothing is special-cased. No assertion was weakened; the siblings that assert 403/400 are untouched and still pass.

## The stale assertion

`test_face_recognition_client...invalid_json_response_body` asserted the raw `<html>service error</html>` body appears in the exception. It cannot — `_get_response_preview` passes HTML bodies through `_strip_html` first, and its docstring says why: a Flask error page should not be dumped whole into a log line.

Git history settles which side is wrong. `d70d62f9` added the helper *and* these tests together; `0bb44a38` ("return JSON error from face service instead of HTML 500") later added the HTML-stripping branch with **zero test changes**. The assertion has been stale since that commit, and the helper is deliberate. So the test changes, not the code:

```python
self.assertIn("service error", str(context.exception))
self.assertNotIn("<html>", str(context.exception))
```

That's a net increase in coverage — the body must still reach the message, and the stripping behaviour now has a test it never had.

## The flaky one

`test_stack_review.test_ordering_by_created_at_descending` failed **~1 run in 3**. `created_at` is `auto_now_add`, `Meta.ordering` is `["-created_at"]` alone, and the pk is a random UUID — so two reviews created in the same clock tick resolve by coin flip. It didn't show up in the first CI run, but nothing structurally prevents it on Linux; a tie is a tie at any clock resolution. This would have made the new job intermittently red, which is worse than no job at all.

The test now spaces the two timestamps explicitly (via `queryset.update()`, since `auto_now_add` ignores an assigned value): **14/14 runs pass**, from ~4/13 failing before.

> ⚠️ **This one is a real product property, not just a test artefact.** `StackReview` rows created in the same tick have no stable order, so they can shift between pages of a paginated response. I tried `ordering = ["-created_at", "-pk"]` first and reverted it — the pk is a UUID, so it makes ties deterministic but *arbitrary*, which fixes nothing. A proper sortable tiebreak needs a migration and a decision about what to sort on, so I've left it out and it's worth its own issue.

**Only tests changed. No application code.**

## The workflow

Installs into a virtualenv rather than the runner's Python. That isn't tidiness: `setup_test_env.sh` falls back to `pip install --user` when `VIRTUAL_ENV` is unset, putting packages under `$HOME`, and `test_repro_issue_907` deliberately spawns a probe with `HOME` repointed at a sandbox — which then can't import Django at all. That was the failure mode of the first real run on #1934.

Python 3.11 rather than `lint-backend.yml`'s 3.14, because ruff only parses the code while the tests import and execute it. Timings measured on a real runner: ~5.5 min to install, ~2 min for the suite, hence `timeout-minutes: 30`.

## Verification

| | tests | failures | errors |
|---|---|---|---|
| `dev` | 1673 | 5 | 3 |
| this branch | 1673 | 1 | 2 |

The three remaining are Windows-only and don't apply to the Linux runner: `test_trash_api` ×2 (the test `print()`s U+2705 through cp1252) and `test_live_photo.test_finds_uppercase_mov_companion` (case-insensitive filesystem). `ruff check` and `ruff format --check` clean on 333 files.

The job on this PR is the real proof — if it's green, the suite gates every backend PR from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
