### PR TITLE
fix: order equal-timestamp photos by filename

### DIFF
--- a/apps/backend/api/tests/test_album_date_photo_ordering.py
+++ b/apps/backend/api/tests/test_album_date_photo_ordering.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.models import AlbumDate
+from api.tests.utils import create_test_photo, create_test_user
+
+
+class AlbumDatePhotoOrderingTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        timestamp = timezone.now()
+        self.photos_by_filename = {}
+
+        for filename in ("d.png", "b.png", "a.png", "c.png"):
+            photo = create_test_photo(owner=self.user, exif_timestamp=timestamp)
+            photo.main_file.path = f"/tmp/{filename}"
+            photo.main_file.save(update_fields=["path"])
+            self.photos_by_filename[filename] = photo
+
+        self.album = AlbumDate.objects.create(
+            date=timestamp.date(),
+            owner=self.user,
+        )
+        self.album.photos.add(*self.photos_by_filename.values())
+
+    def _page_hashes(self, page):
+        response = self.client.get(
+            f"/api/albums/date/{self.album.id}/",
+            {"page": page, "size": 2},
+        )
+        self.assertEqual(response.status_code, 200)
+        return [item["image_hash"] for item in response.json()["results"]["items"]]
+
+    def test_equal_timestamps_are_ordered_before_pagination(self):
+        hashes = self._page_hashes(1) + self._page_hashes(2)
+
+        self.assertEqual(
+            hashes,
+            [
+                self.photos_by_filename[filename].image_hash
+                for filename in ("a.png", "b.png", "c.png", "d.png")
+            ],
+        )

--- a/apps/backend/api/views/albums.py
+++ b/apps/backend/api/views/albums.py
@@ -508,7 +508,7 @@ class AlbumDateViewSet(viewsets.ModelViewSet):
         photo_qs = _with_photo_summary_relations(
             album_date.photos.filter(*photo_filter)
             .distinct()  # Remove duplicates that can occur when filtering through reverse ForeignKey relationships (e.g., faces__person__id)
-            .order_by("-exif_timestamp")
+            .order_by("-exif_timestamp", "main_file__path")
         )
 
         # Paginate photo queryset


### PR DESCRIPTION
## Summary

- order equal-timestamp AlbumDate photos by their main file path at the queryset level
- apply the tie-break before pagination so ordering remains stable across page boundaries
- add endpoint regression coverage spanning two pages

Fixes #563

## Performance

The ordering stays in the existing database query and is applied before `Paginator` slices it. `Photo.exif_timestamp` is indexed, `File.path` has a unique index, and the change does not materialize or sort the album in Python.

## Testing

- `ruff check apps/backend/api/views/albums.py apps/backend/api/tests/test_album_date_photo_ordering.py`
- `ruff format --check apps/backend/api/views/albums.py apps/backend/api/tests/test_album_date_photo_ordering.py`
- `python -m compileall -q apps/backend/api/views/albums.py apps/backend/api/tests/test_album_date_photo_ordering.py`

The Django endpoint test could not run locally because the Windows environment lacks the native `libvips-42.dll`. The PR remains a draft for the repository's backend CI to run the complete test environment.