### PR TITLE
docs: reconcile the documentation with the code

### DIFF
--- a/apps/docs/docs/development/contribution/backend/index.md
+++ b/apps/docs/docs/development/contribution/backend/index.md
@@ -1,8 +1,8 @@
 ---
 title: "☁️ Backend"
-excerpt: "Development Information regarding LibrePhotos Backend."
+description: "Development Information regarding LibrePhotos Backend."
+sidebar_position: 1
 last_modified_at: 2020-08-04
-category: 5
 ---
 
 The backend uses the following technologies:
@@ -13,9 +13,9 @@ The backend uses the following technologies:
 
 ## ✨ Code Standards
 
-In order to have a similar structure to the code, the backend repository has a pre-commit hook. Just use pre-commit install in the folder and then the linter and the formatter will check it before you commit your actual work.
+In order to keep the code consistently structured, the backend has a pre-commit hook. Run `pre-commit install` from `apps/backend/` and the linter and the formatter will check your work before you commit.
 
-We use black, flake8 and isort to keep our code tidy.
+We use [ruff](https://docs.astral.sh/ruff/) for both linting and formatting, configured in `apps/backend/pyproject.toml`. You can also run it by hand with `ruff check .` and `ruff format .`.
 
 ## 🐛 Debugging
 
@@ -45,7 +45,7 @@ In order to debug queries, start the backend container in dev mode. Then you can
 
 ## 🏙️ Structure
 
-There are a lot of folders in our backend. Here is a quick rundown on where you can find what.
+There are a lot of folders in our backend. Here is a quick rundown on where you can find what. The Django project itself — settings (`librephotos/settings/`), URL routing (`librephotos/urls.py`) and `wsgi.py` — lives in the `librephotos/` folder, with supporting pieces in `scripts/`, `chunked_upload/` and `nextcloud/`.
 
 ### Django
 
@@ -67,17 +67,31 @@ Here are the actual data types. If you want to figure out how a photo works or h
 
 Here you can find our API implemented. They are separated, similar to the models. Views that expose the photos will be here in photos too.
 
-#### serializer
+#### serializers
 
 You have your python model and want to somehow convert that to JSON. That's what the serializer does!
+
+### Services
+
+Not everything runs inside Django. The heavy machine-learning work lives in standalone Flask processes that Django talks to over plain HTTP on localhost. Seven of them sit under `service/` — `thumbnail`, `face_recognition`, `clip_embeddings`, `image_captioning`, `llm`, `exif` and `tags` — and `image_similarity/` is a separate top-level folder. Each is served by a gevent `WSGIServer` on a fixed port; the ports are defined in the `SERVICES` dict in `api/services.py` (image_similarity 8002, thumbnail 8003, face_recognition 8005, clip_embeddings 8006, image_captioning 8007, llm 8008, exif 8010, tags 8011).
+
+You start them with `python manage.py start_service`, which also schedules `api.services.check_services` in django-q2 to poll each service's `/health` endpoint and restart any that have gone stale or died. The `llm` service additionally needs certain CPU features (`avx`, `sse4_2`) and is skipped on hardware that lacks them.
+
+Because these are separate processes, the `docker attach` + pdb trick above does not reach them — to debug a service, check its log under `/logs/` or add logging in the service's own `main.py`.
 
 ### Machine Learning
 
 We use as a base framework PyTorch. If you find a cool machine learning model with PyTorch, we sure can add that too.
 
-#### im2txt
+#### Image Captioning
 
-im2txt is an image captioning package which allows us to generate captions on demand. This sometimes creates useful output, but it is kind of old and there should be more recent models
+Captions are generated on demand by the image captioning service (`service/image_captioning/`, port 8007). The model is chosen with the `Captioning Model` site setting (`im2txt` by default, or `none` to turn caption generation off):
+
+- **im2txt** — the original PyTorch captioning model. It still works, though its output is fairly basic.
+- **blip_base_capfilt_large** (BLIP) — a newer captioning model. It is not a separate service; it lives inside the image captioning service at `service/image_captioning/api/im2txt/blip/` and is selected by passing `blip=True` through to the model.
+- **moondream** — a visual LLM. This one does not go through the captioning service at all: `api/image_captioning.py` routes it to the `llm` service (port 8008).
+
+Whichever model runs, the caption is stored under the `"im2txt"` key in `PhotoCaption.captions_json`, and if an LLM is enabled it can post-process the caption before it is saved. For the user-facing comparison of these models, see the [image captioning guide](../../../user-guide/image-captioning.md).
 
 #### Face Recognition
 
@@ -85,7 +99,7 @@ We use [InsightFace](https://github.com/deepinsight/insightface) to detect and r
 
 #### Tagging Models
 
-The tags service (`service/tags/`) generates auto-tags for photos. Three models are available, selectable via the Tagging Model site setting:
+The tags service (`service/tags/`) generates auto-tags for photos. Two models are available, selectable via the Tagging Model site setting:
 
 - **places365** — Scene classification using the Places365 CNN. Generates scene category tags (e.g. "kitchen", "beach").
 - **siglip2** (`service/tags/siglip2/`) — Google's SigLIP 2 vision-language model running as ONNX. Uses zero-shot classification by computing cosine similarity between image embeddings and a curated vocabulary of 900+ text tag embeddings. Tag embeddings are cached to disk after the first run. Returns the top 10 tags.

--- a/apps/docs/docs/development/contribution/backend/missing-photos.md
+++ b/apps/docs/docs/development/contribution/backend/missing-photos.md
@@ -1,7 +1,7 @@
 ---
 title: "Missing Photos Implementation"
-excerpt: "Technical documentation for the missing photos feature"
-category: 5
+description: "Technical documentation for the missing photos feature"
+sidebar_position: 4
 ---
 
 ## Overview
@@ -14,39 +14,47 @@ The missing photos feature in LibrePhotos handles cases where photo files become
 
 #### File Model
 
-Located in `librephotos/api/models/file.py`, the `File` model represents individual files on disk:
+Located in `apps/backend/api/models/file.py`, the `File` model represents individual files on disk:
 
 ```python
 class File(models.Model):
     hash = models.CharField(primary_key=True, max_length=64)
-    path = models.TextField(blank=True, default="")
+    path = models.TextField(blank=True, default="", unique=True)
     type = models.PositiveIntegerField(choices=FILE_TYPES)
     missing = models.BooleanField(default=False)  # Tracks if file is missing
-    embedded_media = models.ManyToManyField("File")
+    embedded_media = models.ManyToManyField("self", symmetrical=False)
 ```
 
 Key fields:
 - `hash`: MD5 hash of file content + user ID (primary key)
-- `path`: Full file system path
+- `path`: Full file system path. It carries `unique=True`, which is load-bearing here: `File.create` looks a file up by `path` and reuses the existing row instead of creating a duplicate when a file reappears.
 - `missing`: Boolean flag indicating if the file cannot be found
 - `type`: File type (IMAGE, VIDEO, METADATA_FILE, RAW_FILE, UNKNOWN)
 
 #### Photo Model
 
-Located in `librephotos/api/models/photo.py`, the `Photo` model has relationships to files:
+Located in `apps/backend/api/models/photo.py`, the `Photo` model has relationships to files:
 
 ```python
 class Photo(models.Model):
-    image_hash = models.CharField(primary_key=True, max_length=64)
+    # UUID primary key - enables flexible asset management
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    # Content hash for deduplication (MD5 of file content + user ID)
+    image_hash = models.CharField(max_length=64, db_index=True)
+
     files = models.ManyToManyField(File)  # All associated files
     main_file = models.ForeignKey(
         File,
         related_name="main_photo",
         on_delete=models.SET_NULL,
+        blank=False,
         null=True,
     )
     # ... other fields
 ```
+
+The primary key is the UUID `id`, not `image_hash`. `image_hash` is an indexed but **non-unique** `CharField`: the database declares no `unique=True`, `unique_together`, or `UniqueConstraint` on it. Uniqueness per user is a property of how the hash is built (MD5 of content + the user's id), not a constraint the database enforces. Always look photos up as `Photo.objects.filter(image_hash=hash, owner=user)` — never `Photo.objects.get(pk=image_hash)`.
 
 **A photo is considered missing when:**
 - `files=None` (no associated files), OR
@@ -55,15 +63,17 @@ class Photo(models.Model):
 Query for missing photos:
 ```python
 missing_photos = Photo.objects.filter(
-    Q(owner=user) & Q(files=None) | Q(main_file=None)
+    Q(owner=user) & (Q(files=None) | Q(main_file=None))
 )
 ```
+
+The parentheses are load-bearing. Without them, Python's `&`-before-`|` precedence parses the filter as `(Q(owner=user) & Q(files=None)) | Q(main_file=None)`, which leaves the `main_file=None` branch unscoped and matches **every** user's photos — a cross-user data leak.
 
 ### Detection Mechanism
 
 #### _check_files() Method
 
-The `Photo._check_files()` method (lines 508-514 in `librephotos/api/models/photo.py`) is the core detection mechanism:
+The `Photo._check_files()` method in `apps/backend/api/models/photo.py` is the core detection mechanism:
 
 ```python
 def _check_files(self):
@@ -81,10 +91,12 @@ This method:
 3. If missing, removes the file from the photo and sets `file.missing = True`
 4. Saves changes to the database
 
+Note that it removes a vanished file from `photo.files` but deliberately leaves `main_file` pointing at it — this matters for relinking (see [Relinking Process](#relinking-process)).
+
 **When is this called?**
-- During photo scans (`scan_missing_photos` job)
-- When adding new files to existing photos
-- After detecting duplicate photos during import
+- Only during the `scan_missing_photos` job (`apps/backend/api/directory_watcher/scan_jobs.py`). This is the sole production call site.
+
+The inverse — clearing the `missing` flag when a file reappears — is handled independently by `File.create` in `apps/backend/api/models/file.py`, not by `_check_files()`.
 
 ## Jobs
 
@@ -92,83 +104,107 @@ This method:
 
 **Type**: `JOB_SCAN_MISSING_PHOTOS` (job type 14)
 
-**Function**: `scan_missing_photos(user, job_id)` in `librephotos/api/directory_watcher.py:356-386`
+**Function**: `scan_missing_photos(user, job_id)` in `apps/backend/api/directory_watcher/scan_jobs.py`
 
 **Purpose**: Checks all photos owned by a user to detect missing files
 
 **Implementation**:
 ```python
 def scan_missing_photos(user, job_id: UUID):
-    # Create or update job entry
-    lrj = LongRunningJob.objects.create(
-        started_by=user,
-        job_id=job_id,
+    lrj = LongRunningJob.get_or_create_job(
+        user=user,
         job_type=LongRunningJob.JOB_SCAN_MISSING_PHOTOS,
+        job_id=job_id,
     )
-    
-    # Get all photos for user
-    existing_photos = Photo.objects.filter(owner=user.id).order_by("image_hash")
-    
-    # Process in batches of 5000 for memory efficiency
-    paginator = Paginator(existing_photos, 5000)
-    lrj.progress_target = paginator.num_pages
-    
-    for page in range(1, paginator.num_pages + 1):
-        for existing_photo in paginator.page(page).object_list:
-            existing_photo._check_files()  # Check each photo's files
-        update_scan_counter(job_id)
+    try:
+        existing_photos = Photo.objects.filter(owner=user.id).order_by("image_hash")
+
+        paginator = Paginator(existing_photos, 5000)
+        lrj.update_progress(current=0, target=paginator.num_pages)
+        for page in range(1, paginator.num_pages + 1):
+            # Allow the job to be cancelled from the UI between pages
+            if is_job_cancelled(job_id):
+                util.logger.info("Scan missing photos job cancelled")
+                return
+            for existing_photo in paginator.page(page).object_list:
+                existing_photo._check_files()
+
+            update_scan_counter(job_id)
+    except Exception as e:
+        util.logger.exception("An error occurred: ")
+        lrj.fail(error=e)
 ```
 
 **Key features**:
-- Processes photos in batches of 5,000 to manage memory
-- Updates progress counter for UI feedback
-- Automatically triggered after full scans if not scanning specific files
+- Processes photos in batches of 5,000 to manage memory.
+- Obtains the job via `LongRunningJob.get_or_create_job()` so an already-queued job row is reused and started rather than duplicated (`job_id` is unique).
+- Reports progress via `lrj.update_progress(current, target)`, which persists the counters for UI feedback.
+- Polls `is_job_cancelled(job_id)` (`apps/backend/api/directory_watcher/utils.py`) once per page, so the job can be cancelled from the UI mid-run.
+- Any exception marks the job failed via `lrj.fail(error=e)`.
+- Automatically triggered after full scans if not scanning specific files.
 
 ### Delete Missing Photos Job
 
 **Type**: `JOB_DELETE_MISSING_PHOTOS` (job type 5)
 
-**Function**: `delete_missing_photos(user, job_id)` in `librephotos/api/autoalbum.py:188-232`
+**Function**: `delete_missing_photos(user, job_id)` in `apps/backend/api/autoalbum.py`
 
 **Purpose**: Permanently removes missing photos and their associated data from the database
 
 **Implementation**:
 ```python
 def delete_missing_photos(user, job_id):
-    # Find all photos with no files or no main file
-    missing_photos = Photo.objects.filter(
-        Q(owner=user) & Q(files=None) | Q(main_file=None)
+    lrj = LongRunningJob.get_or_create_job(
+        user=user,
+        job_type=LongRunningJob.JOB_DELETE_MISSING_PHOTOS,
+        job_id=job_id,
     )
-    
-    # Remove from all album types
-    for missing_photo in missing_photos:
-        album_dates = AlbumDate.objects.filter(photos=missing_photo)
-        for album_date in album_dates:
-            album_date.photos.remove(missing_photo)
-        
-        album_things = AlbumThing.objects.filter(photos=missing_photo)
-        for album_thing in album_things:
-            album_thing.photos.remove(missing_photo)
-        
-        album_places = AlbumPlace.objects.filter(photos=missing_photo)
-        for album_place in album_places:
-            album_place.photos.remove(missing_photo)
-        
-        album_users = AlbumUser.objects.filter(photos=missing_photo)
-        for album_user in album_users:
-            album_user.photos.remove(missing_photo)
-        
-        # Delete associated faces
-        faces = Face.objects.filter(photo=missing_photo)
-        faces.delete()
-    
-    # Delete the photos
-    missing_photos.delete()
-    
-    # Delete missing file records
-    missing_files = File.objects.filter(Q(hash__endswith=user) & Q(missing=True))
-    missing_files.delete()
+    try:
+        missing_pks = list(
+            Photo.objects.filter(
+                Q(owner=user) & (Q(files=None) | Q(main_file=None))
+            ).values_list("pk", flat=True)
+        )
+        target = len(missing_pks)
+        lrj.update_progress(current=0, target=target)
+
+        # Delete in batches to bound peak memory. Album through-rows and Face
+        # rows are removed by DB cascade on Photo.delete(); only AlbumThing
+        # needs its photo_count / cover photos refreshed afterwards, because
+        # cascade bypasses its m2m_changed receiver.
+        affected_album_thing_ids: set[int] = set()
+        for start in range(0, target, _DELETE_MISSING_BATCH_SIZE):
+            batch_pks = missing_pks[start : start + _DELETE_MISSING_BATCH_SIZE]
+            batch_qs = Photo.objects.filter(pk__in=batch_pks)
+            affected_album_thing_ids.update(
+                AlbumThing.objects.filter(photos__in=batch_qs).values_list(
+                    "id", flat=True
+                )
+            )
+            batch_qs.delete()
+            lrj.update_progress(current=start + len(batch_pks), target=target)
+
+        for album_thing in AlbumThing.objects.filter(id__in=affected_album_thing_ids):
+            album_thing.photo_count = album_thing.photos.filter(hidden=False).count()
+            album_thing.save(update_fields=["photo_count"])
+            album_thing.update_default_cover_photo()
+
+        # File.hash is `md5 + str(user.id)`, so the user's missing files are
+        # identified by that suffix.
+        File.objects.filter(
+            Q(hash__endswith=str(user.id)) & Q(missing=True)
+        ).delete()
+
+        lrj.complete()
+    except Exception as e:
+        logger.exception("An error occurred")
+        lrj.fail(error=e)
 ```
+
+Notes on the implementation:
+- The missing-photo query is parenthesised, so both OR branches are scoped to the requesting user.
+- Photos are deleted in batches of `_DELETE_MISSING_BATCH_SIZE` (200) to bound peak memory.
+- The file cleanup filter uses `str(user.id)`, because `File.hash` is `md5 + str(user.id)`. Passing the `User` instance would stringify to the username and match nothing.
 
 **What gets deleted**:
 - Photo records from database
@@ -179,8 +215,10 @@ def delete_missing_photos(user, job_id):
 - Associations with user-created albums
 - Face detections linked to the photos
 
+Album associations and face detections are removed by database cascade on `Photo.delete()` (`Face.photo` is `on_delete=CASCADE`), not by explicit per-photo loops. `AlbumThing` is the one exception: its `photo_count` and cover photos are maintained by an `m2m_changed` receiver that cascade bypasses, so affected `AlbumThing` ids are snapshotted per batch and refreshed afterwards.
+
 **What doesn't get deleted (TODO)**:
-- Thumbnail files (line 221 notes: "To-Do: Remove thumbnails")
+- Thumbnail files on disk (see [Known Issues and TODOs](#known-issues-and-todos)).
 
 ## API Endpoints
 
@@ -188,14 +226,24 @@ def delete_missing_photos(user, job_id):
 
 **Endpoint**: `POST /api/deletemissingphotos`
 
-**Implementation**: `DeleteMissingPhotosView` in `librephotos/api/views/views.py:433-451`
+**Implementation**: `DeleteMissingPhotosView` in `apps/backend/api/views/views.py`
 
 ```python
 class DeleteMissingPhotosView(APIView):
     def post(self, request, format=None):
+        return self._delete_missing_photos(request, format)
+
+    @extend_schema(
+        deprecated=True,
+        description="Use POST method instead",
+    )
+    def get(self, request, format=None):
+        return self._delete_missing_photos(request, format)
+
+    def _delete_missing_photos(self, request, format=None):
         try:
             job_id = uuid.uuid4()
-            delete_missing_photos(request.user, job_id)
+            AsyncTask(delete_missing_photos, request.user, job_id).run()
             return Response({"status": True, "job_id": job_id})
         except BaseException:
             logger.exception("An Error occurred")
@@ -210,13 +258,15 @@ class DeleteMissingPhotosView(APIView):
 }
 ```
 
-**Note**: Also supports GET method (deprecated) for backward compatibility.
+The deletion runs as a background django-q2 task (`AsyncTask(...).run()`), so the `200` is returned as soon as the task is queued — not when the sweep finishes. Track progress on the `LongRunningJob` identified by the returned `job_id` and poll it rather than treating the response as completion.
+
+**Note**: Also supports GET (deprecated) for backward compatibility; both methods delegate to the same `_delete_missing_photos` helper.
 
 ### Photo Statistics
 
 Missing photo count is included in the user statistics API response.
 
-**Calculation**: `get_count_stats(user)` in `librephotos/api/stats.py:382-384`
+**Calculation**: `get_count_stats(user)` in `apps/backend/api/stats.py`
 
 ```python
 num_missing_photos = Photo.objects.filter(
@@ -233,13 +283,17 @@ Returned in stats response as:
 }
 ```
 
+:::note
+Unlike `delete_missing_photos`, this count still uses the **unparenthesised** filter. Because of Python's `&`-before-`|` precedence it evaluates as `(Q(owner=user) & Q(files=None)) | Q(main_file=None)`, so `num_missing_photos` over-counts by including other users' photos that have `main_file=None`. This is a known bug in `stats.py`; the parenthesised, owner-scoped form used by `delete_missing_photos` is the correct one.
+:::
+
 ## Hash-Based Relinking
 
 ### How It Works
 
-When files reappear in the scanned directories (even with different names or paths), LibrePhotos can automatically relink them using hash-based matching.
+When files reappear in the scanned directories, LibrePhotos reconnects them to their existing photo metadata rather than creating duplicate photos. A `File` is identified by a content hash (`File.hash` is `md5(content) + str(user.id)`, the primary key) and also carries a unique `path`, so a file that comes back is matched to the record it had before — even if it was renamed or moved within the scanned directories.
 
-**Hash Calculation**: `calculate_hash(user, path)` in `librephotos/api/models/file.py:136-145`
+**Hash Calculation**: `calculate_hash(user, path)` in `apps/backend/api/models/file.py`
 
 ```python
 def calculate_hash(user, path):
@@ -248,6 +302,7 @@ def calculate_hash(user, path):
         for chunk in iter(lambda: f.read(BUFFER_SIZE), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest() + str(user.id)
+    # ... error handling
 ```
 
 **Key points**:
@@ -257,77 +312,87 @@ def calculate_hash(user, path):
 
 ### Relinking Process
 
-**Function**: `create_new_image(user, path)` in `librephotos/api/directory_watcher.py:62-136`
+Relinking during a scan is driven by two independent pieces of the two-phase scan in `apps/backend/api/directory_watcher/`, not by a `Photo.image_hash` lookup:
 
-```python
-def create_new_image(user, path) -> Photo | None:
-    # Calculate hash for the file
-    hash = calculate_hash(user, path)
-    
-    # Check if photo with this hash already exists
-    photos: QuerySet[Photo] = Photo.objects.filter(image_hash=hash, owner=user)
-    
-    if not photos.exists():
-        # Create new photo
-        photo = Photo()
-        photo.image_hash = hash
-        # ... initialize photo
-    else:
-        # Photo exists - add this file to it (relinking)
-        file = File.create(path, user)
-        photo = photos.first()
-        photo.files.add(file)
-        
-        # Restore if previously marked as removed
-        if photo.removed:
-            photo.removed = False
-            photo.in_trashcan = False
-        
-        photo.save()
-        photo._check_files()  # Verify all files still exist
-        
-    return photo
-```
+1. **`File.create`** (`apps/backend/api/models/file.py`) looks a record up by its unique `path`. If the existing record is flagged `missing` while the file is back on disk, it clears the flag:
 
-**Relinking behavior**:
-1. Calculate hash of discovered file
-2. Query for existing photos with same hash
-3. If found, add new file to existing photo
-4. Restore photo if it was marked as removed
-5. Run `_check_files()` to clean up any still-missing files
+   ```python
+   existing = File.objects.filter(path=path).first()
+   if existing:
+       if existing.missing and os.path.exists(path):
+           existing.missing = False
+           existing.save(update_fields=["missing"])
+       return existing
+   ```
+
+2. **`group_files_into_photo`** (`apps/backend/api/directory_watcher/file_handlers.py`) re-adopts the original `Photo` instead of creating a new one:
+
+   ```python
+   existing_photo = Photo.objects.filter(
+       Q(owner=user) & (Q(files__in=files) | Q(main_file__in=files))
+   ).first()
+   ```
+
+   If a match is found, any files not already attached are added to it, and `main_file` is upgraded when a higher-priority variant appeared (per `FILE_TYPE_PRIORITY`). Only when no match exists is a new `Photo` created.
+
+The `Q(main_file__in=files)` arm is the load-bearing part. `_check_files()` detaches a missing file from `photo.files` but leaves `main_file` pointing at it, so matching on `main_file` is what stops a reappearing file from spawning a duplicate `Photo` with the same `image_hash`.
+
+:::note
+`create_new_image` (`apps/backend/api/directory_watcher/file_handlers.py`) is the legacy single-file path, kept for uploads and the XMP-sidecar branch. It performs no `image_hash` lookup, no `removed`/`in_trashcan` restoration, and no `_check_files()` call — none of that relinking logic lives there any more. The behaviour above is exercised by `apps/backend/api/tests/test_missing_file_reappearance.py`.
+:::
 
 ## Frontend Integration
 
 ### Photo Serializer
 
-**File**: `librephotos/api/serializers/photos.py:348`
+**File**: `apps/backend/api/serializers/photos.py`
 
-The serializer includes a "Missing" label for photos without files:
+`get_image_path` builds the list of file paths for a photo:
 
 ```python
 def get_image_path(self, obj) -> list[str]:
-    if not obj.files or obj.files.count() == 0:
+    try:
+        paths = []
+        for file in obj.files.all():
+            paths.append(file.path)
+        return paths
+    except Exception:
         return ["Missing"]
-    return [file.path for file in obj.files.all()]
 ```
 
-This ensures the frontend can display appropriate UI for missing photos.
+`Photo.files` is a `ManyToManyField(File)`, and `_check_files()` removes vanished files from that relation. A photo whose files have all gone missing therefore serializes `image_path` as an **empty list** `[]`. The `["Missing"]` value is only an error fallback for an unexpected exception — it is not the normal missing-photo signal.
+
+The frontend detects the missing case by an empty array. `VersionComponent.tsx` and `routes/_protected/photo.$id.tsx` guard on `photoDetail.image_path && photoDetail.image_path.length > 0`, and `MediaDisplay.tsx` guards on `!photoDetails?.image_path || !Array.isArray(photoDetails.image_path)`.
 
 ### Video Error Handling
 
-**File**: `apps/frontend/src/components/lightbox/MediaDisplay.tsx:64-69`
+**File**: `apps/frontend/src/components/lightbox/VideoPlayer.tsx`
 
-The frontend displays an error alert when video files are missing:
+`MediaDisplay` builds the media URL (`/media/photos/<hash>.mp4` for videos, `/media/embedded_media/<hash>` for embedded media) and hands it to `VideoPlayer`. When the backend cannot serve the file, the `<video>` element's `onError` handler sets an error state and `VideoPlayer` renders a red alert over the still-available thumbnail poster, with a Retry button:
 
 ```tsx
-if (videoError) {
+if (error) {
   return (
-    <Alert color="red" title="Video Not Found">
-      <Text>The video file could not be found or is no longer available.</Text>
-    </Alert>
+    <div style={{ backgroundImage: posterUrl ? `url(${posterUrl})` : undefined, /* ... */ }}>
+      <Alert color="red" title="Video Unavailable">
+        <Text size="sm">The video file could not be loaded. It may be missing, unsupported, or unavailable.</Text>
+        <Button variant="light" color="red" size="xs" mt="sm" onClick={handleRetry}>Retry</Button>
+      </Alert>
+    </div>
   );
 }
 ```
+
+### Settings UI
+
+The user-facing entry point for deleting missing photos is on the Library settings page (`apps/frontend/src/components/settings/Library.tsx`, reached via the `/library` route):
+
+- A red badge renders only when `countStats.num_missing_photos > 0` (from `useFetchCountStatsQuery`, i.e. the same `num_missing_photos` stat described in [Photo Statistics](#photo-statistics)). The badge label comes from the `settings.missingphotos` translation key ("Missing Photos"), and it sits inside a Mantine `HoverCard` whose dropdown (`settings.missingphotosdescription`) explains the feature.
+- Clicking the badge opens a `Modal` titled `settings.missingphotosbutton` ("Remove missing photos") with Cancel / Confirm. Confirm calls `deleteMissingPhotos.mutate()` and then closes the modal.
+- The mutation lives in `apps/frontend/src/api_client/photos/hooks/useDeleteMissingPhotosMutation.ts`. It `POST`s to `/deletemissingphotos` (the `/api` prefix comes from the fetch client base URL), validates the `{ status, job_id }` response with zod, and on success invalidates the auto-albums, date-albums, recently-added, count-stats, and photo-month-count query keys — worth knowing which cached views go stale after a delete.
+- The same action is also exposed through the Spotlight command palette (`apps/frontend/src/components/spotlight/useSpotlightActions.ts`, action id `action-delete-missing`, label key `spotlight.actions.deleteMissing`). It fires the same mutation directly with no confirmation modal and is disabled when the worker queue cannot accept a job.
+
+The English strings `settings.missingphotos`, `settings.missingphotosbutton`, and `settings.missingphotosdescription` live in `apps/frontend/src/locales/en/translation.json`; other locales come from Weblate.
 
 ## Future Implementation
 
@@ -370,15 +435,17 @@ if (videoError) {
 
 ### Current TODOs
 
-1. **Remove thumbnails** (line 221 in `autoalbum.py`)
-   - When deleting missing photos, thumbnail files are not removed
-   - Thumbnails remain in `data/thumbnails/` directory
-   - Should be cleaned up to free disk space
+1. **Remove thumbnails** (not implemented in `delete_missing_photos`)
+   - `Thumbnail` rows are cascade-deleted with the `Photo` (`Thumbnail.photo` is a `OneToOneField(..., on_delete=CASCADE, primary_key=True)`), but the files on disk are left behind — there is no `post_delete` receiver for `Thumbnail`.
+   - Orphaned files remain under `MEDIA_ROOT` (`$BASE_DATA/protected_media/`), named by `image_hash`, in:
+     - `thumbnails_big/` (`.webp`)
+     - `square_thumbnails/` (`.webp`, plus `.mp4` for video previews)
+     - `square_thumbnails_small/` (`.webp`, plus `.mp4` for video previews)
+   - Should be cleaned up to free disk space.
 
-2. **Move delete_missing_photos function** (line 187 in `autoalbum.py`)
-   - Currently in `autoalbum.py` but doesn't belong there
-   - Should be moved to appropriate module (e.g., `photo_operations.py` or similar)
-   - Comment says: "To-Do: This does not belong here"
+2. **Move delete_missing_photos function** (`autoalbum.py`)
+   - The function carries a `# To-Do: This does not belong here` comment.
+   - It should be moved to a more appropriate module (e.g. `photo_operations.py` or similar).
 
 ### Edge Cases
 
@@ -392,23 +459,39 @@ if (videoError) {
 ### Key Files
 
 - **Models**:
-  - `librephotos/api/models/file.py` - File model with missing flag
-  - `librephotos/api/models/photo.py` - Photo model and `_check_files()` method
-  - `librephotos/api/models/long_running_job.py` - Job type definitions
+  - `apps/backend/api/models/file.py` — `File` model (`missing` flag, unique `path`, `calculate_hash`)
+  - `apps/backend/api/models/photo.py` — `Photo` model and `_check_files()` method
+  - `apps/backend/api/models/long_running_job.py` — job type definitions
+  - `apps/backend/api/models/thumbnail.py` — thumbnail records (cascade-deleted with the photo; files are not)
 
 - **Business Logic**:
-  - `librephotos/api/directory_watcher.py` - Scanning and relinking logic
-  - `librephotos/api/autoalbum.py` - Delete missing photos function
+  - `apps/backend/api/directory_watcher/` — scanning and relinking (a package implementing the two-phase scan):
+    - `scan_jobs.py` — `scan_photos`, `scan_missing_photos`
+    - `file_handlers.py` — Phase 1 `create_file_record`, Phase 2 `group_files_into_photo`, legacy `create_new_image`
+    - `file_grouping.py` — grouping key, `select_main_file`, `FILE_TYPE_PRIORITY`
+    - `processing_jobs.py`, `repair_jobs.py`, `utils.py`
+    - `__init__.py` re-exports the public names, so existing `from api.directory_watcher import ...` imports still work
+  - `apps/backend/api/autoalbum.py` — `delete_missing_photos` function
 
 - **API Views**:
-  - `librephotos/api/views/views.py` - Delete missing photos endpoint
-  - `librephotos/api/views/photos.py` - Photo operations
+  - `apps/backend/api/views/views.py` — delete missing photos endpoint
+  - `apps/backend/api/views/photos.py` — photo operations
 
 - **Statistics**:
-  - `librephotos/api/stats.py` - Count calculations including missing photos
+  - `apps/backend/api/stats.py` — count calculations including missing photos
 
 - **Serializers**:
-  - `librephotos/api/serializers/photos.py` - Photo serialization with "Missing" label
+  - `apps/backend/api/serializers/photos.py` — photo serialization (`get_image_path`)
+
+- **Frontend**:
+  - `apps/frontend/src/components/settings/Library.tsx` — missing-photos badge and confirmation modal
+  - `apps/frontend/src/api_client/photos/hooks/useDeleteMissingPhotosMutation.ts` — `POST /deletemissingphotos` and cache invalidation
+  - `apps/frontend/src/components/spotlight/useSpotlightActions.ts` — Spotlight "Delete Missing Photos" action
+  - `apps/frontend/src/components/lightbox/VideoPlayer.tsx` — video load-error UI
+
+- **Tests**:
+  - `apps/backend/api/tests/test_delete_missing_photos.py`
+  - `apps/backend/api/tests/test_missing_file_reappearance.py`
 
 ## Testing Considerations
 
@@ -422,9 +505,23 @@ When testing missing photos functionality:
 6. **Verify relinking**: Ensure photos automatically relink
 7. **Delete**: Test permanent deletion with `delete_missing_photos`
 
+### Automated tests
+
+The behaviour above is covered by two test modules; extend them when changing this code:
+
+- `apps/backend/api/tests/test_delete_missing_photos.py` — the `delete_missing_photos` sweep: per-user scoping of the `Q(owner=user) & (Q(files=None) | Q(main_file=None))` filter, the `hash__endswith=str(user.id)` missing-file filter, `LongRunningJob` progress reporting, batched processing, cascade cleanup of album through-rows, the single `AlbumThing.photo_count` / cover-photo refresh, and the `AsyncTask` wrap on the view.
+- `apps/backend/api/tests/test_missing_file_reappearance.py` — clearing `File.missing` when a file returns to disk, and re-adoption of a reappearing file by its original `Photo` (no duplicate `Photo` created).
+
+Run them from the backend app directory (normally inside the `backend` container — see [Development Install](../../dev-install.md)):
+
+```bash
+cd apps/backend
+python manage.py test api.tests.test_delete_missing_photos api.tests.test_missing_file_reappearance
+```
+
 ## Related Documentation
 
+- [Missing Photos (User Guide)](../../../user-guide/missing-photos.md) - User-facing guide to identifying and resolving missing photos
 - [Photo List Implementation](./photo-list.md) - Understanding photo queries and display
 - [Thumbnails](./thumbnails.md) - How thumbnails are generated and stored
 - [Upload System](./upload.md) - File handling during uploads
-

--- a/apps/docs/docs/development/contribution/backend/photo-list.md
+++ b/apps/docs/docs/development/contribution/backend/photo-list.md
@@ -1,10 +1,14 @@
 ---
 title: " 🖼 Photo List"
-excerpt: "How to fetch alot of images as a developer"
+description: "How to fetch alot of images as a developer"
 sidebar_position: 5
 ---
 
 ## Endpoints:
+
+:::note
+The boolean flags below (`favorite`, `public`, `hidden`, `video`, `photo`, `in_trashcan`, `show_all_stack_photos`) are plain truthiness checks on the query string: any non-empty value enables them, so `?hidden=false` still returns hidden images. Omit a flag to get the default behaviour. `in_trashcan` was previously named `deleted`; clients that still send `?deleted=true` are silently ignored and receive the normal timeline rather than the trashcan.
+:::
 
 ### `GET /api/albums/date/list/`
 
@@ -13,10 +17,15 @@ Gives you a list of days with the number of elements. This is not paginated and 
 #### Parameters:
 
 - `?favorite=true` - Give me the list for favorite images
-- `?public=true` - Give me the list for public images
-- `?username=<name>` - Give me the list of this users public images
-- `?deleted=true` - Give me the list for deleted images
+- `?public=true&username=<name>` - Give me the list of this user's public images. On this endpoint the two are coupled: `username` is applied even when absent, so `?public=true` on its own filters on `owner__username IS NULL` and always returns an empty result set.
+- `?in_trashcan=true` - Give me the list for images currently in the trashcan (images already marked as removed are excluded)
 - `?person=<id>` - Give me the list for this person
+- `?hidden=true` - Return hidden images instead of the default non-hidden ones
+- `?video=true` - Videos only
+- `?photo=true` - Photos only (non-videos). `video` and `photo` are independent filters, so sending both at once returns nothing.
+- `?folder=<prefix>` - Only images whose file path starts with this prefix (a prefix match, not folder equality)
+- `?show_all_stack_photos=true` - By default only the primary photo of each stack (plus images in no stack) is counted; pass this to include non-primary stack members. This changes the per-day counts that "How React Pig works" relies on below.
+- `?last_modified=<date>` - Only days containing images last modified on or after this date. This rebuilds the filter set from scratch, so it cannot be combined with any of the parameters above.
 
 #### Headers:
 
@@ -24,16 +33,23 @@ Gives you a list of days with the number of elements. This is not paginated and 
 
 ### `GET /api/albums/date/<id>`
 
-Returns the actual images, for a given day in chunks of 100 images.
+Returns the actual images, for a given day in chunks of 100 images by default.
 
 #### Parameters:
 
 - `?page=1` - Give me the first page of the album
+- `?size=<n>` - Change the chunk size (default 100). This endpoint paginates manually, so the parameter is `size`, not the `page_size` used by the paginated endpoints, and the value is passed straight to the paginator without an upper bound.
 - `?favorite=true` - Give me the list for favorite images
-- `?public=true` - Give me the list for public images
-- `?username=<name>` - Give me the list of this users public images
-- `?deleted=true` - Give me the list for deleted images
+- `?public=true` - Give me the list for public images. Here `username` is optional: `?public=true` on its own returns the day's public images regardless of owner.
+- `?username=<name>` - Restrict the public images to this owner (only takes effect together with `?public=true`)
+- `?in_trashcan=true` - Give me the list for images currently in the trashcan (images already marked as removed are excluded)
 - `?person=<id>` - Give me the list for this person
+- `?hidden=true` - Return hidden images instead of the default non-hidden ones
+- `?video=true` - Videos only
+- `?photo=true` - Photos only (non-videos). `video` and `photo` are independent filters, so sending both at once returns nothing.
+- `?folder=<prefix>` - Only images whose file path starts with this prefix (a prefix match, not folder equality)
+- `?show_all_stack_photos=true` - By default only the primary photo of each stack (plus images in no stack) is returned; pass this to include non-primary stack members.
+- `?last_modified=<date>` - Only images with an EXIF timestamp on or after this date. This rebuilds the filter set from scratch, so it cannot be combined with any of the parameters above.
 
 #### Headers:
 

--- a/apps/docs/docs/development/contribution/backend/thumbnails.md
+++ b/apps/docs/docs/development/contribution/backend/thumbnails.md
@@ -1,7 +1,7 @@
 ---
 title: "🎞 Thumbnails"
-excerpt: "How do thumbnails work in LibrePhotos?"
-sidebar_position: 5
+description: "How do thumbnails work in LibrePhotos?"
+sidebar_position: 2
 ---
 
 We process media files with different libraries to convert them to a widely compatible format and to speed up previewing files.
@@ -29,50 +29,46 @@ Big thumbnails act as a source of truth for all subsequent processing like findi
 
 ### Other thumbnails
 
-We also create thumbnails for previewing the faces and for the avatars of users. This is done to increase the speed of displaying a lot of them.
+We also create thumbnails for previewing faces: during face extraction the face region is cropped out of the big thumbnail and stored as a JPEG under `protected_media/faces`, so a lot of them can be displayed quickly. User avatars are not thumbnailed by the backend — the frontend scales the chosen image to a 150x150 PNG in the browser before upload, and the backend stores that file as-is under `protected_media/avatars`.
 
 ## Endpoints:
+
+:::note Authentication
+
+These `/media/...` endpoints are all served by `UnifiedMediaAccessView`, which is declared `AllowAny` and authenticates from the **`jwt` cookie**, not from an `Authorization` header. Obtain the cookie with `POST /api/auth/token/obtain/` and refresh it with `POST /api/auth/token/refresh/`; both responses set the `jwt` cookie automatically. Send your request with cookies enabled — an `Authorization: Bearer <token>` header on its own is ignored, and the request is rejected with `403 Forbidden`.
+
+The exception is media belonging to an active public album share, which is served without any authentication. See [API authentication](../../../user-guide/api-authentication.md) for the full flow.
+
+:::
 
 ### `GET /media/thumbnails_big/<hash>`
 
 Gives you a large preview of the actual file. It is also an image for videos. If you want to display the video file use `media/photos/<hash>` instead.
 
-#### Headers:
-
-- `Authorization` - `Bearer <token>`
-
 ### `GET /media/square_thumbnails/<hash>`
 
 Gives you a normal preview of the actual file. Can be an image or a video.
 
-#### Headers:
-
-- `Authorization` - `Bearer <token>`
-
-### `GET /media/small_square_thumbnails/<hash>`
+### `GET /media/square_thumbnails_small/<hash>`
 
 Gives you a small preview. Usually only usable with a blur to indicate loading. Could be replaced by blur hash.
-
-#### Headers:
-
-- `Authorization` - `Bearer <token>`
 
 ### `GET /media/photos/<hash>`
 
 Return the actual image or video from the server.
 
-#### Headers:
+### `GET /media/faces/<filename>`
 
-- `Authorization` - `Bearer <token>`
+Returns the cropped face image for a photo. The file is created as `<hash>_<face_number>.jpg`, but Django's default storage appends a random uniqueness suffix when that name is already taken (for example `bb6685821c52c994cf7bbe9ebfd5eb7e1_2_fpZqB0S.jpg`), so do not construct the name yourself — use the `face_url` value returned by the faces or persons endpoints.
 
-### `GET /media/faces/<hash>_<face_number>.jpg`
+### `GET /media/avatars/<filename>`
 
-Returns the face for an image.
+Returns the avatar for a given user. The frontend uploads it as `<first_name>avatar.png` (there is no hash component on the first upload); the same random uniqueness suffix is appended on re-upload. Use the `avatar_url` field from the user endpoints rather than building the name.
 
-#### Headers:
+### `GET /media/embedded_media/<hash>`
 
-- `Authorization` - `Bearer <token>`
+Returns the embedded video track of a motion photo (Samsung or Google) as `video/mp4`. The path segment accepts either the photo UUID (36 characters with 4 hyphens) or the legacy image hash, and returns 404 if the photo has no embedded media file. Used by the frontend lightbox to play the motion-photo clip. Unlike the other endpoints this one does not hard-require the cookie: an unauthenticated request is limited to public photos, and it narrows to the owner's photos when a session user or valid `jwt` cookie is present.
 
-### `GET /media/avatars/<first_name>avatar_<hash>.png`
+### `GET /media/zip/<prefix>`
 
-Returns an avatar for a given user.
+Serves a bulk-download archive as `application/x-zip-compressed`. The path segment is a filename prefix, not the full filename — the backend appends the requesting user's id and `.zip`, so a user can only retrieve their own archive. Requires a valid `jwt` cookie; returns `403 Forbidden` otherwise.

--- a/apps/docs/docs/development/contribution/backend/upload.md
+++ b/apps/docs/docs/development/contribution/backend/upload.md
@@ -1,7 +1,7 @@
 ---
 title: " 📁 Upload"
-excerpt: "How to uploading photos works as a developer"
-sidebar_position: 6
+description: "How to uploading photos works as a developer"
+sidebar_position: 3
 ---
 
 ## Endpoints:
@@ -24,18 +24,20 @@ On the first chunk leave `upload_id` empty, you will get a response with the `up
 
 - `file` - The chunk of the file, name is blob
 - `upload_id` - The id of the upload
-- `offset` - The offset of the chunk
+- `offset` - The byte offset of the chunk (sent by the web client, but ignored by the server — see the note below)
 - `md5` - The md5 hash of the chunk (not used yet, you can leave it empty)
 
 #### Headers:
 
 - `Content-Type` - `multipart/form-data`
-- `Authorization` - `Bearer <token>`
+- `Cookie` - `jwt=<access token>`
 - `Content-Range` - `bytes <start>-<end>/<total>`
+
+The server derives the chunk position from the `Content-Range` header only, not from the `offset` form field. If the header is omitted it assumes the chunk starts at byte 0, so any upload of more than one chunk must send `Content-Range` or the second chunk fails with `400 "Offsets do not match"`. The response body returns the server's authoritative `offset` (alongside `upload_id` and `expires`); use it as the start of the next chunk.
 
 ### `POST /api/upload/complete/`
 
-Combines the chunks of a file into a single file and moves it to the upload folder
+Assembles the uploaded chunks into a single file and imports it.
 
 #### Form Data:
 
@@ -46,8 +48,31 @@ Combines the chunks of a file into a single file and moves it to the upload fold
 #### Headers:
 
 - `Content-Type` - `multipart/form-data`
-- `Authorization` - `Bearer <token>`
+- `Cookie` - `jwt=<access token>`
 
-### `GET /api/scanuploadedphotos/`
+#### On completion:
 
-Start a new job to scan all photos in the upload folder
+On success the server:
+
+- Writes the assembled file to `<scan_directory>/uploads/web/<sanitized filename>` (the `uploads/` and `uploads/web/` directories are created if missing; `web` is currently hardcoded as the origin device).
+- Queues a background task chain (django-q) that imports the photo — `create_new_image` + `handle_new_image`, caption generation, geolocation, album-date location and face extraction. Because of this, **clients do not need to call `/api/scanuploadedphotos/` afterwards**; the upload is already imported.
+- Deduplicates by hash: if a `Photo` with the same hash already exists, or a same-named file in the upload folder has the same hash, the file is not copied and no new import is performed (the endpoint still returns `200`). If a same-named file exists with a *different* hash, the image hash is appended to the basename.
+
+Error responses:
+
+- `400` if the user has no configured scan directory, or the configured directory does not exist on disk.
+- `400 "File type not allowed"` if the file fails the media-type check (`is_valid_media`); the chunked-upload record is deleted.
+
+:::note Authentication for the upload endpoints
+Unlike the other endpoints, `/api/upload/` and `/api/upload/complete/` are plain Django views rather than DRF views, so DRF's JWT authentication never runs and the `Authorization` header is ignored. They authenticate solely from the `jwt` cookie, whose value is the access token set on the response of `POST /api/auth/token/obtain/` and `POST /api/auth/token/refresh/`. Browser clients send it automatically with `credentials: "include"`; other clients must send it explicitly (e.g. `curl --cookie "jwt=<access token>"`). A request without a valid cookie returns `403 {"detail": "Authentication credentials were not provided"}`. Uploads must also be enabled: the endpoints check the `ALLOW_UPLOAD` site setting first and return `403 "Uploading is not allowed"` when it is off, so that 403 is not always an authentication problem.
+:::
+
+### `POST /api/scanuploadedphotos/`
+
+Alias of `POST /api/fullscanphotos/` — both are handled by the same view (`FullScanPhotosView`). Despite the name it is **not** restricted to the upload folder: it queues a **full rescan of the user's entire scan directory**, reprocessing every file rather than only new or modified ones.
+
+Returns `{"status": true, "job_id": "<uuid>"}` on success and `{"status": false}` on failure.
+
+`GET` is still accepted but is marked deprecated in the OpenAPI schema (`deprecated=True`, "Use POST method instead"); new clients should use `POST`.
+
+You normally do not need to call this after an upload — `POST /api/upload/complete/` already imports the file, including the caption, geolocation and face-extraction steps.

--- a/apps/docs/docs/development/contribution/docker.md
+++ b/apps/docs/docs/development/contribution/docker.md
@@ -1,26 +1,30 @@
 ---
 title: "🐋 Docker"
-excerpt: "Contributing to LibrePhotos Docker infrastructure."
+description: "Contributing to LibrePhotos Docker infrastructure."
+sidebar_position: 4
 last_modified_at: 2024-12-14
-category: 5
 ---
 
 ## Overview
 
 The `deploy/` directory in the monorepo contains the Docker configuration for running LibrePhotos. This includes:
 
-- `deploy/compose/docker-compose.yml` - Production configuration
-- `deploy/compose/docker-compose.dev.yml` - Development overrides
-- `deploy/docker/backend/` - Backend Dockerfile and entrypoint
-- `deploy/docker/frontend/` - Frontend Dockerfile and development config
+- `deploy/compose/docker-compose.yml` - Base configuration (published images), used in both dev and prod
+- `deploy/compose/docker-compose.dev.yml` - Development overrides (builds from local source, hot reload)
+- `deploy/compose/docker-compose.e2e.yml` - End-to-end test stack (builds from local source)
+- `deploy/docker/backend/` - Backend Dockerfile (app layer) and entrypoint
+- `deploy/docker/backend/base/` - Backend base image Dockerfile (system dependencies), published separately
+- `deploy/docker/backend-gpu/` and `deploy/docker/backend-gpu/base/` - CUDA (GPU) equivalents of the backend and its base
+- `deploy/docker/frontend/` - Frontend Dockerfiles (production and development)
 - `deploy/docker/proxy/` - Nginx reverse proxy configuration
+- `deploy/docker/unified/` - Single-container image ([Single Container Deployment](../../installation/unified-deployment.md)) with its own standalone Dockerfile and compose file
 
 ## ✨ Code Standards
 
 When modifying Docker files, please ensure:
 
 1. **Cross-platform compatibility**: Test on both Linux and macOS/Windows (WSL2)
-2. **ARM64 support**: Images should build on both AMD64 and ARM64 (Apple Silicon, Raspberry Pi)
+2. **ARM64 support**: Images should build on both AMD64 and ARM64 (Apple Silicon, Raspberry Pi). The GPU images (`deploy/docker/backend-gpu/`) are the exception — they are AMD64-only by design, because the CUDA base has no ARM64 build. CI opts them out with `amd64-only: true` (see `.github/workflows/_build-image.yml`)
 3. **Layer optimization**: Order commands to maximize Docker layer caching
 4. **Security**: Don't run services as root when avoidable; use minimal base images
 
@@ -31,20 +35,19 @@ When modifying Docker files, please ensure:
 ```
                     ┌─────────────┐
                     │   proxy     │ :80
-                    │   (nginx)   │
-                    └──────┬──────┘
+                    │   (nginx)   │  also serves /data, /protected_media,
+                    └──────┬──────┘  /original from its own bind mounts
                            │
-            ┌──────────────┼──────────────┐
-            │              │              │
-      ┌─────▼─────┐  ┌─────▼─────┐  ┌─────▼─────┐
-      │ frontend  │  │  backend  │  │  static   │
-      │  (React)  │  │ (Django)  │  │  files    │
-      └───────────┘  └─────┬─────┘  └───────────┘
-                           │
-                     ┌─────▼─────┐
-                     │    db     │
-                     │(Postgres) │
-                     └───────────┘
+                ┌──────────┴──────────┐
+          ┌─────▼─────┐         ┌─────▼─────┐
+          │ frontend  │         │  backend  │
+          │  (React)  │         │ (Django)  │
+          └───────────┘         └─────┬─────┘
+                                      │
+                                ┌─────▼─────┐
+                                │    db     │
+                                │(Postgres) │
+                                └───────────┘
 ```
 
 ### Development vs Production
@@ -52,7 +55,7 @@ When modifying Docker files, please ensure:
 | File | Purpose |
 |------|---------|
 | `docker-compose.yml` | Base configuration, used in both dev and prod |
-| `docker-compose.dev.yml` | Development overrides (hot reload, mounted source, debug tools) |
+| `docker-compose.dev.yml` | Development overrides (hot reload, mounted source, pgadmin on `:3001`) |
 
 ## Making Changes
 
@@ -71,11 +74,27 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d backend
 docker compose logs -f backend
 ```
 
+### Modifying the Backend Base Image
+
+The backend image is built in two tiers. `deploy/docker/backend/Dockerfile` starts `FROM reallibrephotos/librephotos-base:dev`, then only copies `apps/backend/` and pip-installs `requirements.txt`. All system-level dependencies — ffmpeg, libvips, ImageMagick, LibRaw, ExifTool, CPU PyTorch — live in the separate `deploy/docker/backend/base/Dockerfile`.
+
+The base is **pulled, not built**: `docker compose build backend`, even with `--no-cache`, will not rebuild it. To test a change to the base locally, build and tag it yourself first, then rebuild the backend:
+
+```bash
+# from the monorepo root
+docker build -t reallibrephotos/librephotos-base:dev deploy/docker/backend/base
+
+# then rebuild the app layer (from deploy/compose/)
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build backend
+```
+
+The base image is published to Docker Hub by `.github/workflows/image-backend-base.yml`, which runs only on pushes to `dev` that touch `deploy/docker/backend/base/**`. The GPU build has the same split — `deploy/docker/backend-gpu/base/Dockerfile` produces `reallibrephotos/librephotos-base-gpu:dev` — and the unified image (`deploy/docker/unified/`) also builds `FROM` the CPU base, so a base change affects it too.
+
 ### Modifying the Frontend Dockerfile
 
 The frontend has two Dockerfiles:
 
-- `deploy/docker/frontend/Dockerfile` - Production build (static files served by nginx)
+- `deploy/docker/frontend/Dockerfile` - Production build (multi-stage: `node:20-slim` builds `dist/`, then `halverneus/static-file-server` serves it on port 3000 behind the nginx proxy)
 - `deploy/docker/frontend/Dockerfile.dev` - Development build (hot reload)
 
 ### Modifying the Proxy (Nginx)
@@ -95,30 +114,43 @@ Environment variables are loaded from the `.env` file. Key variables for Docker:
 |----------|---------|---------|
 | `tag` | Docker image tag to use | `latest` |
 | `httpPort` | Host port for the application | `3000` |
-| `codedir` | (Dev only) Path to source code | - |
 | `scanDirectory` | Path to photo library | - |
 | `data` | Path to persistent data | - |
 
+The dev overlay bind-mounts `apps/backend` and `apps/frontend` by path relative to `deploy/compose/`, so there is no environment variable for the source-code location.
+
 ## Testing Changes
 
-Before submitting a PR:
+Before submitting a PR, from `deploy/compose/`. Include the dev overlay on every command — the base `docker-compose.yml` uses published images and defines no `build:` sections, so `docker compose build` on its own rebuilds nothing and starts the images pulled from Docker Hub instead of your change:
 
-1. **Clean build**: `docker compose build --no-cache`
-2. **Fresh start**: `docker compose down -v && docker compose up -d`
-3. **Check all services**: `docker compose ps` (all should be "healthy" or "running")
+1. **Clean build**: `docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache` (this does not refresh the base image — see [Modifying the Backend Base Image](#modifying-the-backend-base-image))
+2. **Fresh start**: `docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v && docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d`
+3. **Check all services**: `docker compose -f docker-compose.yml -f docker-compose.dev.yml ps` (all should be "healthy" or "running")
 4. **Test basic functionality**: Upload a photo, trigger a scan, verify it works
+
+:::note
+On a fresh stack, uploads are **off** by default: `librephotos.env` ships without an `allowUpload` entry, so `docker-compose.yml` passes `ALLOW_UPLOAD=false` and the upload button is hidden in the UI entirely. Enable it by adding `allowUpload=true` to your `.env` before the first start, or by turning on **Allow uploads** under the app's Admin → Site Settings.
+:::
 
 ## GPU Support
 
-The `deploy/docker/backend-gpu/` directory contains GPU-enabled Dockerfiles for NVIDIA CUDA support:
+The `deploy/docker/backend-gpu/` directory contains the GPU-enabled Dockerfile for NVIDIA CUDA support. There is no compose overlay for GPU — the image is built and published separately as `reallibrephotos/librephotos-gpu` by `.github/workflows/image-backend-gpu.yml`.
+
+To build it locally, run from the **monorepo root** (the Dockerfile's build context is the repo root, not `deploy/compose/`):
 
 ```bash
-# Build GPU image
-docker compose -f docker-compose.yml -f docker-compose.gpu.yml build
-
-# Run with GPU
-docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+docker build -f deploy/docker/backend-gpu/Dockerfile \
+  --build-arg IMAGE_TAG=dev \
+  -t reallibrephotos/librephotos-gpu:dev .
 ```
+
+This pulls `reallibrephotos/librephotos-base-gpu:dev` as its base rather than building it.
+
+:::note
+The GPU images are built for `linux/amd64` only; ARM is not supported. Do not spend effort making these Dockerfiles ARM64-compatible.
+:::
+
+To run it, point the `backend` service in `deploy/compose/docker-compose.yml` at the GPU image and add a device reservation — see [Utilizing GPU Acceleration](../../installation/environment-variables.md#utilizing-gpu-acceleration).
 
 Ensure you have:
 - NVIDIA drivers installed

--- a/apps/docs/docs/development/contribution/frontend/index.md
+++ b/apps/docs/docs/development/contribution/frontend/index.md
@@ -1,8 +1,8 @@
 ---
 title: "👨‍💻 Frontend"
-excerpt: "Development Information regarding LibrePhotos Frontend."
+description: "Development Information regarding LibrePhotos Frontend."
+sidebar_position: 2
 last_modified_at: 2026-07-22
-category: 5
 ---
 
 The frontend is a [React 18](https://react.dev/) single-page app, written in TypeScript and built
@@ -18,9 +18,16 @@ debugging, and how the source tree is laid out.
 
 ## ✨ Code Standards
 
-We use ESLint and Prettier to keep our code tidy. Running `yarn install` also installs the git hooks
-(the `prepare` script runs `husky install`), so staged files are formatted and linted on every
-commit — there is no extra setup step.
+We use ESLint and Prettier to keep our code tidy. Before you commit, run `yarn lint:error` to check
+your changes and `yarn lint:error:fix` to apply the automatic fixes — the ESLint config enforces
+Prettier through the `prettier/prettier` rule, so linting also flags unformatted code. The
+`lint-frontend` CI workflow runs the lint, test and build steps on every pull request that touches
+`apps/frontend` and fails on anything unclean, so nothing un-linted gets merged.
+
+The repository ships a `husky` pre-commit hook (`apps/frontend/.husky/pre-commit`, which runs
+`lint-staged`), but it is currently inactive in the monorepo: `yarn install` runs the `prepare`
+script — `husky install` — with the working directory set to `apps/frontend`, which has no `.git` of
+its own, so husky exits without registering the hook. Don't rely on it; lint before you commit.
 
 ## 🐛 Debugging
 

--- a/apps/docs/docs/development/contribution/frontend/to-do.md
+++ b/apps/docs/docs/development/contribution/frontend/to-do.md
@@ -1,15 +1,36 @@
 ---
 title: "🖱️ To-Do"
-excerpt: "On going migrations regarding LibrePhotos Frontend."
+description: "Ways to contribute to the LibrePhotos frontend: open issues, E2E tests, and docs."
+sidebar_position: 2
 last_modified_at: 2021-05-31
-category: 5
 ---
 
 You can look into the issues [here](https://github.com/LibrePhotos/librephotos/issues?q=is%3Aopen+is%3Aissue+label%3Afrontend),
 on what features are missing from the frontend.
 
-We are in the process of migrating from Redux to redux-toolkit and redux-query.
+E2E tests already exist in `apps/frontend/e2e`. They use [Cypress](https://www.cypress.io/) with the
+[cucumber preprocessor](https://github.com/badeball/cypress-cucumber-preprocessor): the specs are
+Gherkin `.feature` files under `test/features`, backed by page objects in `test/pages` and step
+definitions in `test/step_definitions`. They currently cover login, duplicates, stacks and user
+settings — more coverage is very welcome.
 
-It would be also create if you could write E2E tests with [Cypress](https://www.cypress.io/) for the frontend.
+To run them, first bring up the dedicated stack from `deploy/compose` (it serves the app on
+http://localhost:8080 and seeds an `admin`/`admin` account, which is what `cypress.config.js`
+expects):
+
+```bash
+cd deploy/compose
+docker compose --env-file librephotos.env -f docker-compose.e2e.yml up -d
+```
+
+Then, in a second shell, install and run the suite:
+
+```bash
+cd apps/frontend/e2e
+yarn install
+yarn test    # or `yarn start` for the interactive runner
+```
+
+The E2E suite is not wired into CI, so please run it locally before opening a PR.
 
 You can also help by expanding the documentation.

--- a/apps/docs/docs/development/contribution/frontend/upload.md
+++ b/apps/docs/docs/development/contribution/frontend/upload.md
@@ -1,7 +1,7 @@
 ---
 title: " 📁 Upload"
-excerpt: "How to uploading photos works as a developer"
-sidebar_position: 5
+description: "How to uploading photos works as a developer"
+sidebar_position: 1
 ---
 
 ### How does it work?
@@ -9,10 +9,16 @@ sidebar_position: 5
 It uses the [endpoints](/docs/development/contribution/backend/upload) of the backend to upload the files in chunks. The steps are:
 
 - Only show button if upload is enabled in admin area
+- Even then, the button and the dropzone stay disabled (greyed out, with a "Scan directory not configured - contact administrator" tooltip) if the logged in user has no scan directory. The backend enforces the same rule and answers `complete` with a 400 when the user's scan directory is unset or does not exist on disk
 - Check if file is on the server by using the `exists` endpoint.
 - If it is, don't upload it
 - If it isn't, upload it with the `upload` endpoint
 - If the upload is complete, call the `complete` endpoint
-- If all files are uploaded, call the `scanuploadedphotos` endpoint
 
-This is implemented in the `ChunkedUploadButton` component in the frontend. The progress is saved wihtin the state of the component.
+The frontend never triggers a scan itself. While the backend handles `complete`, it queues a django-q `Chain` for that one file: `handle_new_image`, caption generation, geolocation, adding the location to the album dates and face extraction. Duplicates are skipped — the endpoint answers with "Photo duplicated. No new import performed." and no chain is queued. Once the last file is done, the client only invalidates its cached queries (recently added photos, date albums, count stats, photo month count and storage stats).
+
+:::note
+`GET /api/scanuploadedphotos` still exists on the backend, but it is only an alias of the same view as `/api/fullscanphotos` and nothing in the web frontend calls it.
+:::
+
+This is implemented in the `ChunkedUploadButton` component in the frontend. The progress is saved within the state of the component.

--- a/apps/docs/docs/development/contribution/index.md
+++ b/apps/docs/docs/development/contribution/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Contribution"
-sidebar_position: 1
+description: "How to contribute to LibrePhotos across the backend, frontend, mobile, and Docker."
+sidebar_position: 2
 ---
 
 # Contributing to LibrePhotos
@@ -9,11 +10,11 @@ Thank you for considering contributing to LibrePhotos! We welcome contributions 
 
 ## How to Contribute
 
-1. **Fork the Repository**: Start by forking the relevant LibrePhotos repository to your GitHub account; please also reference their pages. There are the [Frontend](https://docs.librephotos.com/docs/development/contribution/frontend/), [Backend](https://docs.librephotos.com/docs/development/contribution/backend/), [Docker](https://docs.librephotos.com/docs/development/contribution/docker), and [Mobile](https://docs.librephotos.com/docs/development/contribution/mobile/) guides.
+1. **Fork the Repository**: LibrePhotos is a single monorepo, so there is just one repository to fork: [github.com/LibrePhotos/librephotos](https://github.com/LibrePhotos/librephotos). Everything lives there — `apps/backend/`, `apps/frontend/`, `apps/mobile/`, `apps/docs/`, and `deploy/`. Do not open pull requests against the archived `librephotos-frontend`, `librephotos-docker`, `librephotos.docs`, or `librephotos-mobile` repositories. Depending on what you're working on, see the [Frontend](https://docs.librephotos.com/docs/development/contribution/frontend/), [Backend](https://docs.librephotos.com/docs/development/contribution/backend/), [Docker](https://docs.librephotos.com/docs/development/contribution/docker), and [Mobile](https://docs.librephotos.com/docs/development/contribution/mobile/) guides.
 
-2. **Clone the Repository**: Clone your forked repository to your local machine.
+2. **Clone the Repository**: Clone your forked repository to your local machine. A GitHub fork keeps the name `librephotos` by default.
     ```sh
-    git clone https://github.com/your-username/repository-name.git
+    git clone https://github.com/your-username/librephotos.git
     ```
 
 3. **Create a Branch**: Create a new branch for your feature or bug fix.
@@ -33,7 +34,7 @@ Thank you for considering contributing to LibrePhotos! We welcome contributions 
     git push origin my-feature-branch
     ```
 
-7. **Create a Pull Request**: Open a pull request to the main repository. Provide a clear description of your changes and why they are necessary.
+7. **Create a Pull Request**: Open a pull request against the upstream repository, targeting the `dev` branch (the default branch — not `main`). Provide a clear description of your changes and why they are necessary. See the repository's [CONTRIBUTING.md](https://github.com/LibrePhotos/librephotos/blob/dev/CONTRIBUTING.md) for the full pull-request guidelines.
 
 <!-- ## Code of Conduct
 
@@ -41,14 +42,18 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 ## Reporting Issues
 
-If you find a bug or have a feature request, please create an issue on the relevant issue tracker, such the [backend issue tracker](https://github.com/LibrePhotos/librephotos/issues).
+LibrePhotos is a monorepo with a single [issue tracker](https://github.com/LibrePhotos/librephotos/issues) — bugs, feature requests, and documentation problems all go there, not to the archived `librephotos-frontend`, `librephotos-docker`, `librephotos.docs`, or `librephotos-mobile` repositories. Pick the **Bug report**, **Enhancement request**, or **Incorrect/outdated information** template, and label the issue with the affected area (for example `frontend` or `mobile`).
 
 ## Getting Help
 
-If you need help, feel free to ask questions on our [Discord server](https://discord.com/invite/xwRvtSDGWb). You can also watch watch development videos on [Niaz Faridani-Rad's channel](https://www.youtube.com/channel/UCZJ2pk2BPKxwbuCV9LWDR0w).
+If you need help, feel free to ask questions on our [Discord server](https://discord.com/invite/xwRvtSDGWb). You can also watch development videos on [Niaz Faridani-Rad's channel](https://www.youtube.com/channel/UCZJ2pk2BPKxwbuCV9LWDR0w).
 
 ## Documentation
 
-Please refer to the [documentation](https://docs.librephotos.com) for more information on how to use and contribute to LibrePhotos.
+The documentation site is built with [Docusaurus](https://docusaurus.io/) and lives in [`apps/docs/`](https://github.com/LibrePhotos/librephotos/tree/dev/apps/docs) in the main repository. Improving it is as simple as opening a pull request against that folder — the pages under `apps/docs/docs/` are plain Markdown. To preview your changes locally, run `cd apps/docs && yarn install && yarn start`.
+
+## Translations
+
+Translations are contributed through [Weblate](https://hosted.weblate.org/engage/librephotos/), not by editing `apps/frontend/src/locales/<lang>/translation.json` directly — direct edits to the non-English files are overwritten by Weblate. Change only the English strings in code, and translators will pick them up from there.
 
 We appreciate your contributions and look forward to working with you!

--- a/apps/docs/docs/development/contribution/mobile/index.md
+++ b/apps/docs/docs/development/contribution/mobile/index.md
@@ -1,8 +1,8 @@
 ---
 title: "📱 Mobile"
-excerpt: "What data does Libre Photos collect."
-last_modified_at: 2022-03-09
-category: 5
+description: "Development Information regarding the LibrePhotos Mobile App."
+sidebar_position: 3
+last_modified_at: 2026-07-23
 ---
 
 Open-Source Android and iOS Mobile Application for the [LibrePhotos](https://github.com/LibrePhotos/librephotos) Project
@@ -12,7 +12,7 @@ Open-Source Android and iOS Mobile Application for the [LibrePhotos](https://git
 **Compatibility**
 
 - Android 5.0+
-- iOS 9.0+ (Stability on iOS is not tested yet.)
+- iOS 10.0+ (Stability on iOS is not tested yet.)
 
 ### 📱 Android
 
@@ -25,13 +25,21 @@ Currently, there are no automated builds for IOS. You will need to build the app
 
 ### 🔨 Build from Source
 
-You also need to install the dependencies required by React Native: [Environment Setup](https://reactnative.dev/docs/environment-setup)
+You need the dependencies required by React Native — follow the [Environment Setup](https://reactnative.dev/docs/environment-setup) guide for your platform.
 
-Once the dependencies are set up, you can run the project as follows:
+You also need [Node.js](https://nodejs.org/). The app is pinned to Node 20 in `apps/mobile/.node-version`, which is what CI installs from; anything older than Node 18 will fail at `yarn install`. Tools like fnm, nodenv and asdf read `.node-version` automatically.
 
-1. `npm install -g yarn`
-2. `yarn install`
-3. `yarn <platform>` # Replace platform with `android` or `ios`
+Once the dependencies are set up, build the app from the `apps/mobile` directory:
+
+1. Install Yarn if you don't already have it: `npm install -g yarn`
+2. `cd apps/mobile`
+3. `yarn install`
+4. On iOS only (macOS): install the CocoaPods dependencies with `cd ios && pod install && cd ..` (CocoaPods is part of the React Native environment setup linked above).
+5. `yarn android` — or `yarn ios` on macOS.
+
+## ✨ Code Standards
+
+We use ESLint and Prettier to keep the code tidy. `yarn lint` (which runs `eslint --fix .`) must pass — it runs on every pull request that touches `apps/mobile/`, and again when your change lands on `dev`. `yarn test` runs the [Jest](https://jestjs.io/) tests locally — a render smoke test plus a couple of regression tests — but the suite is not part of CI yet.
 
 ## 🐛 Debugging
 
@@ -39,8 +47,8 @@ For debugging, we use [reactotron](https://github.com/infinitered/reactotron/)
 
 ### Enable File Logging
 
-Logging to the phone's local file system can be enabled/disabled from the Settings page.
+Logging to the phone's local file system can be enabled or disabled from the Settings page, under Debug Options → Debug Logging. It is enabled by default on a clean install.
 Logs are stored in the cache directory of the phone.
 For Android: `/storage/emulated/0/Android/data/com.librephotosmobile/cache/logs/`
 
-You can also quickly send a bug report to the developer by shaking your phone.
+You can also quickly send a bug report to the developer by shaking your phone. Shake-to-report only works while Debug Logging is enabled — the shake listener is registered alongside the file logger, so turning logging off disables it too.

--- a/apps/docs/docs/development/contribution/mobile/local-images.md
+++ b/apps/docs/docs/development/contribution/mobile/local-images.md
@@ -1,19 +1,19 @@
 ---
 title: "☁️ Local Images"
-excerpt: "How do local images work?"
-sidebar_position: 5
+description: "How do local images work?"
+sidebar_position: 2
 ---
 
-## Local Image Slice
+## Local Images Store
 
 - ✅ Synced: The image is synced with the server and exists on your phone
 - 🔄 Syncing: The image is currently syncing with the server
 - ❌ Local: The image is not synced with the server and only exists on your phone
 - ☁️ Remote: The image is only on the server and not on your phone
 
-On the first load of the app, it will check for new local images. We use `react-native-camera-roll` to get the images from the phone. This is a async action in LocalImagesSlice called `loadLocalImages`. It will get the images from the phone and save them in the store. We use the `react-native-file-access` library to get the md5 hash of the image, which we combine with `user_id` to get the server hash. This is used to check if the image is already on the server.
+On the first load of the app, it will check for new local images. We use `react-native-camera-roll` to get the images from the phone. This is an async action called `loadLocalImages` in `src/stores/localImagesActions.ts`, which gets the images from the phone and saves them in the zustand store `useLocalImagesStore` (`src/stores/localImagesStore.ts`). On Android, `loadLocalImages` first requests a runtime read permission — `READ_MEDIA_IMAGES` on API level 33+, `READ_EXTERNAL_STORAGE` below that. If it is not granted, the action returns immediately, before the loading flag is set and without logging anything, so the timeline simply stays empty (iOS skips this check). We use the `react-native-file-access` library to get the md5 hash of the image, which we combine with `user_id` to get the server hash. This is used to check if the image is already on the server.
 
-The slice is persisted with `redux-persist` and `async-storage`, so the images will be loaded from the store on the next start of the app.
+The store is persisted with zustand's `persist` middleware backed by `@react-native-async-storage/async-storage` (storage key `localImages-storage`), so the images are rehydrated on the next start of the app.
 
 ### Limitations
 
@@ -21,7 +21,9 @@ The slice is persisted with `redux-persist` and `async-storage`, so the images w
 
 ## Showing local images, together with the images from the server
 
-We implemented a new selector, which merges local images and albumByDate images. When we find the same hash in both, we set the `synced` property to `true` for the local image and remove the image from the albumByDate images.
+The merge happens in the `timelineData` `useMemo` in `src/Containers/Gallery/Index.js`, which folds the local images from `useLocalImagesStore` into the date albums returned by `useFetchDateAlbumsQuery`. It only runs for the `With Timestamp` category. Each local image has an `id` of `md5(file) + user_id`, so when the same id appears in both, the server entry with that id is dropped from the date album and replaced by the local image, and one `isTemp` placeholder tile is removed per synced photo in that date group.
+
+Sync state is not decided by this merge. `checkIfLocalImagesAreSynced()` (`src/stores/localImagesActions.ts`) asks the server `GET /exists/<id>/` for every local image and calls `markSynced` / `markNotSynced` on the store, which set the image's `syncStatus` field. `syncStatus` is the `SyncStatus` enum from `src/stores/types/localImages.zod.ts` (`synced` / `syncing` / `local`); there is no boolean `synced` property.
 
 ## Deleting backed up images
 

--- a/apps/docs/docs/development/contribution/mobile/to-do.md
+++ b/apps/docs/docs/development/contribution/mobile/to-do.md
@@ -1,12 +1,12 @@
 ---
 title: "🖱️ To-Do"
-excerpt: "On going migrations regarding the mobile app."
+description: "On going migrations regarding the mobile app."
+sidebar_position: 3
 last_modified_at: 2021-05-31
-category: 5
 ---
 
 You can look into the issues [here](https://github.com/LibrePhotos/librephotos/issues?q=is%3Aopen+is%3Aissue+label%3Amobile),
-on what features are missing from the frontend.
+on what features are missing from the mobile app.
 
 **Show local images everywhere**
 
@@ -14,17 +14,18 @@ The local images to not yet show up in all views. You can help out by adding the
 
 **Maintainability**
 
-We currently are working on improving maintainability, by converting our code base to TypeScript. There are still alot of classes, which are written in plain JavaScript. You can help out by converting them to TypeScript!
+We currently are working on improving maintainability, by converting our code base to TypeScript. Most of the app is already TypeScript, but a few dozen plain-JavaScript modules remain — mostly under `src/Theme`, `src/Containers`, `src/Components` and `src/Navigators`. These are function components, theme and config files rather than classes. You can help out by converting them to TypeScript!
 
 **Viewing images offline**
 
-There are a couple of things to migrate first until we can try to view images offline.
+The Redux migration is done. The mobile app now uses Zustand stores (`apps/mobile/src/stores/`) with a typed API client built on TanStack Query (`apps/mobile/src/api_client/`), and the frontend uses TanStack Query too (`apps/frontend/src/api_client/`). AsyncStorage persistence for the stores is also in place: each store wraps Zustand's `persist` middleware with `createJSONStorage(() => AsyncStorage)`, and JWTs are persisted through `apps/mobile/src/api_client/platform/tokenStorage.ts`.
 
-- [ ] Migrate from Redux-Wrapper to redux-toolkit and redux-query in the mobile code base
-- [ ] Migrate from Redux to redux-toolkit and redux-query in the frontend code base
-- [ ] Create a new package for the state management and nd API calls for the frontend and the mobile app (Single Sourcing)
-- [ ] Implement step by step Asyc Storage for the stores (initial load, invalidating, partial fetching)
+A few things still stand between us and viewing images offline:
+
+- [ ] Create a shared package for the state management and API calls of the frontend and the mobile app (single sourcing)
+- [ ] Persist the TanStack Query cache to AsyncStorage so fetched data survives an app restart
+- [ ] Cache remote thumbnails and media on disk
 
 **Documentation**
 
-Write docs for classes and functions and explain what they do, why it's there.
+Write docs for functions and components and explain what they do, why it's there.

--- a/apps/docs/docs/development/contribution/mobile/upload.md
+++ b/apps/docs/docs/development/contribution/mobile/upload.md
@@ -1,7 +1,7 @@
 ---
 title: " 📁 Upload"
-excerpt: "How to uploading photos works as a developer"
-sidebar_position: 5
+description: "How to uploading photos works as a developer"
+sidebar_position: 1
 ---
 
 ### How does it work?
@@ -13,13 +13,13 @@ It uses the [endpoints](/docs/development/contribution/backend/upload) of the ba
 - If it is, don't upload it
 - If it isn't, upload it with the `upload` endpoint
 - If the upload is complete, call the `complete` endpoint
-- If all files are uploaded, call the `scanuploadedphotos` endpoint
+- When the `complete` endpoint returns, mark the local image as synced with `markSynced`. No separate scan call is needed, because the backend's `complete` handler queues the import chain for the uploaded file itself.
 
-This is implemented in the `UploadSlice`, where you can call the action `uploadImages` to upload the images. The progress is saved wihtin the slice as `total` and `current`.
+This is implemented in `apps/mobile/src/stores/uploadActions.ts`, where you can call `uploadImages(files)` to upload the images. Progress and status are stored in the zustand store `useUploadStore` (`apps/mobile/src/stores/uploadStore.ts`) as `total`, `current` and `isUploading`.
 
 ### Differences to the frontend
 
 To continue using blobs, we need to use `react-native-blob-util` to convert the file to a blob and chunk it. The library is not well documented, so it took some time to figure out how to use it. The types are mostly wrong, which is the reason for a lot of `any` types.
-Blobs get created asynchronously, so we need to wrap chunking in a `Promise.all` to get the actual blobs.
+Blobs get created asynchronously via a callback, so `calculateChunks` wraps each `blob.slice(start, end).onCreated(cb)` call in a `Promise` and awaits them one chunk at a time. The chunk size is set by `chunkSize` (1,000,000 bytes) in `apps/mobile/src/stores/uploadActions.ts`.
 
-We cannot use redux-query when using the `upload` endpoint, because it is based on fetch. Fetch isn't correctly implemented yet on androids okhttp library. When we use it, we will get a `Network error`. So we use axios instead.
+All upload requests go through the shared fetch wrapper `fetchClient` (`apps/mobile/src/api_client/api.ts`), the same client used for the rest of the mobile API. The Android-specific pitfall is `Content-Type`: it must not be set manually on the multipart request, otherwise React Native's `FormData` cannot generate the multipart boundary and the upload fails. `FetchClient.request` handles this by only applying its default `application/json` header when the request body is not a `FormData` instance.

--- a/apps/docs/docs/development/dev-install.md
+++ b/apps/docs/docs/development/dev-install.md
@@ -1,8 +1,8 @@
 ---
 title: "👷‍♂️ Development Installation"
-excerpt: "How to install LibrePhotos for Developers"
+description: "How to install LibrePhotos for Developers"
+sidebar_position: 1
 last_modified_at: 2024-12-14
-category: 1
 ---
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=LibrePhotos_ownphotos&metric=alert_status)](https://sonarcloud.io/dashboard?id=LibrePhotos_ownphotos) ![Discord](https://img.shields.io/discord/784619049208250388?style=plastic) ![Website](https://img.shields.io/website?down_color=lightgrey&down_message=offline&style=plastic&up_color=blue&up_message=online&url=https%3A%2F%2Flibrephotos.com) ![GitHub contributors](https://img.shields.io/github/contributors/librephotos/librephotos?style=plastic)
@@ -17,7 +17,7 @@ Before you begin, ensure you have the following installed:
 
 :::info
 
-- Use absolute paths (not relative) when configuring `codedir` and `scanDirectory` in your `.env` file
+- Use absolute paths (not relative) when configuring `scanDirectory` in your `.env` file
 - Docker Compose v2 uses `docker compose` (with a space) instead of `docker-compose` (with a hyphen)
 
 :::
@@ -30,9 +30,9 @@ Create a project directory and clone the LibrePhotos monorepo. All apps (backend
 
 **Linux/macOS:**
 ```bash
-export codedir=~/dev
-mkdir -p $codedir
-cd $codedir
+export devdir=~/dev
+mkdir -p $devdir
+cd $devdir
 
 git clone https://github.com/LibrePhotos/librephotos.git
 cd librephotos
@@ -40,9 +40,9 @@ cd librephotos
 
 **Windows (PowerShell):**
 ```powershell
-$Env:codedir = "$HOME\dev"
-New-Item -ItemType Directory -Force -Path $Env:codedir
-Set-Location $Env:codedir
+$Env:devdir = "$HOME\dev"
+New-Item -ItemType Directory -Force -Path $Env:devdir
+Set-Location $Env:devdir
 
 git clone https://github.com/LibrePhotos/librephotos.git
 Set-Location librephotos
@@ -65,17 +65,7 @@ scanDirectory=/home/youruser/dev/test-photos
 
 # Internal data directory
 data=./librephotos/data
-
-# CRITICAL: Path to the monorepo checkout
-# This must match where you ran the git clone command
-codedir=/home/youruser/dev/librephotos
 ```
-
-:::warning
-
-The `codedir` variable must be an absolute path and point at the root of the cloned monorepo. Docker will mount the source code from this location.
-
-:::
 
 ### Step 3: Start Development Environment
 
@@ -83,11 +73,11 @@ The `codedir` variable must be an absolute path and point at the root of the clo
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 ```
 
-The first build will take 10-20 minutes as it:
-- Downloads base images
-- Installs Python dependencies
-- Installs Node.js dependencies
-- Downloads ML models
+The first startup takes 10-20 minutes:
+- The image build downloads the base images and installs the Python dependencies.
+- On first start the frontend container runs `yarn install`. It does this on every start, so the first start is the slowest.
+
+ML models are **not** downloaded during this step. They are fetched in the background the first time something needs them — saving ML settings, starting a photo scan, or running face recognition — and total several GB.
 
 ### Step 4: Access LibrePhotos
 
@@ -96,7 +86,7 @@ Once the containers are running, access the application:
 - **Application**: http://localhost:3000
 - **API Documentation (Swagger)**: http://localhost:3000/api/swagger
 - **API Documentation (ReDoc)**: http://localhost:3000/api/redoc
-- **pgAdmin (Database UI)**: http://localhost:3001 (user: admin@admin, pass: admin)
+- **pgAdmin (Database UI)**: http://localhost:3001 (user: `admin@admin.com`, pass: `admin` — override with `PGADMIN_DEFAULT_EMAIL` / `PGADMIN_DEFAULT_PASSWORD` in your `.env`)
 
 Create your admin account through the web interface or via command line:
 
@@ -130,11 +120,15 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f frontend
 ```bash
 docker exec -it backend bash
 
-# Now inside the container:
+# Now inside the container (/code is apps/backend):
 python manage.py migrate
 python manage.py shell
 python manage.py test api.tests
+ruff check .      # lint
+ruff format .     # format
 ```
+
+CI runs `ruff check apps/backend` and `ruff format --check apps/backend` on every pull request, so run these before pushing or the required `lint-backend` check will fail.
 
 **Frontend (Node.js):**
 ```bash
@@ -147,16 +141,19 @@ yarn test
 
 ### Rebuilding After Dependency Changes
 
-When you modify `requirements.txt` (backend) or `package.json` (frontend):
+**Backend (`requirements.txt` / `requirements.dev.txt`)** — Python packages are installed into the image at build time, so rebuild the image and recreate the container:
 
 ```bash
-# Rebuild the affected container
-docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache backend
-# or
-docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build backend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d backend
+```
 
-# Restart containers
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+A plain `build` already re-runs `pip install`, because copying the changed source invalidates the cache; add `--no-cache` only if you suspect a stale layer.
+
+**Frontend (`package.json`)** — no image rebuild is needed. The dev image contains no `node_modules`; the entrypoint runs `yarn install` into the bind-mounted `apps/frontend` every time the container starts. Just restart it:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml restart frontend
 ```
 
 ### Common Docker Commands
@@ -171,7 +168,9 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml restart backend
 # Stop all containers
 docker compose -f docker-compose.yml -f docker-compose.dev.yml down
 
-# Stop and remove all data (fresh start)
+# Stop containers and remove anonymous volumes. NOTE: your photos and database
+# live in host bind mounts (the `data` / `scanDirectory` paths in your .env) and
+# are NOT deleted by this — see "Database Issues" below for a real reset.
 docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
 
 # Access container shell
@@ -234,7 +233,6 @@ In development mode, access `/api/silk` for request profiling and SQL query anal
 ### Frontend (React)
 
 - **React DevTools**: Install the [browser extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
-- **Redux DevTools**: Install the [browser extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
 - **WDYR (Why Did You Render)**: Set `VITE_APP_WDYR=true` in `deploy/compose/.env` to log component
   re-render reasons to the browser console. The value must be the lowercase string `true`; anything
   else leaves WDYR off. Recreate the frontend container to pick up the change:
@@ -259,8 +257,14 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 ### Database Issues
 
 ```bash
-# Reset the database
-docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
+# Reset the database. The Postgres data is a host bind mount, not a Docker
+# volume, so `down -v` will NOT clear it — you must delete the directory.
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down
+
+# Remove the DB directory under your `data` path (default ./librephotos/data,
+# relative to deploy/compose/). The files are root-owned, hence sudo.
+sudo rm -rf ./librephotos/data/db
+
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 # Run migrations manually
@@ -271,12 +275,22 @@ docker exec -it backend python manage.py migrate
 
 If port 3000 is in use, change `httpPort` in your `.env` file:
 ```bash
-httpPort=3001
+httpPort=3080
 ```
+
+Avoid `3001`: in the dev stack that host port is already taken by the pgAdmin service, whose port is fixed and not configurable through `.env`.
 
 ### Source Code Not Updating
 
-Ensure your `codedir` path in `.env` exactly matches the root of the cloned monorepo. The path must be absolute (starting with `/` on Linux/macOS).
+The dev stack bind-mounts the source into the containers (`../../apps/backend` and `../../apps/frontend`). Compose resolves those relative paths against the location of the compose files you pass to `-f` — not your shell's current directory — so the code that runs is whatever clone contains the `deploy/compose` files you launched. If your edits don't appear, make sure you're editing the same checkout you started the stack from, not a copy of it.
+
+You can check what is actually mounted with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml config
+```
+
+and reading the resolved `volumes:` source paths (or run `docker inspect backend`).
 
 ## Next Steps
 

--- a/apps/docs/docs/development/index.md
+++ b/apps/docs/docs/development/index.md
@@ -1,31 +1,35 @@
 ---
 title: "Development"
+description: "Set up a LibrePhotos development environment and contribute to the backend, frontend, and mobile apps."
 sidebar_position: 4
 ---
 
 ## Architecture
 
-Currently the setup is split up into for different containers. In this document the general architecture and reason for the components will be explained
+Currently the standard setup is split up into four different containers. In this document the general architecture and reason for the components will be explained.
+
+LibrePhotos also ships a single-container image (`reallibrephotos/librephotos-unified`, built from `deploy/docker/unified/`), which is the deployment the installation docs recommend for most users. In that mode there is no NGINX proxy and no separate frontend container: the frontend build is collected into Django's static files and served by WhiteNoise from Gunicorn on port 8001 (`SERVE_FRONTEND=true`), and the database defaults to SQLite. See [Single Container Deployment](../installation/unified-deployment.md) for the details.
 
 ### Backend
 
 The Backend uses Django as a Framework. Everything the generally applies to Django can be applied to LibrePhotos. If there is some feature that is in Django, but not yet in LibrePhotos, then this would be quite easy to add.
 
-In general there are four process running in the backend.
+In general there are around ten processes running in the backend.
 
-- As a Webserver and for the handling of general API calls we use Gunicorn. Scaling works here with the worker argument Gunicorn provides-
-- For long running jobs we use django_q2 with ORM settings. Scaling works here with the HEAVYWORKER env variable.
-- A image similarity service is also hosted, which uses faiss. If you want to get similar images or if you want to search semantically, this is needed.
-- A thumbnail service, which generates thumbnails. Pretty selfexplanatory, is only used, because pytorch and imagemagick do not play nice together.
+- As a webserver and for the handling of general API calls we use Gunicorn. Scaling works here with the worker count Gunicorn provides, set via the `WEB_CONCURRENCY` env variable.
+- For long running jobs we use django_q2 with the ORM broker. The worker pool is sized by the `WORKER_CONCURRENCY` env variable (set as `workerConcurrency` in the compose `.env`, see `deploy/compose/librephotos.env`); left unset, django-q falls back to one worker per CPU core. The "Limiting CPU and memory usage" section of [Advanced docker-compose usage](../installation/environment-variables.md) covers how to tune it.
+- On top of those, `manage.py start_service all` (run from the container entrypoint) launches a set of small HTTP sidecar services, each on its own port, and registers a django_q2 schedule (`api.services.check_services`) that health-checks them every minute and restarts any that died. The authoritative list and ports live in the `SERVICES` dict in `apps/backend/api/services.py`; it currently covers image similarity (8002), thumbnails (8003), face recognition (8005), CLIP embeddings (8006), image captioning (8007), the LLM chat service (8008), EXIF extraction (8010) and tag extraction (8011). The LLM service is skipped on CPUs that lack the AVX/SSE4.2 instruction sets it needs, so the exact process count varies.
+  - The **image similarity** service uses faiss and powers "similar photos" lookups. It is also the second hop of semantic search: a text query is first sent to the **CLIP embeddings** service (8006) to be turned into an embedding, which is then handed to the image similarity service (8002) to find matching photos.
+  - The **thumbnail** service generates thumbnails. It runs as its own process only because PyTorch and ImageMagick do not play nice together in the same one.
 
 ### Frontend
 
-Pretty simple container. In production this is just a static webserver with the build frontend project. The dev version installs the right packages with the right node versions to seamlessly work.
+Pretty simple container. In production this is just a static webserver with the build frontend project. The dev version installs the right packages with the right node versions to seamlessly work. (The single-container image has no separate frontend container; Django serves the built frontend itself.)
 
 ### Proxy
 
-We use a reverse proxy to handle traffic from outside to the frontend and backend. We use NGNIX for it. Serving actual images and videos is also done with NGINX, because it is better at it then Django.
+We use a reverse proxy to handle traffic from outside to the frontend and backend. We use NGINX for it. Serving actual images and videos is also done with NGINX, because it is better at it then Django. (The single-container image has no proxy; Django serves everything itself.)
 
 ### Database
 
-This is usually Postgres, but maybe could be different databases in the future. However there are still two or three features depending on Postgres running.
+The split-container setup uses PostgreSQL, which is hardcoded in `apps/backend/librephotos/settings/production.py`. The single-container image supports both backends, selected with the `DB_BACKEND` environment variable - `sqlite` (the default) or `postgresql` - configured in `deploy/docker/unified/production_noproxy.py`. Backend code should therefore stay portable across both engines.

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -1,7 +1,7 @@
 ---
 title: "📖 Advanced docker-compose usage"
-excerpt: "Here are a couple of advanced tips"
-sidebar_position: 5
+description: "Here are a couple of advanced tips"
+sidebar_position: 4
 ---
 
 ### PostgreSQL v18+ Volume Mount Change
@@ -203,19 +203,32 @@ services:
 
 By default LibrePhotos is served from the root of a domain (e.g. `https://photos.example.com/`). If you need to host it under a sub-path instead (e.g. `https://example.com/photos/`), the frontend has to know that base path.
 
-The frontend reads it from the `PUBLIC_URL` build-time variable (the alias `VITE_PUBLIC_URL` also works). It sets the base path used for the app's assets and routes and defaults to `/`.
+The frontend reads it from the `VITE_PUBLIC_URL` build-time variable. It sets the base path the app's static assets are loaded from and the prefix its API calls are made against, and defaults to `/`. (`PUBLIC_URL` is also read by `vite.config.ts`, but only for the asset paths — set it on its own and the app's API calls still point at the domain root and fail, so use `VITE_PUBLIC_URL`.)
 
 Because it is applied when the frontend is **built**, the prebuilt images are served from `/`. To use a sub-path you need to build the frontend yourself with the variable set, for example:
 
 ```bash
 # building the frontend directly
-PUBLIC_URL=/photos/ yarn build
+VITE_PUBLIC_URL=/photos yarn build
 ```
 
-or by passing `PUBLIC_URL` into the frontend image build. Make sure your reverse proxy forwards the same sub-path (`/photos/`) to the frontend container.
-
 :::note
-Always include the trailing slash, e.g. `/photos/`, not `/photos`.
+Do not add a trailing slash: use `/photos`, not `/photos/`. The app joins this value directly with `/api` and `/login`, so a trailing slash produces doubled paths such as `/photos//api`. Vite adds the slash it needs for the asset URLs on its own.
+:::
+
+The bundled proxy — not the frontend container — is the one published to the host (on `httpPort`, `3000` by default), and its nginx config matches `/api`, `/media` and the other backend paths anchored at the root. So an outer reverse proxy has to strip the sub-path before handing requests on to it, for example:
+
+```nginx
+location /photos/ {
+  # the trailing slash on proxy_pass strips the /photos/ prefix
+  proxy_pass http://127.0.0.1:3000/;
+}
+```
+
+Alternatively, re-anchor the location blocks in `deploy/docker/proxy/nginx.conf` under the sub-path yourself.
+
+:::warning
+Sub-path hosting is not fully working today. `VITE_PUBLIC_URL` re-bases the assets and the API calls, but the client-side router (`apps/frontend/src/App.tsx`) is created without a matching base path, so once the app has loaded its in-browser routes are still matched against root-relative paths and navigation breaks. Fixing this needs a change in the frontend, not just the build variable.
 :::
 
 ### Changing the container names
@@ -238,16 +251,24 @@ Older guides mention a `make rename` helper that rewrote these names from your `
 
 ### Old environment variables
 
-These are now site settings. If you set these values, they will act as the default on the first set-up.
+These are now site settings: setting them here only supplies the default used on the first set-up, after which the value lives in the site settings and any change you make there takes precedence.
 
 ```bash
 # Comma delimited list of patterns to ignore (e.g. "@eaDir,#recycle" for synology devices)
 skipPatterns=
 # Allow uploading files
 allowUpload=true
-# Do you want to see on a map where all your photos where taken (if a location is stored in your photos)
-# Get a Map box API Key https://account.mapbox.com/auth/signup/
+# API key for the geocoding map provider. Only needed if you switch the provider
+# to Mapbox, MapTiler, TomTom or OpenCage; the default, Nominatim (OpenStreetMap),
+# needs no key.
 mapApiKey=
+```
+
+### Admin account variables
+
+`userName`, `userPass` and `adminEmail` are **not** site settings. They are still live environment variables, wired to `ADMIN_USERNAME`, `ADMIN_PASSWORD` and `ADMIN_EMAIL` in `docker-compose.yml`:
+
+```bash
 # Username for the Administrator login.
 userName=admin
 # Password for the administrative user you set above.
@@ -255,3 +276,11 @@ userPass=admin
 # Email for the administrative user.
 adminEmail=admin@example.com
 ```
+
+Whenever `userName` is set, the backend entrypoint runs `createadmin` on **every** container start:
+
+- On the first start it creates the superuser. The username is lower-cased, and `adminEmail` is used for the account.
+- On every later start the existing user's password is overwritten with `userPass`. Leaving `userPass` set therefore resets the admin password on each restart — a password you changed in the UI will not survive a `docker compose restart`. This is the same behaviour described under [How to change the admin password, when you can't log in](../user-guide/managing-users.md#how-to-change-the-admin-password-when-you-cant-log-in).
+- `adminEmail` is only applied when the account is first created; on later starts `createadmin` ignores it and logs a warning.
+
+To stop the password from being reset, clear `userName` — that skips `createadmin` entirely. Clearing only `userPass` while leaving `userName` set instead makes the command abort on each start with "Admin password cannot be empty".

--- a/apps/docs/docs/installation/index.md
+++ b/apps/docs/docs/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Installation"
+description: "How to install LibrePhotos: single-container, standard Docker, and platform-specific guides."
 sidebar_position: 2
 ---
 
@@ -22,12 +23,17 @@ A simplified single-container deployment that serves both the API and frontend f
 - Existing PostgreSQL infrastructure
 - Simplified container management
 
+:::note
+The unified image is CPU-only. It is built on the CPU base image, and no GPU-enabled unified image is published. If you want NVIDIA GPU acceleration, use the [Standard Docker Setup](standard-install.md) instead, where the `backend` service is swapped to the `reallibrephotos/librephotos-gpu` image (see [Utilizing GPU Acceleration](environment-variables.md#utilizing-gpu-acceleration)).
+:::
+
 ## 🐋 [Standard Docker Setup](standard-install.md)
 **For advanced users and high-traffic deployments**
 
 The traditional multi-container setup with separate nginx proxy. Choose this if you:
 - Need nginx-specific features and optimizations
 - Run high-traffic deployments
+- Want NVIDIA GPU acceleration (see [Utilizing GPU Acceleration](environment-variables.md#utilizing-gpu-acceleration) — x86 only)
 - Prefer the original architecture
 
 ## Platform-Specific Guides

--- a/apps/docs/docs/installation/standard-install.md
+++ b/apps/docs/docs/installation/standard-install.md
@@ -1,7 +1,7 @@
 ---
 title: "🐋 Standard Docker Setup"
-excerpt: "Traditional multi-container deployment with nginx proxy."
-sidebar_position: 3
+description: "Traditional multi-container deployment with nginx proxy."
+sidebar_position: 2
 ---
 
 ## Docker Compose
@@ -38,7 +38,7 @@ Do not forget to create the directories you specified in the `.env` file if they
 If you are using Postgres v18+, you must mount your database volume to `/var/lib/postgresql` instead of `/var/lib/postgresql/data`. See the [advanced usage guide](environment-variables.md#postgresql-v18-volume-mount-change) for details.
 :::
 
-Start LibrePhotos with `docker-compose up -d`
+Start LibrePhotos with `docker compose up -d`
 
 You should have LibrePhotos accessible after a few minutes of boot-up on [localhost:3000](http://localhost:3000)
 
@@ -54,12 +54,21 @@ For more details, see the [first steps guide](../user-guide/first-steps.md).
 
 ### Updating
 
-To update LibrePhotos when using Docker Compose, navigate to the `librephotos/deploy/compose` folder that was created when you installed LibrePhotos.
-
-Then run:
+To update LibrePhotos when using Docker Compose, first refresh your checkout so you also pick up changes to `docker-compose.yml`, then update the running containers. From the `librephotos/deploy/compose` folder that was created when you installed LibrePhotos, run:
 
 ```sh
-docker-compose down
-docker-compose pull
-docker-compose up -d
+git pull            # updates docker-compose.yml and the other tracked files
+docker compose down
+docker compose pull # only refreshes the container images
+docker compose up -d
 ```
+
+:::note
+
+`docker compose pull` only downloads newer container images. `docker-compose.yml` is a tracked file in the repository and gains new settings over time. Recent versions, for example, added the lines that pass `workerConcurrency`, `gunicornTimeout` and `frontendBaseUrl` from your `.env` through to the backend, and changed the database volume path for Postgres v18+. If your `docker-compose.yml` predates those changes, setting the matching variables in `.env` has no effect until you `git pull`.
+
+Your `.env` is not tracked by git, so `git pull` will not touch your settings. After updating, compare it against the shipped `librephotos.env` to pick up any newly documented variables.
+
+If you edited `docker-compose.yml` yourself — for instance to use the GPU image or to set resource limits, as described in the [advanced usage guide](environment-variables.md) — `git pull` may refuse to update or report a conflict. Run `git stash` before the pull and `git stash pop` afterwards, then re-apply your changes on top of the updated file.
+
+:::

--- a/apps/docs/docs/installation/unified-deployment.md
+++ b/apps/docs/docs/installation/unified-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: "🚀 Single Container Deployment"
-excerpt: "Simplified single-container deployment with internal or external database"
-sidebar_position: 2
+description: "Simplified single-container deployment with internal or external database"
+sidebar_position: 1
 ---
 
 ## Overview
@@ -38,9 +38,9 @@ Single container deployment serves both the LibrePhotos API and frontend from on
 
 
 **Notes:**
-- **Secret key**: Optional - if not provided, one will be generated and saved to `/logs/secret_key.txt`
+- **Secret key**: Optional - if not provided, one will be generated and saved to `/logs/secret.key`. Do not delete this file (see [Internal files](../user-guide/internal-files.md)). To supply your own, pass `-e SECRET_KEY=...`
 - **Database**: SQLite file will be created automatically in the `/db` directory
-- **Photos**: Mount your photo directory as read-only if preferred: `-v /path/to/photos:/data:ro`
+- **Photos**: You can mount your photo directory read-only (`-v /path/to/photos:/data:ro`), but this disables uploading, deleting photos, and writing metadata back to files — uploads are otherwise written to an `uploads/` folder inside `/data`. Uploads are on by default, so if you use `:ro`, also pass `-e ALLOW_UPLOAD=false` (or turn off "Allow Upload" in the setup wizard). See [Why is the scan directory not mounted read-only?](../user-guide/faq.md#why-is-the-scan-directory-not-mounted-read-only)
 
 ## 🗄️ Option 2: External PostgreSQL Database
 
@@ -49,18 +49,27 @@ Single container deployment serves both the LibrePhotos API and frontend from on
 ### 1. PostgreSQL Setup
 
 **Existing PostgreSQL:**
+
+Create the database and a user that owns it. On first start the container runs `manage.py migrate` as this user, so it must be able to create tables — and since PostgreSQL 15, `GRANT ALL PRIVILEGES ON DATABASE` no longer conveys that. Make the app user the database owner instead:
+
 ```sql
-CREATE DATABASE librephotos;
 CREATE USER librephotos_user WITH PASSWORD 'your_secure_password';
-GRANT ALL PRIVILEGES ON DATABASE librephotos TO librephotos_user;
+CREATE DATABASE librephotos OWNER librephotos_user;
 ```
 
+If the database already exists, run `ALTER DATABASE librephotos OWNER TO librephotos_user;`. For a database carried over from PostgreSQL 14 or earlier, also connect to it (`\c librephotos`) and run `GRANT ALL ON SCHEMA public TO librephotos_user;`.
+
 **New PostgreSQL container:**
+
+Create a shared network first so the database and LibrePhotos containers can reach each other by name, then start PostgreSQL on it (creating the database through `POSTGRES_USER`/`POSTGRES_DB` makes `librephotos_user` its owner, so no extra grants are needed):
+
 ```bash
+sudo docker network create librephotos-net
+
 sudo docker run -d \
   --name librephotos-db \
+  --network librephotos-net \
   --restart unless-stopped \
-  -p 5432:5432 \
   -e POSTGRES_DB=librephotos \
   -e POSTGRES_USER=librephotos_user \
   -e POSTGRES_PASSWORD=your_secure_password \
@@ -73,6 +82,7 @@ sudo docker run -d \
 ```bash
 sudo docker run -d \
   --name librephotos \
+  --network librephotos-net \
   --restart unless-stopped \
   -p 3000:8001 \
   -v /home/yourusername/librephotos/protected_media:/protected_media \
@@ -83,10 +93,19 @@ sudo docker run -d \
   -e DB_NAME=librephotos \
   -e DB_USER=librephotos_user \
   -e DB_PASS=your_secure_password \
-  -e DB_HOST=localhost \
+  -e DB_HOST=librephotos-db \
   -e DB_PORT=5432 \
   reallibrephotos/librephotos-unified:latest
 ```
+
+Set `DB_HOST` to match your database:
+
+- **Sibling `librephotos-db` container**: keep `--network librephotos-net` and use `-e DB_HOST=librephotos-db` (the container name), as shown above. `DB_HOST=localhost` will not work — inside the container it points back at LibrePhotos itself, not the database.
+- **Existing PostgreSQL server**: drop `--network librephotos-net` and set `-e DB_HOST=<hostname or IP of that server>`. If it runs on the Docker host itself, add `--add-host=host.docker.internal:host-gateway` and use `-e DB_HOST=host.docker.internal`, and make sure PostgreSQL listens on all interfaces with a matching `pg_hba.conf` entry.
+
+## Behind a reverse proxy
+
+If you put this container behind an HTTPS reverse proxy (Traefik, Caddy, a cloud load balancer), add `-e CSRF_TRUSTED_ORIGINS=https://photos.example.com` (comma-separated for several origins; each must include the scheme and match the browser-visible address exactly). The unified image starts with an empty trusted-origin list, so without it the Django admin at `/api/django-admin/` rejects logins with a CSRF error. The photo app itself is unaffected — it authenticates with JWT and its API endpoints are CSRF-exempt.
 
 ## Next Steps
 

--- a/apps/docs/docs/installation/unraid.md
+++ b/apps/docs/docs/installation/unraid.md
@@ -1,7 +1,7 @@
 ---
 title: "📦 unRAID"
-excerpt: "How to install LibrePhotos on Unraid using Docker Compose."
-sidebar_position: 4
+description: "How to install LibrePhotos on Unraid using Docker Compose."
+sidebar_position: 3
 ---
 
 ## Docker Compose
@@ -37,7 +37,10 @@ wget -O .env https://raw.githubusercontent.com/LibrePhotos/librephotos/dev/deplo
 wget https://raw.githubusercontent.com/LibrePhotos/librephotos/dev/deploy/compose/docker-compose.yml
 ```
 
-You'll need to edit the .env file with paths to your photos (myPhotos) and possibly the timeZone variable. Optionally, you'll want to grab a mapbox API key as documented in the file. Keep note of the default HTTP port, 3000.
+You'll need to edit the .env file and set the two mandatory variables: `scanDirectory`, the folder holding your photos (e.g. `/mnt/user/pictures`), and `data`, a folder for LibrePhotos' internal state - its database, protected media, logs and model cache (e.g. `/mnt/user/appdata/librephotos`). Create both folders before you start the stack, and keep note of the default HTTP port, 3000.
+
+The map API key is no longer set in this file. After first boot, set it under your avatar -> Admin Area -> Site Settings. See [Old environment variables](environment-variables.md#old-environment-variables) if you'd rather seed it as a first-boot default.
+
 You should have LibrePhotos accessible after a few minutes of boot-up on unraidip:3000 unless you changed this in the .env file.
 
 ​Once done, you can fire up the containers by typing:
@@ -60,10 +63,16 @@ docker ps | grep librephoto
 
 Finally, you can access the UI by going to http://unraidip:3000
 
-Furthermore, you can also monitor progress from shell prompt by tailing this file:
+Furthermore, you can also monitor progress from the shell prompt by tailing the backend log. It lives at `logs/ownphotos.log` inside the `data` folder you set in .env (with the example above, that is `/mnt/user/appdata/librephotos/logs/ownphotos.log`):
 
 ```bash
-tail -f librephotos_logs/ownphotos.log
+tail -f /mnt/user/appdata/librephotos/logs/ownphotos.log
+```
+
+Or, independent of where you mounted it - the backend container is always named `backend`:
+
+```bash
+docker exec backend tail -f /logs/ownphotos.log
 ```
 
 To shut everything down:
@@ -72,11 +81,15 @@ To shut everything down:
 docker-compose down
 ```
 
-If you want to grab any updates, you can type:
+If you want to grab any updates, run:
 
 ```bash
+docker-compose down
 docker-compose pull
+docker-compose up -d
 ```
+
+Running `docker-compose pull` on its own only downloads the new images; the containers keep running the old ones until they are recreated, so pull the images and then bring the stack back up.
 
 ## docker-compose issues when rebooting
 

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-excerpt: "A self-hosted open source photo management service."
+description: "A self-hosted open source photo management service."
 sidebar_position: 1
 ---
 
@@ -8,6 +8,12 @@ sidebar_position: 1
 <sub>Mock-up designed by rawpixel.com / Freepik</sub>
 
 Unlike commercial service that store your photos in the cloud and scan/index them to train their machine learning models and collect ad targeting data on you, LibrePhotos keeps all your photos and metadata on your local machine. Your data is never sent to or stored on a 3rd party server. Get the same power as those commercial services without giving up your personal data and privacy.
+
+## Get started
+
+- **[Install LibrePhotos](installation/index.md)** — pick a deployment method and get the server running.
+- **[First steps](user-guide/first-steps.md)** — what to do right after your first login.
+- **[Development setup](development/index.md)** — build LibrePhotos locally and contribute.
 
 ## Features
 
@@ -35,8 +41,9 @@ Unlike commercial service that store your photos in the cloud and scan/index the
 - **RAW Conversion:** [ImageMagick](https://github.com/ImageMagick/ImageMagick)
 - **Video Conversion:** [FFmpeg](https://github.com/FFmpeg/FFmpeg)
 - **EXIF Support:** [ExifTool](https://github.com/exiftool/exiftool)
-- **Face detection:** [face_recognition](https://github.com/ageitgey/face_recognition)
-- **Face classification/clusterization:** scikit-learn
+- **Face detection:** [InsightFace](https://github.com/deepinsight/insightface) (SCRFD detector + ArcFace embeddings)
+- **Face classification/clusterization:** [scikit-learn](https://scikit-learn.org/) and [hdbscan](https://github.com/scikit-learn-contrib/hdbscan)
 - **Image captioning:** [im2txt](https://github.com/HughKu/Im2txt), [BLIP](https://github.com/salesforce/BLIP), and [Moondream 2](https://github.com/vikhyat/moondream)
-- **Scene classification** [places365](http://places.csail.mit.edu/)
+- **Scene classification / tagging:** [places365](http://places.csail.mit.edu/) (default) or [SigLIP 2](https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX), selectable in the admin site settings
+- **Semantic search:** [CLIP](https://huggingface.co/sentence-transformers/clip-ViT-B-32) via [sentence-transformers](https://www.sbert.net/), with embeddings indexed by [FAISS](https://github.com/facebookresearch/faiss) (also powers similar-photo suggestions)
 - **Reverse geocoding:** [Nominatim](https://nominatim.openstreetmap.org/) (default) and other providers (Mapbox, MapTiler, OpenCage, TomTom)

--- a/apps/docs/docs/user-guide/albums.md
+++ b/apps/docs/docs/user-guide/albums.md
@@ -1,7 +1,7 @@
 ---
 title: "📁 Albums"
-excerpt: "Managing your photo albums in LibrePhotos"
-sidebar_position: 5
+description: "Managing your photo albums in LibrePhotos"
+sidebar_position: 4
 ---
 
 # Albums
@@ -17,13 +17,17 @@ Albums you create manually to organize photos however you like. You can add any 
 Automatically generated albums based on face recognition. Each recognized person gets their own album.
 
 ### Auto Albums (Events)
-Automatically generated albums based on time and location patterns in your photos.
+Albums that group your photos into events based on when they were taken. Grouping is purely chronological: a photo joins the current event if it was taken less than **1 day and 12 hours** after the previous photo already in that event, so a continuous trip stays a single event however long it runs. An event needs at least two photos — a single photo on its own produces no album. Location and recognized people are not used for the grouping itself; they only feed the album's generated title (for example "Weekend in Paris") and its position on the map.
+
+:::note
+Unlike People, Places and Things albums, event albums are **not** created during a scan. To create them, open **Settings → Library**, find the **Event Albums** section and click **Generate** (or run the **Generate Event Albums** command from the search spotlight), and re-run it after importing new photos. **Regenerate Event Titles** only refreshes the titles of existing albums, which is useful once you have named faces or after reverse geocoding has filled in place names. See [Job System](./job-system.md) for the underlying jobs.
+:::
 
 ### Places Albums
 Automatically generated albums based on the GPS location data in your photos.
 
 ### Things Albums
-Automatically generated albums based on detected objects and scenes in your photos. Things Albums are filtered by the currently active **Tagging Model** (configurable in Site Settings), so only tags from the selected model are shown. Switching models instantly updates which Things Albums are visible.
+Automatically generated albums based on detected objects and scenes in your photos. Things Albums are filtered by the currently active **Tagging Model** (configurable in Site Settings), so only tags from the selected model are shown. Switching models does not delete your existing tags, but it also does not create tags for the newly selected model — until tags exist for that model, the Things section will look empty. To generate them, run a full **Rescan** from **Settings → Library** (in the *Scan Library* section, open the dropdown next to **Scan** and choose **Rescan**), which retags your existing photos. Albums created from `#hashtags` you typed into photo captions are always shown, regardless of the active model.
 
 ---
 
@@ -49,7 +53,7 @@ The cover picker loads photos in batches of 50 for better performance. Click "Lo
 If you already know which photo you want to use:
 
 1. Navigate to the album
-2. **Select exactly one photo** by clicking on it (you'll see a checkmark appear)
+2. **Select exactly one photo** — hover over it and click the checkbox that appears in its top-left corner (a plain click on a photo opens it in the lightbox instead of selecting it)
 3. Click the **three-dot menu** (⋮) in the selection toolbar
 4. Click **"Set album cover"**
 5. The selected photo becomes the cover immediately
@@ -71,15 +75,28 @@ The "Set album cover" option only appears when you're viewing a People Album or 
 
 ---
 
+## Renaming and Deleting User Albums
+
+On the **Albums** page, every User Album card has a **three-dot menu** (⋮) in its top-right corner. From it you can:
+
+- **Rename** — enter a new title and confirm. Titles must be unique; the dialog blocks a name that another one of your albums already uses.
+- **Sharing** — open the album sharing dialog (see the [Sharing guide](./sharing.md)).
+- **Delete** — a confirmation dialog appears before the album is removed.
+
+:::caution
+Deleting an album is permanent and cannot be undone, but it only removes the album itself. The photos it contained stay in your library.
+:::
+
+---
+
 ## Sharing Albums
 
 User Albums can be shared with other users on your LibrePhotos instance, or publicly via a link. For full details on all sharing features, see the [Sharing guide](./sharing.md).
 
 1. Navigate to the User Album you want to share
-2. Select any photo to activate the selection toolbar
-3. Click the **three-dot menu** (⋮)
-4. Under "Album Actions", click **"Sharing"**
-5. Search for and select the users you want to share with
+2. Click the **three-dot menu** (⋮) in the selection toolbar
+3. Under "Album Actions", click **"Sharing"**
+4. Search for and select the users you want to share with
 
 ---
 
@@ -88,15 +105,16 @@ User Albums can be shared with other users on your LibrePhotos instance, or publ
 You can share albums publicly with anyone via a unique link, without requiring them to have an account on your LibrePhotos instance:
 
 1. Navigate to the User Album you want to share publicly
-2. Go to the **Sharing** page from the navigation
-3. Click **"Create Public Link"** for the album
-4. A unique URL slug will be generated that you can share with anyone
-5. Configure **privacy settings** for the public link to control what information is visible:
+2. Click the **three-dot menu** (⋮) in the selection toolbar and, under "Album Actions", click **"Sharing"**
+3. In the dialog, toggle **"Public sharing"** on — a unique URL slug is generated automatically that you can share with anyone
+4. Click **"Show settings"** to customize the slug (3–64 characters), set an expiration (7, 30 or 90 days, or never), and control what information visitors can see:
    - Location data
    - Camera information
    - Timestamps
    - Captions
    - Recognized faces
+
+Once an album is public, it appears under **Sharing → Links**, where you can copy the link, open it, or reopen the sharing dialog to change its settings. Albums that are not yet public are not listed there.
 
 Default privacy settings for new public links can be configured in **Settings → Public Sharing Defaults**.
 

--- a/apps/docs/docs/user-guide/api-authentication.md
+++ b/apps/docs/docs/user-guide/api-authentication.md
@@ -3,6 +3,7 @@ id: api-authentication
 title: API authentication
 sidebar_label: API authentication
 description: How to authenticate against the LibrePhotos API (JWT and Basic auth)
+sidebar_position: 24
 ---
 
 LibrePhotos secures most API endpoints and requires authentication by default. If you see 401 Unauthorized or 403 Forbidden responses when calling API endpoints, you likely need to authenticate using one of the supported methods below.
@@ -43,6 +44,20 @@ curl -X POST "http://<backend>/api/auth/token/refresh/" \
   -d '{"refresh":"<refresh_token>"}'
 ```
 
+Access tokens are short-lived and expire after 5 minutes; refresh tokens are valid for 7 days by default. Refreshing returns a new `access` token only, so keep reusing the same `refresh` token until it expires. A long-running script should refresh at least every 5 minutes, or simply retry once against `/api/auth/token/refresh/` whenever a call returns 401. The access-token lifetime is fixed; the refresh-token lifetime can be changed with the `REFRESH_TOKEN_DAYS` environment variable on the backend container.
+
+### Revoke a refresh token (logout)
+
+To invalidate a refresh token — on logout, or to revoke one you think has leaked — blacklist it:
+
+```bash
+curl -X POST "http://<backend>/api/auth/token/blacklist/" \
+  -H 'Content-Type: application/json' \
+  -d '{"refresh":"<refresh_token>"}'
+```
+
+No `Authorization` header is needed; the refresh token itself is the credential. On success you get HTTP 200 with an empty JSON body. Blacklisting stops the refresh token from minting new access tokens, but any access token it has already issued stays valid until it expires (5 minutes by default), so revocation is not instantaneous. This is the same endpoint the web frontend calls when you log out.
+
 ### Call APIs using the JWT access token
 
 Include the token in the `Authorization` header:
@@ -52,7 +67,29 @@ curl -H 'Authorization: Bearer <access_token>' \
   "http://<backend>/api/photos/"
 ```
 
-If you are in a browser environment and already called the token endpoints, the `jwt` cookie will be set and used automatically by the backend for relevant media endpoints. For pure API calls, prefer the Authorization header.
+In a browser, the `jwt` cookie set by the obtain and refresh endpoints is sent automatically, which is how the cookie-only media endpoints authenticate. For the standard JSON endpoints the frontend still adds an `Authorization: Bearer` header, just as a script would. From a script, use the `Authorization` header shown above for the standard JSON endpoints such as `/api/photos/`. A few endpoints accept *only* the cookie — see [Endpoints that require the `jwt` cookie](#endpoints-that-require-the-jwt-cookie) below.
+
+### Endpoints that require the `jwt` cookie
+
+A few endpoints do not use the standard authentication and read the `jwt` cookie directly. An `Authorization: Bearer <access_token>` header or `curl -u user:pass` is ignored there, and you get a 403 when the cookie is missing:
+
+- Media files — `GET /media/photos/<image_hash>` (originals), plus the thumbnail, square-thumbnail, face-crop and avatar paths (`/media/thumbnails_big/...`, `/media/square_thumbnails/...`, `/media/faces/...`, `/media/avatars/...`) and generated archives at `/media/zip/<name>`. These are all served by one view that authenticates only from the cookie.
+- Chunked uploads — `POST /api/upload/` and `POST /api/upload/complete/`.
+- Zip deletion — `DELETE /api/delete/zip/<name>`. This one needs the cookie *in addition to* a normal token: without a Bearer/Basic credential you get 401, and without the cookie you get 403, so send both.
+
+Two exceptions: media belonging to an active public or shared album is served without any credential, and `/media/embedded_media/...` does honour the normal authenticated user.
+
+From a script, capture the cookie when you obtain the token and replay it:
+
+```bash
+curl -c cookies.txt -X POST "http://<backend>/api/auth/token/obtain/" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"myuser","password":"mypassword"}'
+
+curl -b cookies.txt "http://<backend>/media/photos/<image_hash>" -o photo.jpg
+```
+
+or send it explicitly with `-H "Cookie: jwt=<access_token>"`. The cookie carries the short-lived access token, so refresh it the same way you refresh the header token.
 
 ### Call APIs using Basic auth (optional)
 
@@ -60,18 +97,24 @@ If you are in a browser environment and already called the token endpoints, the 
 curl -u myuser:mypassword "http://<backend>/api/photos/"
 ```
 
+Basic auth works on the standard DRF endpoints, but not on the cookie-only endpoints listed above.
+
 ### Helpful endpoints
 
-- API help: `http://<backend>/api/help` returns a structured JSON with authentication instructions and example `curl` commands.
-- OpenAPI/Swagger (development builds with DEBUG enabled):
-  - Schema: `http://<backend>/api/schema`
-  - Swagger UI: `http://<backend>/api/swagger`
-  - Redoc: `http://<backend>/api/redoc`
+These routes are only registered when the backend runs with `DEBUG=1` (development builds). The standard docker-compose deployment runs with `DEBUG=0`, where they all return 404:
+
+- API help: `http://<backend>/api/help` — structured JSON with authentication instructions and example `curl` commands.
+- Schema: `http://<backend>/api/schema`
+- Swagger UI: `http://<backend>/api/swagger`
+- Redoc: `http://<backend>/api/redoc`
+
+For the same reason, the extra `auth` hint that development builds append to a 401/403 error body is not present on a production install, so a production 401 will not point you at `/api/help`.
 
 ### Troubleshooting 401/403
 
 - Ensure you are including `Authorization: Bearer <access_token>` or using Basic auth.
 - Verify the access token is current; refresh if needed.
+- A 403 from `/media/...`, `/api/upload/...` or `/api/delete/zip/...` is not fixed by adding an `Authorization` header — those endpoints need the `jwt` cookie instead (see [Endpoints that require the `jwt` cookie](#endpoints-that-require-the-jwt-cookie)).
 - If testing cross-origin from a separate frontend, ensure CORS and credentials are configured properly and that cookies are allowed if relying on the `jwt` cookie.
 
 

--- a/apps/docs/docs/user-guide/auto-scan.md
+++ b/apps/docs/docs/user-guide/auto-scan.md
@@ -1,7 +1,7 @@
 ---
 title: "🤖 Auto scan all folders"
-excerpt: "How to auto scan all folders"
-sidebar_position: 2
+description: "How to auto scan all folders"
+sidebar_position: 11
 ---
 
 ## Auto scan all folders
@@ -9,12 +9,20 @@ sidebar_position: 2
 You can start a scan with the following command:
 
 ```
-sudo docker exec --user root CONTAINER_NAME python3 manage.py scan
+sudo docker exec --user root backend python3 manage.py scan
 ```
+
+`backend` is the default container name set by `container_name:` in `docker-compose.yml`; substitute your own if you changed it (see [Changing the container names](../installation/environment-variables.md#changing-the-container-names)).
+
+The plain `scan` command is incremental — it only picks up files that are new or that were modified since the last finished scan. Use `scan -f` to force a full re-process of every file, or `scan -s /path/a.jpg /path/b.jpg` to scan specific files. See [Management Commands](./library.md#management-commands) for the full list.
+
+:::note Nextcloud users
+`manage.py scan` only scans the local scan directory. To scan a connected [Nextcloud library](./library.md#nextcloud-integration) from the command line, run `manage.py scan -n` — cron it separately.
+:::
 
 You can just create a cron job to regularly call this command
 
 ```
 # Every day at 3 AM
-0 3 * * * sudo docker exec --user root CONTAINER_NAME python3 manage.py scan >/dev/null 2>&1
+0 3 * * * sudo docker exec --user root backend python3 manage.py scan >/dev/null 2>&1
 ```

--- a/apps/docs/docs/user-guide/duplicate-detection.md
+++ b/apps/docs/docs/user-guide/duplicate-detection.md
@@ -1,7 +1,7 @@
 ---
 title: "🔍 Duplicate Detection"
-excerpt: "Find and manage duplicate photos in your library"
-sidebar_position: 8
+description: "Find and manage duplicate photos in your library"
+sidebar_position: 14
 ---
 
 LibrePhotos can detect duplicate photos in your library using both exact file matching and visual similarity analysis. This helps you reclaim storage space and keep your library clean.
@@ -29,6 +29,12 @@ LibrePhotos computes a 64-bit perceptual hash (pHash) for each image using a DCT
 
 Two images are considered visually similar when their **Hamming distance** (the number of differing bits) is below a threshold.
 
+:::note Visual duplicates need a perceptual hash first
+The perceptual hash is computed while a photo is scanned, from its large thumbnail, and visual duplicate detection only looks at photos that already have one. Photos indexed before this feature was added have no hash, and an ordinary scan skips files it has already indexed — so **Detect Duplicates** can report no visual duplicates on an older library.
+
+To fill in the missing hashes, run a **Rescan** once from the [Library page](./library.md#library-actions) — open the dropdown next to **Scan** and choose **Rescan**; this re-processes every photo. Exact-copy detection uses the file's MD5 hash and isn't affected.
+:::
+
 ### Two-Pass Algorithm
 
 For large collections, LibrePhotos uses a memory-efficient two-pass algorithm:
@@ -43,20 +49,21 @@ This approach keeps memory usage manageable even with hundreds of thousands of p
 
 ### Finding Duplicates
 
-1. Navigate to **Organizing → Duplicates**
-2. Click **"Find Duplicates"**
-3. Configure detection options:
-   - **Exact copies** — Enable to find identical files
-   - **Visual duplicates** — Enable to find visually similar photos
-   - **Sensitivity** — Strict (fewer matches, higher confidence), Normal, or Loose (more matches, may include false positives)
-   - **Clear pending** — Optionally clear previously pending results before running
-4. Click **"Start Detection"**
+1. Navigate to **Organizing → Duplicate Photos**.
+2. Open the **Detection Options** dropdown and choose what to look for. Do this *before* you start detection — the detect button runs immediately with whatever options are currently set:
+   - **Exact file copies (identical content)** — find byte-identical files
+   - **Visual duplicates (similar images)** — find visually similar photos
+   - **Visual sensitivity** — Strict (fewer matches, higher confidence), Normal, or Loose (more matches, may include false positives). This only appears while *Visual duplicates* is enabled.
+   - **Clear pending duplicates** — remove existing pending groups before detection runs
+3. Click **"Detect Duplicates"**. Detection starts straight away using the options you selected.
+
+The Detection Options aren't remembered between runs, so set them each time you detect. The default **Visual sensitivity** and **Clear pending duplicates** values come from **Settings → Duplicate Detection** and can be changed there; the *Exact file copies* and *Visual duplicates* checkboxes always start enabled.
 
 Detection runs as a background job. You can monitor progress in the [Job System](./job-system.md).
 
 ### Reviewing Duplicates
 
-Once detection is complete, duplicates appear as groups on the **Organizing → Duplicates** page:
+Once detection is complete, duplicates appear as groups on the **Organizing → Duplicate Photos** page:
 
 - Each group shows preview thumbnails of the duplicate photos
 - Badges indicate the **type** (exact copy or visual duplicate) and **review status**
@@ -66,8 +73,12 @@ Once detection is complete, duplicates appear as groups on the **Organizing → 
 
 Use the filters at the top to narrow down results:
 
-- **Status**: Pending, Resolved, Dismissed, or All
+- **Status**: Pending Review, Resolved, Dismissed, or All
 - **Type**: Exact Copies or Visual Duplicates
+
+:::note
+Dismissing a group unlinks its photos, which drops it below the two-photo minimum the list requires. As a result the **Dismissed** filter currently returns no groups, even though the **Dismissed (N)** tab still counts them.
+:::
 
 #### Resolving a Duplicate Group
 
@@ -75,14 +86,14 @@ Click on a duplicate group to open the review modal:
 
 1. Each photo is shown with its **resolution**, **file size**, **camera**, **date**, and **file path**
 2. The highest-resolution photo is automatically pre-selected as the one to keep
-3. Click **"Keep This"** on the photo you want to keep (or select a different one)
+3. The pre-selected photo's button reads **"Keep This"**; every other photo shows a **"Select"** button. To keep a different photo, click its **"Select"** button — that photo's button then changes to **"Keep This"**
 4. Click **"Keep Selected & Trash Others"** — the other photos are moved to trash
 5. The group status changes to **Resolved**
 
 #### Other Actions
 
-- **"Not a Duplicate"** — Dismiss the group if the photos aren't actually duplicates. The status changes to **Dismissed**.
-- **"Revert & Restore Photos"** — For resolved or dismissed groups, undo the action and restore any trashed photos.
+- **"Not a Duplicate"** — Dismiss the group if the photos aren't actually duplicates. The group's status changes to **Dismissed** and its photos are unlinked from the group. Because the page only lists groups that still contain two or more photos, a dismissed group then disappears from view entirely — including from the **Dismissed** filter — even though it is still counted in the **Dismissed (N)** tab. This can't be undone from the interface.
+- **"Revert & Restore Photos"** — For **resolved** groups only: undo the resolution, restore the trashed photos from the trash, and set the group back to **Pending**. Dismissed groups can't be reverted — the server rejects the request, and dismissing has already unlinked the photos rather than trashing them.
 - **Delete Group** — Remove the duplicate group record entirely.
 
 ### Batch Operations
@@ -93,5 +104,5 @@ You can select multiple duplicate groups using the checkboxes and delete them in
 
 - **Start with exact copies** — These are guaranteed duplicates and safe to clean up
 - **Review visual duplicates carefully** — Similar-looking photos from a burst sequence or different angles may not be true duplicates
-- **Use strict sensitivity first** — You can always run again with looser settings to find more
+- **Use strict sensitivity first** — Strict gives you high-confidence matches to review. A later run can still form new groups from photos that weren't matched, but visual detection skips any photo already in a visual-duplicate group, so a looser re-run won't add members to groups the strict run already created. To re-evaluate those photos, first clear their groups — enable **Clear pending duplicates** when you re-run (this deletes pending groups only; resolved groups are kept and their photos stay excluded), or delete the individual groups
 - The **batch size** parameter can be tuned in the detection API for systems with limited memory (smaller batches use less RAM but take longer)

--- a/apps/docs/docs/user-guide/exif-data.md
+++ b/apps/docs/docs/user-guide/exif-data.md
@@ -1,7 +1,7 @@
 ---
 title: "📇 Exif Data"
-excerpt: "What exif data can we read, write and filter for"
-sidebar_position: 2
+description: "What exif data can we read, write and filter for"
+sidebar_position: 17
 ---
 
 ## Compatibility
@@ -40,28 +40,35 @@ sidebar_position: 2
         <td>Timestamp</td>
         <td>✔️</td>
         <td>❌</td>
-        <td>Parsing rules settable in settings. Date will only be saved in EXIF:DateTime</td>
+        <td>Parsing rules settable in settings. Dates you edit are written back to XMP:DateCreated, never to an EXIF date tag.</td>
     </tr>
-     <tr>
-        <td>EXIF:DateTime</td>
+    <tr>
+        <td>XMP:DateCreated</td>
         <td>Timestamp</td>
         <td>✔️</td>
         <td>✔️</td>
-        <td>Parsing rules settable in settings. Date will only be saved in EXIF:DateTime</td>
+        <td>The only tag LibrePhotos writes dates to. It is used instead of an EXIF date tag because EXIF tags cannot be written into an XMP sidecar, and because writing it leaves the camera's original EXIF:DateTimeOriginal untouched. Highest-priority date parsing rule.</td>
     </tr>
     <tr>
-        <td>QUICKTIME_CREATE_DATE</td>
+        <td>EXIF:ModifyDate</td>
         <td>Timestamp</td>
         <td>✔️</td>
         <td>❌</td>
-        <td>Parsing rules settable in settings. Date will only be saved in EXIF:DateTime</td>
+        <td>Read-only. Parsing rules settable in settings; dates you edit are written back to XMP:DateCreated.</td>
     </tr>
     <tr>
-        <td>QUICKTIME_DURATION</td>
+        <td>QuickTime:CreateDate</td>
+        <td>Timestamp</td>
+        <td>✔️</td>
+        <td>❌</td>
+        <td>Parsing rules settable in settings. Dates you edit are written back to XMP:DateCreated, never to an EXIF date tag.</td>
+    </tr>
+    <tr>
+        <td>QuickTime:Duration</td>
         <td>Video length</td>
         <td>✔️</td>
         <td>❌</td>
-        <td>Used for videon length on video tiles</td>
+        <td>Used for video length on video tiles</td>
     </tr>
     <tr>
         <td>Composite:GPSLatitude</td>
@@ -76,6 +83,13 @@ sidebar_position: 2
         <td>✔️</td>
         <td>❌</td>
         <td>Used for photo label on map</td>
+    </tr>
+    <tr>
+        <td>Composite:GPSDateTime</td>
+        <td>Timestamp</td>
+        <td>✔️</td>
+        <td>❌</td>
+        <td>Used by the GPS-based timestamp parsing rules.</td>
     </tr>
     <tr>
         <td>EXIF:Model</td>
@@ -107,10 +121,10 @@ sidebar_position: 2
     </tr>
     <tr>
         <td>EXIF:ExposureTime</td>
-        <td>Exposure Time</td>
+        <td>Shutter Speed</td>
         <td>✔️</td>
         <td>❌</td>
-        <td>Exposure Time in Info</td>
+        <td>Shown as Shutter Speed in Info (stored as a fraction, e.g. 1/250)</td>
     </tr>
     <tr>
         <td>EXIF:ISOSpeedRatings</td>
@@ -134,31 +148,54 @@ sidebar_position: 2
         <td>Focal Length in 35mm Film in Info</td>
     </tr>
     <tr>
-        <td>EXIF:ShutterSpeedValue</td>
-        <td>Shutter Speed</td>
-        <td>✔️</td>
-        <td>❌</td>
-        <td>Shutter Speed in Info</td>
-    </tr>
-     <tr>
-        <td>EXIF:SubjectDistance</td>
-        <td>Subject Distance</td>
-        <td>✔️</td>
-        <td>❌</td>
-        <td>Subject Distance in Info</td>
-    </tr>
-    <tr>
-        <td>EXIF:DigitalZoomRatio</td>
-        <td>Digital Zoom Ratio</td>
-        <td>✔️</td>
-        <td>❌</td>
-        <td>Digital Zoom Ratio  in Info</td>
-    </tr>
-    <tr>
         <td>XMP:RegionInfo</td>
         <td>Faces</td>
         <td>✔️</td>
+        <td>✔️</td>
+        <td>Faces and people are read from XMP:RegionInfo. Writing is opt-in via the "Write face tags to image files" setting (off by default); when enabled, labelling a face writes MWG regions as XMP-mwg-rs:RegionInfo (with AppliedToDimensions and normalized areas) to the image file or XMP sidecar. Only manually labelled people are given a name; auto-detected faces are written as unnamed regions.</td>
+    </tr>
+    <tr>
+        <td>XMP:Subject</td>
+        <td>Keywords / People</td>
+        <td>✔️</td>
+        <td>✔️</td>
+        <td>Read and merged with IPTC:Keywords into the photo's keywords. Written alongside face regions: the names of manually labelled people are added as keywords for Lightroom compatibility.</td>
+    </tr>
+    <tr>
+        <td>IPTC:Keywords</td>
+        <td>Keywords</td>
+        <td>✔️</td>
         <td>❌</td>
-        <td>Faces and Person will be read from XMP</td>
+        <td>Merged with XMP:Subject into the photo's keywords.</td>
+    </tr>
+    <tr>
+        <td>EXIF:Orientation</td>
+        <td>Orientation</td>
+        <td>✔️</td>
+        <td>✔️</td>
+        <td>Read to transform face-region coordinates. Written back (composed with your rotation) when you rotate a photo, but only if "Synchronize metadata to disk" is enabled.</td>
+    </tr>
+    <tr>
+        <td>EXIF:SubSecTimeOriginal</td>
+        <td>Sub-second time</td>
+        <td>✔️</td>
+        <td>❌</td>
+        <td>Read on every metadata extract; used for burst/sequence detection.</td>
+    </tr>
+    <tr>
+        <td>EXIF:ImageNumber</td>
+        <td>Image sequence</td>
+        <td>✔️</td>
+        <td>❌</td>
+        <td>Read on every metadata extract; used for burst/sequence detection.</td>
     </tr>
 </table>
+
+Some tags are only read when a matching rule is active. The burst/stacking detection
+rules read `MakerNotes:BurstMode`, `MakerNotes:ContinuousDrive` and
+`MakerNotes:SequenceNumber` only when the corresponding stack-detection rule is enabled
+in your settings.
+
+To back-fill an existing library with face tags, run
+`python manage.py save_metadata --types face_tags` (add `--media-file` to write into the
+images instead of XMP sidecars).

--- a/apps/docs/docs/user-guide/face-recognition.md
+++ b/apps/docs/docs/user-guide/face-recognition.md
@@ -1,12 +1,25 @@
 ---
 title: "😃 Face recognition"
-excerpt: "How to use the face dashboard"
-sidebar_position: 3
+description: "How to use the face dashboard"
+sidebar_position: 6
 ---
 
 ## Label a face
 
-To label a face, click on the green plus button. A pop-up will show up where you can either search for an already existing person or add a new person. We want to add a new person, so input the name of the person you want to add and click on the green plus. Now the face is associated with the person.
+To label a face, click on the green plus button. A pop-up titled **Label faces** will show up where you can either search for an already existing person or add a new person. We want to add a new person, so type the name into the **Person Name** field under **New person** and click **Add Person** (the button stays disabled until you enter a name that does not already exist). Now the face is associated with the person.
+
+### Writing face tags to your files
+
+By default, labelling a face only updates the LibrePhotos database — your image files are not touched.
+
+If you enable **Settings → Face Options → Write face tags to image files**, then every time you label a face LibrePhotos also writes the face's region and the person's name into the photo as XMP MWG-RS region tags. This makes your face data portable to other photo managers such as Lightroom, digiKam and XnView.
+
+Where the tags are written depends on **Settings → Metadata → Synchronize metadata to disk**:
+
+- **Save to sidecar** — the regions go into the photo's `.xmp` sidecar file; the original image is left unchanged.
+- **Save to media file** or **Off** (the default) — the regions are written into the original image file itself.
+
+Note the second case: turning on **Write face tags to image files** is enough on its own to start modifying your originals. **Synchronize metadata to disk** only chooses sidecar versus media file; leaving it **Off** does not stop face tags from being written.
 
 ## Change the label of a face
 
@@ -14,15 +27,23 @@ To change a face to a new person, click on the green plus button. Search for the
 
 ## Train faces
 
-If you click on the blue button in the face dashboard or if you click on the button "Train" in the settings tab, the system will try to cluster unknown faces and will try to either match them to already known faces or create a new unknown person. To see the recommendations, go to the inferred tab in the face dashboard. There you can for each face the confidence of the match. If you want to confirm a recommended face, select the face and click on the green plus button to add it to the person.
+If you click on the blue button (the barbell icon) in the face dashboard, or the **Train** button on the [Library page](./library.md) (avatar menu → **Library**, under **Faces & People**), the system will try to cluster unknown faces and will try to either match them to already known faces or create a new unknown person.
+
+The dashboard has three tabs: **Inferred** (the matches training produced), **Unknown** (faces that were not matched, or that you rejected, grouped under "Unknown - Other"), and **Labeled** (faces you have already named). To see the recommendations, go to the **Inferred** tab. There you can see, for each face, the confidence of the match. By default the dashboard only shows matches it is at least 70% confident about — use the **% confident** filter in the toolbar to lower this threshold and surface weaker recommendations (the filter applies to both the Inferred and Unknown tabs).
+
+To confirm a whole inferred group at once, click the green check-person icon next to the person's name; it appears on the Inferred tab next to persons that already have a name. To confirm individual faces, select them and click the green plus button in the toolbar to add them to the person. To reject faces, select them and click the orange person-off button in the toolbar, which moves them back to "Unknown - Other".
 
 ## Delete faces
 
-Sometimes the face recognition might find a face that is not actually a face. To remove it, select the face and the click on the trashcan symbol. The face is the no longer in the system and the face data is going to be deleted.
+Sometimes the face recognition might find a face that is not actually a face. To remove it, select the face and click on the trashcan symbol; a confirmation dialog appears first. The face is then hidden everywhere in LibrePhotos — it disappears from the face dashboard, from the person's face list and from the photo's face list — and it is no longer used for training, clustering or classification. This cannot be undone from the interface. Note that hiding a face does not free disk space: the cropped face image and its embedding are kept, so the same region is not detected again on a later scan.
 
 ## Re-scan faces
 
-Some user deleted all the faces with the delete face action. To get the faces again, you can re-scan the faces. This will take a while, because it will then have to look up all the photos again for faces.
+Re-scan faces looks through all your photos again and adds any face it finds that does not already have a face record. This will take a while, because it has to look up all the photos again.
+
+:::note
+A re-scan will not bring back faces you removed with the delete face action. Deleting a face marks it as deleted but keeps its region on record, and the re-scan skips any newly detected face that overlaps an existing record — including deleted ones. Deleting a face cannot be undone from the user interface.
+:::
 
 ## Workflow
 
@@ -34,6 +55,8 @@ After the first scan finished, go to the face dashboard. Label a couple of faces
 
 Faces are detected with [InsightFace](https://github.com/deepinsight/insightface). Its detector (SCRFD) finds the faces in each photo and returns a bounding box for every face it sees. This replaced the older dlib detectors, so there is no longer a separate `hog` / `cnn` choice — a single detector is used for everyone.
 
+Detection is skipped entirely for photos that already carry XMP `RegionInfo` face regions in the file or its XMP sidecar — for example ones written by digiKam, Lightroom or XnView. Any region marked `Type="Face"` with usable coordinates is taken as-is, and if the region carries a `Name`, the matching person is created and the face is labelled automatically. LibrePhotos only falls back to the InsightFace detector when a photo has no usable face regions. This bypasses detection only: those faces still get an ArcFace embedding during the next train or re-scan, so clustering and classification work on them normally.
+
 ### Face Quality
 
 At the moment no matter, which detection methods we use, there will be face detected, which are not actually faces. The user has to manually delete these faces. In the future, we will have a new classifier, which determines if it is a face and how likely it is a face.
@@ -42,13 +65,23 @@ At the moment no matter, which detection methods we use, there will be face dete
 
 Creates a 512-dimension [ArcFace](https://github.com/deepinsight/insightface) embedding for each detected face, which is what makes faces comparable to one another. You can choose which model is used in **Admin Area → Site Settings → Face Recognition Model**: smaller packs (like the default `buffalo_sc`) are faster and lighter, while larger packs (`buffalo_l`, `antelopev2`) are more accurate but use more memory.
 
+:::warning Switching the model later
+Changing the model only affects faces that do not yet have an embedding. Faces that were already encoded keep the embedding produced by the previous model: **Train faces** re-encodes only faces that have no embedding yet, and **Re-scan faces** skips faces that overlap ones already stored. Embeddings from different InsightFace packs are not comparable even though they are all 512-dimensional, so until every face is re-encoded, clustering and classification will mix two embedding spaces. To fully switch packs today you have to delete the affected faces and re-scan them.
+:::
+
 :::note Upgrading from an older version
 Older versions of LibrePhotos used dlib with 128-dimension encodings. When you upgrade to the ArcFace engine, those old encodings and the existing face clusters are cleared automatically because they are not compatible with the new 512-dimension embeddings. Just run **Train faces** / **Re-scan faces** once and your faces will be re-encoded with the new model.
 :::
 
 ### Face Clustering
 
-Clustering solves the issue of a system, which has no labelled persons yet. Users can get clusters they can name instead of going through a lot of faces and naming them. Clustering is stable, which means that you will get the same clusters out, when you put the same data in. If you label more faces, this will have no impact on face clustering at the moment. If you want to change how clustering is done, either change the settings, add images or delete wrong faces.
+Clustering solves the issue of a system, which has no labelled persons yet. Users can get clusters they can name instead of going through a lot of faces and naming them. Clustering is stable, which means that you will get the same clusters out, when you put the same data in. Labels are not fed into the clustering algorithm itself — the encodings are grouped the same way no matter which faces you have already named. They do change the clusters that come out of it, though: any group that contains at least one labelled face is split into one cluster per labelled person, instead of producing a new unknown cluster for you to name.
+
+If you want to change how the grouping itself is done, add images, delete wrong faces, or change the clustering settings under **[Settings](./settings/index.md) → Face Options**:
+
+- **Minimum Cluster Size** (default **Auto**) — the smallest group the algorithm will treat as a cluster. **Auto** also applies when the stored value is 0 or 1, and grows from 2 to 4, 8 and 16 as your library passes 1,000, 10,000 and 100,000 encoded faces.
+- **Minimum Samples** (default **1**) — how conservative clustering is; a higher value is more conservative and leaves more faces unclustered.
+- **Cluster Selection Epsilon** (default **0.05**, shown as "Normal") — how readily nearby clusters are merged; a higher value merges more clusters together.
 
 Steps which could be done to improve clustering are combining very similar faces from e.g. a serial recording or photo shoot, to prevent from too many small images to be clustered.
 

--- a/apps/docs/docs/user-guide/faq.md
+++ b/apps/docs/docs/user-guide/faq.md
@@ -1,14 +1,16 @@
 ---
 title: "❓ FAQ"
-excerpt: "Scan always fails after importing few images"
-sidebar_position: 7
+description: "Scan always fails after importing few images"
+sidebar_position: 27
 ---
 
 ## Proxmox - Scan always fails after importing few images
 
 ### Symptom
 
-You get errors like these and you use Proxmox:
+Your scan crashes with a `Fatal Python error: Illegal instruction` on a Proxmox guest, usually after only a few images have been imported.
+
+The traceback below is an example from an older LibrePhotos release, which used dlib / `face_recognition` on Python 3.9. On current builds the frames differ - face detection runs in a separate process now - so what identifies this problem is the `Illegal instruction` crash during a scan, not the specific frames shown here.
 
 ```
 Thread 0x00007fc8dcf3f640 (most recent call first):
@@ -54,9 +56,12 @@ If you don't care about live migration and moving VMs between nodes, the much ea
 ### Steps for Proxmox 6.4:
 
 Select your VM and then Hardware tab.
-{% include figure image_path="/assets/images/135711616-14903f44-2bdc-4830-82e9-a29562f75762.png" alt="Select your VM and then Hardware tab" %}
+
+![Select your VM and then Hardware tab](../../static/img/135711616-14903f44-2bdc-4830-82e9-a29562f75762.png)
+
 Then double-click on Processors or select it and click Edit:
-{% include figure image_path="/assets/images/135711657-3cdc2600-2368-440c-af75-00313c8c8997.png" alt="Then double-click on Processors or select it and click Edit"  %}
+
+![Then double-click on Processors or select it and click Edit](../../static/img/135711657-3cdc2600-2368-440c-af75-00313c8c8997.png)
 
 ## error decoding 'Volumes[0]': invalid spec: :/data: empty section between colons / "The "scanDirectory" variable is not set. Defaulting to a blank string."
 

--- a/apps/docs/docs/user-guide/feature-toggles.md
+++ b/apps/docs/docs/user-guide/feature-toggles.md
@@ -1,7 +1,7 @@
 ---
 title: "✅ Feature Toggles"
-excerpt: "LibrePhotos feature toggles"
-sidebar_position: 6
+description: "LibrePhotos feature toggles"
+sidebar_position: 20
 ---
 
 ## LibrePhotos feature toggles
@@ -15,7 +15,7 @@ Feature toggles are implemented as environment variables you would have to confi
     <th>Feature</th>
     <th>Description</th>
     <th>Status</th>
-    <th>Variable to enable the feature</th>
+    <th>Environment variable</th>
   </tr>
   <tr>
     <td>Embedded media</td>
@@ -90,6 +90,12 @@ Feature toggles are implemented as environment variables you would have to confi
 </table>
 
 All of these default to on. See [Advanced docker-compose usage](../installation/environment-variables.md) for what turning each one off actually stops, and for the matching `.env` keys of the bundled Compose setup.
+
+:::note Embedded media
+The **Embedded media** switch behaves a little differently from the rest. It reacts only to the exact value `True` — which is why its row shows `True` and not `true` — so any other value, including lowercase `true`, turns it off.
+
+It is also checked only the first time a file is imported. Enabling it on a library that has already been scanned extracts nothing for the photos that are already there, not even with **Rescan All Photos**, which skips extraction for files it has already imported. Only files added afterwards are affected. Turning it off never removes clips that were already extracted; those stay on disk under `protected_media/embedded_media/`.
+:::
 
 #### Legend
 

--- a/apps/docs/docs/user-guide/features.md
+++ b/apps/docs/docs/user-guide/features.md
@@ -1,7 +1,7 @@
 ---
 title: "💡 Feature Comparison"
-excerpt: "Which features does Librephotos have?"
-sidebar_position: 6
+description: "Which features does Librephotos have?"
+sidebar_position: 26
 ---
 
 ## Features compared to competitors

--- a/apps/docs/docs/user-guide/first-steps.md
+++ b/apps/docs/docs/user-guide/first-steps.md
@@ -1,6 +1,6 @@
 ---
 title: "✔️ First steps"
-excerpt: "First steps after setting up"
+description: "First steps after setting up"
 sidebar_position: 1
 ---
 
@@ -34,7 +34,9 @@ These settings can always be changed later in the Admin Area. Click **Continue**
 
 This is where you tell LibrePhotos where your photos are stored:
 
-1. **Skip RAW Files** (optional) – Toggle this on if you want LibrePhotos to ignore RAW image files during scanning
+1. **Stack RAW+JPEG pairs** (on by default) – Leave this on to have RAW files automatically grouped with their JPEG counterparts during scans. Both files remain in your library. Turn it off if you want RAW and JPEG versions to appear as separate photos.
+
+   You can change this later under your avatar (top right) > `Library`.
 
 2. **Scan Directory** – Select or type the path to your photos folder. If you haven't modified the default `docker-compose.yml`, this should be `/data`, which corresponds to the folder you configured as `scanDirectory` in your `.env` file.
 
@@ -65,10 +67,10 @@ Click on your avatar in the top right, and go to `Admin Area`. On this page, it 
 
 ### How to Start a Scan
 
-Click on your avatar in the top right, and go to `Library`. Click the green `Scan photos (file system)` button. See the [auto scan page](./auto-scan.md) if you would like to set up automated scanning for new photos. For more details on the Library page and all available actions, see [Library Management](./library.md).
+Click on your avatar in the top right, and go to `Library`. Under **Scan Library**, click the **Scan** button. The chevron next to it opens a menu with **Rescan**, which reprocesses your entire library. See the [auto scan page](./auto-scan.md) if you would like to set up automated scanning for new photos. For more details on the Library page and all available actions, see [Library Management](./library.md).
 
 ### How to Import Photos from an External Nextcloud Instance
 
-If you have a Nextcloud instance, you can also input login details for it in the `Dashboard` > `Library` page.
+If you have a Nextcloud instance, you can also input login details for it on the `Library` page (click on your avatar in the top right, and go to `Library`).
 The Nextcloud section is hidden until an admin enables it in `Admin Area` > `Site Settings` > `Enable Nextcloud integration` (see [Library Management](./library.md#enabling-the-integration)).
-Fill out the details for the Nextcloud section. Once logged in (the little circle next to `Nextcloud Scan Directory` will be green), you can choose a top level directory in your logged in Nextcloud account. Once this has been configured, you can click the blue `Scan photos (Nextcloud)` button. This will copy the contents of the specified Nextcloud directory ([excluding videos](https://github.com/LibrePhotos/librephotos/issues/278)) to the local filesystem.
+Fill out the server address, username and app password for the Nextcloud section. Once the connection succeeds, the **Status** badge at the top of the Nextcloud section turns green and reads *Connected*. You can then click **Browse** next to **Nextcloud Scan Directory** to pick a top level directory in your Nextcloud account. Once this has been configured, you can click the blue **Scan** button at the bottom of the Nextcloud section (the one with the Nextcloud icon). This will copy the contents of the specified Nextcloud directory — images, videos, RAW files and XMP sidecars — to the local filesystem, and then index them the same way a regular file system scan does.

--- a/apps/docs/docs/user-guide/image-captioning.md
+++ b/apps/docs/docs/user-guide/image-captioning.md
@@ -1,37 +1,59 @@
 ---
 title: "📝 Image Captioning"
-excerpt: "What is image captioning and how do I use it?"
-sidebar_position: 6
+description: "What is image captioning and how do I use it?"
+sidebar_position: 8
 ---
 
 ## What is image captioning?
 
-The goal of automatic image captioning to understand the content of an image and then produce a coherent and contextually relevant sentence or phrase that describes what is happening in the image.
+The goal of automatic image captioning is to understand the content of an image and then produce a coherent and contextually relevant sentence or phrase that describes what is happening in the image.
 
-To use the feature in LibrePhotos, open up an image, click on the information icon and then click on the generate button below the caption segment. It should generate a phrase, which should describe your image.
+To use the feature, open one of your own photos and click the information icon in the top bar to show the details panel. In the **Caption** section, click the pencil icon in the top-right corner of the caption box to start editing, then click the wand icon that appears in its place. Once a caption has been generated, it appears as a suggestion just above the caption box — click it to drop the text into the caption field, then press the green tick below the box to save it. (If a caption has already been generated for this photo, the suggestion appears as soon as you start editing.) The wand, cancel and tick controls are only shown while you are editing, and captions cannot be generated on publicly shared photos.
 
 ## How do I change the model?
 
-Click on your avatar in the top right, and go to `Admin Area`. There is a setting for `Captioning Model`. You can select here between the different models. After selecting a model, it will be downloaded and added to your data_models folder.
+Click on your avatar in the top right and go to `Admin Area`. There is a setting for `Captioning Model` where you can choose between the different models. After selecting `im2txt` or `BLIP Base Capfilt Large`, the model is downloaded and added to your `data_models` folder.
+
+Moondream is the exception: its files are only downloaded when `Moondream Visual LLM` is also selected as the `LLM Model`. If you set `Captioning Model` to Moondream while `LLM Model` is left at `None`, the model files are never fetched and captioning fails. To use Moondream, set **both** `Captioning Model` and `LLM Model` to `Moondream Visual LLM`.
+
+Selecting `BLIP Base Capfilt Large` opens a confirmation dialog titled *Large RAM Size possible*, warning that the model needs an additional 3 GB of RAM. Click **Save** to apply it; clicking **Cancel** — or closing the dialog — resets the captioning model back to `im2txt`.
 
 ## What is the difference between the models?
 
-Currently, there are four available models: "im2txt PyTorch," "im2txt Onnx," "Blip," and "Moondream 2."
+There are three captioning models to choose from — `im2txt PyTorch`, `BLIP Base Capfilt Large`, and `Moondream Visual LLM` — plus a `None` option that turns captioning off. When `None` is selected, no captioning model is downloaded.
 
 ### im2txt PyTorch
 
-This model serves as the default choice. It offers rapid results and represents the original implementation of the image captioning task. It uses the PyTorch deep learning framework, it has been a reliable option for users seeking both speed and baseline performance.
+This model serves as the default choice. It offers rapid results and represents the original implementation of the image captioning task. It uses the PyTorch deep learning framework and has been a reliable option for users seeking both speed and baseline performance.
 
-### im2txt ONNX
+### BLIP Base Capfilt Large
 
-Utilizing the Open Neural Network Exchange (ONNX) as its engine, "im2txt Onnx" is designed for enhanced efficiency during inference. It exhibits a slight speed improvement compared to the original PyTorch model. The integration of ONNX facilitates seamless deployment across different platforms.
+The next generation model "BLIP" excels in providing highly accurate image descriptions. However, it comes with a trade-off, as it operates at approximately 20 times slower speeds than "im2txt PyTorch." This deliberate sacrifice in speed is made to achieve superior descriptive accuracy, making "BLIP" an ideal choice for applications prioritizing precision over real-time processing. BLIP is also the most memory-hungry of these models: it needs roughly 3 GB of RAM on top of what LibrePhotos already uses, so it is a poor fit for a host with only 4 GB.
 
-### Blip Base Capfilt Large
-
-The next generation model "Blip" excels in providing highly accurate image descriptions. However, it comes with a trade-off, as it operates at approximately 20 times slower speeds than "im2txt PyTorch." This deliberate sacrifice in speed is made to achieve superior descriptive accuracy, making "Blip" an ideal choice for applications prioritizing precision over real-time processing.
-
-### Moondream 2
+### Moondream Visual LLM
 
 Moondream 2 is a multi-modal model (via llama-cpp-python) that can analyze both images and text together. It produces richer, more contextually aware captions compared to the other models and lays the groundwork for advanced features like visual queries. It requires more resources than the simpler models but produces the most detailed descriptions.
 
+:::warning Moondream requires two settings
+In `Admin Area`, set **both** `Captioning Model` **and** `LLM Model` to `Moondream Visual LLM`. The Moondream weights are downloaded based on the `LLM Model` setting, so leaving `LLM Model` at `None` means the files are never fetched and every caption generation fails.
+:::
+
+On x86/x64 systems Moondream additionally requires a CPU that reports the AVX and SSE4.2 instruction sets. If they are missing — including on virtual machines that mask CPU flags, such as Proxmox guests using the default `kvm64` CPU type — the backend's LLM service refuses to start and captioning fails with a "Service unavailable" error, with no automatic fallback to the other models. ARM systems (aarch64/arm64) are unaffected, as this check is skipped there.
+
 Users can choose a model based on their specific requirements, balancing the need for speed, accuracy, and the trade-offs associated with each implementation. It's recommended to consider the performance of your system and the desired performance characteristics when selecting the most suitable model.
+
+## Improving captions with an LLM
+
+The captioning models above produce a caption on their own, but LibrePhotos can optionally run that caption through a large language model to refine it. This is **off by default** and needs two separate opt-ins:
+
+- In `Admin Area`, an admin must set `LLM Model` to something other than `None` — either `Mistral 7B Instruct v0.2 Q5 K M` or `Moondream Visual LLM`. See [Settings](./settings/index.md#site-settings).
+- In their own `Settings`, under **Large Language Model Settings**, each user must turn on **Enable Large Language Model For Captions** (also off by default).
+
+Without both, the model descriptions above apply as written.
+
+Two further switches become available once the LLM is enabled — **Add Persons to the Captions** and **Add Locations to the Captions** (both greyed out until the enable switch is on). *Add Persons* only has an effect when the photo has a recognised, named person, and *Add Locations* only when the photo has a geocoded location.
+
+How the LLM is applied depends on the captioning model:
+
+- With **im2txt PyTorch** or **BLIP Base Capfilt Large**, the model generates a caption first and the LLM then rewrites it in a second pass.
+- With **Moondream Visual LLM**, there is no second pass — the caption prompt itself is rebuilt before generation, so the person and location hints steer the original output.

--- a/apps/docs/docs/user-guide/index.md
+++ b/apps/docs/docs/user-guide/index.md
@@ -1,4 +1,57 @@
 ---
 title: "User Guide"
+description: "Everyday use of LibrePhotos: first steps, organizing, searching, sharing, and administration."
 sidebar_position: 3
 ---
+
+Welcome to the LibrePhotos user guide. These pages walk you through everyday use of your photo library, from your first login through organizing, sharing, and administering your collection. If you have not installed LibrePhotos yet, start with the [Installation](../installation/index.md) section first.
+
+New here? Begin with [First steps](first-steps.md).
+
+## Getting started
+
+- [First steps](first-steps.md) — what to do right after your first login.
+- [Viewing photos](viewing-photos.md) — photo views, the lightbox, and the photo details sidebar.
+- [Upload](upload.md) — adding photos through the web interface.
+- [Search](search.md) — finding photos with spotlight, semantic, and text search.
+
+## Organizing your photos
+
+- [Albums](albums.md) — creating and managing photo albums.
+- [Places](places.md) — how geolocation and the places map work.
+- [Face recognition](face-recognition.md) — training and using the face dashboard.
+- [Image captioning](image-captioning.md) — automatic captions for your photos.
+- [Stacks & file variants](stacks-and-file-variants.md) — how RAW+JPEG pairs, Live Photos, and bursts are grouped.
+- [Sharing](sharing.md) — sharing photos and albums with other users or via public links.
+
+## Managing your library
+
+- [Library management](library.md) — scanning, Nextcloud integration, and server management.
+- [Auto scan all folders](auto-scan.md) — scanning every folder automatically.
+- [Missing photos](missing-photos.md) — understanding and clearing missing photos.
+- [Duplicate detection](duplicate-detection.md) — finding and managing duplicate photos.
+- [Trash](trash.md) — how the trash works.
+- [Statistics & data visualization](statistics.md) — interactive visualizations of your library.
+
+## Files & metadata
+
+- [Exif data](exif-data.md) — which EXIF fields LibrePhotos reads, writes, and filters on.
+- [Internal files](internal-files.md) — a tour of the folders and files LibrePhotos keeps on disk.
+
+## Administration
+
+- [Settings](settings/index.md) — where the settings live and what they control.
+- [Manage multiple users](managing-users.md) — adding and managing additional user accounts.
+- [Feature toggles](feature-toggles.md) — turning individual features on and off.
+- [Job system](job-system.md) — what the background worker jobs and logs mean.
+- [Offline usage](offline-setup.md) — running LibrePhotos without an internet connection.
+- [API authentication](api-authentication.md) — authenticating against the API with JWT or Basic auth.
+
+## Mobile
+
+- [Mobile apps](mobile/index.md) — the companion mobile apps for LibrePhotos.
+
+## Reference
+
+- [Feature comparison](features.md) — how LibrePhotos compares with other photo managers.
+- [FAQ](faq.md) — answers to common questions and problems.

--- a/apps/docs/docs/user-guide/internal-files.md
+++ b/apps/docs/docs/user-guide/internal-files.md
@@ -1,7 +1,7 @@
 ---
 title: 📂 Internal files
-excerpt: "How to auto scan all folders"
-sidebar_position: 2
+description: "Which folders and files LibrePhotos creates on disk"
+sidebar_position: 18
 ---
 
 ## /logs
@@ -10,7 +10,11 @@ There are a lot of log files in this folder. The most important one is "ownphoto
 
 ## ⚠ DO NOT DELETE "secret.key"
 
+The `secret.key` file lives in the `/logs` folder described above: it is `/logs/secret.key` inside the backend container, which the shipped Docker Compose file maps to `${data}/logs/secret.key` on the host.
+
 In order to encrypt passwords in the database, Django uses a secret key. On the first boot, we create this file, which will then get used every time you start it. If you delete this file, you cannot log in anymore, and you have to reset the passwords of your users.
+
+If you set `shhhhKey` in your `.env` file, that value is used as the secret key instead and this file is never created or read.
 
 ## /protected_media
 
@@ -30,13 +34,31 @@ The thumbnails and not actually square. You see them in the overview, when you s
 
 In order to make all files viewable, we create thumbnails for them. These are only static, as they are also used for all ML algorithms and face recognition to have a consistent format. These are the files you actually see in the lightbox.
 
-### /chunked_upload
+### /chunked_uploads
 
-When you upload a file, it gets uploaded in chunks. While the upload is incomplete, the files be saved in that folder.
+When you upload a file, it gets uploaded in chunks. While the upload is incomplete, the files are saved in that folder.
 
 ### /faces
 
 Here we save the thumbnails of all the faces, so that viewing them is faster.
+
+### /data_models
+
+All the machine learning models live here: image captioning (im2txt, Blip, Moondream 2), the CLIP embeddings used for semantic search, scene and tag recognition (places365, SigLIP 2), the optional LLM (Mistral) and the InsightFace face recognition models. Rather than being baked into the image, they are downloaded by the "Download Models" job, or when you pick a new model in the `Admin Area` (for example the `Captioning Model` setting). Because of that, this folder only grows as you enable features, but it is usually by far the largest folder in `/protected_media` — several GB in total.
+
+Deleting it is safe: the models are simply downloaded again the next time they are needed. If your server has no Internet access, see [Offline Usage](./offline-setup.md) for how to place the files by hand.
+
+### /embedded_media
+
+Some phones store a short video inside the JPEG of a motion photo (Google and Samsung both do this). When such a file is scanned, LibrePhotos extracts that video and saves it here as `<hash>_motion.mp4` — this is what plays when you view the motion photo, while the original JPEG still keeps its embedded copy. This is controlled by the `FEATURE_PROCESS_EMBEDDED_MEDIA` setting, which is on by default.
+
+### /zip
+
+When you download several photos at once, LibrePhotos builds the archive here and serves it back to you. Each archive is deleted automatically about a day after it is created, so this folder normally stays small and needs no manual cleanup.
+
+### /matplotlib
+
+A font cache for matplotlib, which comes along as a dependency of the face recognition code. The backend points the cache here so it does not have to be rebuilt every time a process starts. Safe to delete; it is recreated automatically.
 
 ## /db
 

--- a/apps/docs/docs/user-guide/job-system.md
+++ b/apps/docs/docs/user-guide/job-system.md
@@ -1,7 +1,7 @@
 ---
 title: "💼 Job System"
-excerpt: "A overview of what the worker logs mean"
-sidebar_position: 5
+description: "A overview of what the worker logs mean"
+sidebar_position: 23
 ---
 
 ## How does it work
@@ -12,13 +12,13 @@ The job system gives you information about the long-running jobs, including whic
 
 Scan photos will look at all media files in your scan directory and will add them to the library.
 
-### Generate Auto Albums
+### Generate Event Albums
 
-This job will look at all media files that already exist. It tries to find common events by looking at the timestamp and grouping the images. If the media files are in a 1 day and 12 hour interval, they will appear in the same auto album.
+This job will look at all media files that already exist. It tries to find common events by looking at the timestamp and grouping the images. If the media files are in a 1 day and 12 hour interval, they will appear in the same event album.
 
-### Generate Auto Albums Titles
+### Regenerate Event Titles
 
-This will create a title for the auto album based on the information of the media files in the auto album.
+This will create a title for the event album based on the information of the media files in the event album.
 
 ### Train Faces
 
@@ -28,15 +28,31 @@ This will look at all faces and its groups and will give us a certainty value fo
 
 Finds all missing media files and removes them from the database.
 
-### Calculate Clip Embedding
+### Scan Missing Photos
+
+Goes through every photo in the database and flags the ones whose file can no longer be found on disk. It does not delete anything — use **Delete Missing Photos** for that. It runs automatically after a full scan and after any scan of your configured scan directory; it is skipped when you scan a different directory or only a specific list of files. See [Missing Photos](./missing-photos.md).
+
+### Calculate Clip Embeddings
 
 Calculates the CLIP value for all images. This is used for semantic search and for finding similar images.
+
+### Generate Tags
+
+Runs the configured tagging model over your photos to produce the scene and content tags used for search. It runs automatically after each scan; a normal scan only tags photos added since the last successful run, while a full scan re-tags everything.
+
+### Add Geolocation
+
+Looks up place names for each photo's GPS coordinates (reverse geocoding) so they appear in the places view and location search. It runs automatically after each scan; a normal scan only processes photos added since the last successful run, while a full scan reprocesses everything.
 
 ### Scan Faces
 
 Looks for faces in the images and save them to the database
 
-### Cluster All Faces
+### Generate Face Embeddings
+
+Computes the numeric encoding for faces that have been detected but not yet encoded, so they can be grouped and matched. It runs automatically as part of **Scan Faces**. If no faces are waiting to be encoded it finishes immediately, so you may not always see a row for it.
+
+### Find Similar Faces
 
 Clusters the faces into known and unknown groups.
 
@@ -44,18 +60,26 @@ Clusters the faces into known and unknown groups.
 
 This downloads the needed machine learning models to data/protected_media/data_models/.
 
+### Download Selected Photos
+
+Packs a multi-photo download into a zip file in the background. It starts when you select several photos and choose to download them, and the app offers you the file once the job finishes.
+
 ### Repair File Variants
 
-Runs after each scan to fix any previously ungrouped file variants. If RAW+JPEG pairs or Live Photos were scanned separately before the file variant system was introduced, this job will merge them into proper photo groups. See [Stacks & File Variants](./stacks-and-file-variants.md) for more details.
+Runs after each scan to fix RAW files that were scanned as their own photos. For each photo whose main file is a RAW file, it either merges it into the matching image photo (such as a JPEG or HEIC) in the same folder and removes the leftover RAW-only entry, or — if an image file is already attached — promotes that image to be the main file. It does not re-pair Live Photo videos that were scanned separately; those are only paired during a scan. See [Stacks & File Variants](./stacks-and-file-variants.md) for more details.
 
-### Detect Duplicates
+### Detect Duplicate Photos
 
-Finds duplicate photos in your library using perceptual hashing. It detects both exact copies (via hash comparison) and visual duplicates (via a two-pass algorithm). Results are shown in the Organizing page where you can review and manage them. See [Duplicate Detection](./duplicate-detection.md) for more details.
+Finds duplicate photos in your library using perceptual hashing. It detects both exact copies (via hash comparison) and visual duplicates (via a two-pass algorithm). Results are shown in the Organizing page, where you can review and manage them; the button that starts this job there is called **Detect Duplicates**. See [Duplicate Detection](./duplicate-detection.md) for more details.
 
 ## Where to get information about previous run jobs
 
-When you are logged in as an admin, click on the profile picture in the top right corner and then navigate to `Admin Area`. You should see the jobs at the bottom of the page in a table called `Worker Logs`
+When you are logged in as an admin, click on the profile picture in the top right corner and then navigate to `Admin Area`. You should see the jobs at the bottom of the page in a table called `Worker Logs`.
+
+Click a row in the `Worker Logs` table to open that job's detail page. It shows the job's ID and status, when it was queued, started and finished, how long it ran, who started it, and the current progress step. If the job failed, an `Error Details` section shows the captured error message and the full result data.
 
 ## What to do when a job gets stuck
 
-When a job gets stuck, that usually means, that it crashed, and we could not catch the error correctly. You can just remove the entry from the list to start another job.
+If a job is still running and you want to stop it, use the **Cancel** button in its `Worker Logs` row. Cancelling marks the job as cancelled and finished and removes any of its steps that are still waiting in the queue. Jobs that work through a list of photos check for cancellation as they go and stop at the next checkpoint, so it can take a moment before a running job actually stops. A few jobs have no such checkpoint yet — cancelling marks them finished right away, but any work already in progress runs to completion. Either way, cancelling frees the queue for a new job, so you do not need to remove the entry afterwards.
+
+The **Remove** button only deletes the log entry from the database — it does **not** stop a running job. Use it for a job that has genuinely crashed (nothing is progressing and the logs show an ungraceful failure) so that the queue will accept new jobs again.

--- a/apps/docs/docs/user-guide/library.md
+++ b/apps/docs/docs/user-guide/library.md
@@ -1,7 +1,7 @@
 ---
 title: "📚 Library Management"
-excerpt: "Scanning, Nextcloud integration, services, and server management"
-sidebar_position: 12
+description: "Scanning, Nextcloud integration, services, and server management"
+sidebar_position: 10
 ---
 
 The **Library** page is your central hub for managing your photo library. Access it by clicking on your avatar (top right) and selecting **Library**, or via the spotlight search (`Ctrl+K` → "Library").
@@ -10,27 +10,35 @@ The **Library** page is your central hub for managing your photo library. Access
 
 At the top of the Library page, you'll see quick stats about your library:
 
-- **Photos** — Total number of photos and the number of days they span
+- **Photos** — Total number of photos and the number of distinct days they were taken on (undated photos are grouped into a single extra bucket)
 - **People** — Number of recognized people, with a breakdown of inferred, labeled, and unknown faces
 - **Faces** — Total faces detected
 - **Events** — Number of auto-generated event albums
+
+## Library Settings
+
+- **Stack RAW+JPEG pairs** — When enabled, RAW files are automatically grouped with their JPEG counterparts as [file variants](./stacks-and-file-variants.md) during scans. Both files remain in your library. This is a per-user setting and is **on by default**. It is also offered during first-time setup, when you configure your scan directory.
 
 ## Scanning
 
 ### Scan Photos (File System)
 
-Click **"Scan photos"** to scan your configured scan directory for new photos. The scan process:
+In the **Scan Library** row, click **Scan** to scan your configured scan directory for new photos. The scan process:
 
 1. Discovers new image and video files
 2. Groups related files (RAW+JPEG pairs, Live Photos) as [file variants](./stacks-and-file-variants.md)
 3. Creates thumbnails
 4. Extracts EXIF metadata
 5. Runs face detection
-6. Generates AI captions and tags
+6. Generates AI tags (Places365 or SigLIP 2, depending on your Tagging Model setting)
 7. Performs reverse geocoding
 8. Calculates CLIP embeddings for semantic search
 
-You can also **rescan** to re-process all existing photos.
+To re-process all existing photos, open the dropdown next to **Scan** (the chevron) and choose **Rescan**.
+
+:::note
+AI *captions* are not generated during a scan — they are created per photo on demand. Open a photo, show the details panel, and use the wand icon in the **Caption** section. See [Image Captioning](./image-captioning.md).
+:::
 
 ### Scan Progress
 
@@ -48,30 +56,32 @@ The integration is off by default, and the **Nextcloud** section is hidden on th
 
 1. On the Library page, find the **Nextcloud** section
 2. Enter your Nextcloud server URL, username, and password
-3. A green indicator will appear next to "Nextcloud Scan Directory" once connected
-4. Click the folder icon to browse and select your Nextcloud photo directory
+3. Save your changes when the **Save Changes** dialog appears (click **Update**). The **Status** row at the top of the Nextcloud section then shows a green **Connected** badge. It reads **Missing credentials**, **Connecting**, or **Disconnected** while the connection is unset, in progress, or failing.
+4. Click **Browse** (folder icon) to select your Nextcloud photo directory
 
 ### Scanning from Nextcloud
 
-Click **"Scan photos (Nextcloud)"** to download and scan photos from your configured Nextcloud directory. Files are copied to the local filesystem under `nextcloud_media/<username>/` before being processed.
+In the **Nextcloud** section, click **Scan** to download and scan photos from your configured Nextcloud directory. Files are copied to the local filesystem under `nextcloud_media/<username>/` before being processed.
 
 :::note
-Video files are currently not supported for Nextcloud scanning ([#278](https://github.com/LibrePhotos/librephotos/issues/278)).
+Nextcloud scanning indexes the same media as a local scan: images, videos, RAW files and XMP sidecars.
 :::
 
 ## Library Actions
 
 The Library page provides quick access to common maintenance actions:
 
-| Action | Description |
-|--------|-------------|
-| **Scan photos** | Scan for new photos in the file system |
-| **Rescan photos** | Re-process all existing photos |
-| **Train faces** | Run face clustering and classification |
-| **Rescan faces** | Re-detect faces in all photos |
-| **Generate events** | Create or regenerate auto albums |
-| **Delete missing photos** | Remove database entries for photos no longer on disk |
-| **Scan photos (Nextcloud)** | Scan photos from a connected Nextcloud instance |
+| Row | Button | Description |
+|-----|--------|-------------|
+| **Scan Library** | **Scan** | Scan for new photos in the file system |
+| **Scan Library** (dropdown) | **Rescan** | Re-process all existing photos |
+| **Generate Event Albums** | **Generate** | Create auto albums grouped by time |
+| **Regenerate Event Titles** | **Generate** | Regenerate titles for existing event albums |
+| **Train faces** | **Train** | Run face clustering and classification |
+| **Rescan Faces** | **Rescan** | Re-detect faces in all photos |
+| **Nextcloud** | **Scan** | Scan photos from a connected Nextcloud instance |
+
+If LibrePhotos detects photos that are no longer on disk, a red **N Missing Photos** badge appears next to the **Photos** heading. Click it to open the **Remove missing photos** dialog and confirm removal of those database entries. The badge is hidden when nothing is missing.
 
 ## Service Management
 
@@ -98,25 +108,27 @@ For each service, you can:
 
 ### Server Stats
 
-Administrators can view system information in the Admin Area:
+Administrators can download a server-stats report from the Admin Area (**Admin Tools** → **Download Server Stats**), which saves a `serverstats.json` file containing:
 
-- **CPU** — Model, core count, usage
-- **RAM** — Total and used memory
-- **GPU** — GPU model and memory (if available)
+- **CPU** — Model, core count, architecture, and instruction-set flags
+- **RAM** — Total system memory
+- **GPU** — GPU model and memory (only populated when a CUDA GPU is available)
 - **Storage** — Total, used, and free disk space
-- **Per-user stats** — Photo counts per user
+- **Per-user stats** — Detailed counts per user (photos, videos, albums, faces, and more)
+
+The stats are not rendered in the UI — download the JSON to inspect them. Per-user photo counts are also shown directly in the Admin Area's user table.
 
 ### Storage Display
 
-The sidebar shows a storage usage bar indicating how much disk space your photo library is using relative to the total available space.
+The sidebar shows a storage bar for the disk holding your LibrePhotos data directory (`/data` in the default Docker setup). It reports how full that whole volume is — hover for `<used> of <total> used` — so it includes the operating system and anything else on the same disk, not just your photos.
 
 ### Server Logs
 
-Administrators can download the server log file (`ownphotos.log`) directly from the Admin Area for debugging purposes.
+The Admin Area shows a **Server Logs** panel with the most recent log lines (1–1000, default 100) and a **Refresh** button. The download icon saves the full `ownphotos.log` file.
 
 ### Image Version
 
-The sidebar shows the current backend Docker image version. Hover over it to see the full version tag and git hash.
+The sidebar shows the backend image tag (`dev` when `IMAGE_TAG` is unset). Hover over it to see the backend git hash.
 
 ## Management Commands
 
@@ -132,21 +144,27 @@ python manage.py scan -f
 # Scan specific files
 python manage.py scan -s /path/to/file.jpg
 
+# Scan Nextcloud directories for every user that has one configured
+# (users without a Nextcloud scan directory are skipped; -n cannot be combined with -f or -s)
+python manage.py scan -n
+
 # Build similarity index for all users
 python manage.py build_similarity_index
 
 # Save metadata to image files or XMP sidecars
 python manage.py save_metadata
 
-# Start ML services
-python manage.py start_service
+# Start all ML services (individual services are managed from the Admin Area)
+python manage.py start_service all
 
 # Clear site-wide cache
 python manage.py clear_cache
 
-# Create a new user
-python manage.py createuser
+# Create a new user (username and email are required; the password is
+# autogenerated unless --password is given, and --admin grants admin rights)
+python manage.py createuser <username> <email>
 
-# Create an admin user
-python manage.py createadmin
+# Create an admin user; the password is read from the ADMIN_PASSWORD
+# environment variable, otherwise a random one is generated and not printed
+ADMIN_PASSWORD=... python manage.py createadmin <username> <email>
 ```

--- a/apps/docs/docs/user-guide/managing-users.md
+++ b/apps/docs/docs/user-guide/managing-users.md
@@ -1,7 +1,7 @@
 ---
 title: "👨‍👩‍👧‍👦 Manage multiple user"
-excerpt: "In this document I explain how to manage users"
-sidebar_position: 2
+description: "In this document I explain how to manage users"
+sidebar_position: 21
 ---
 
 ### Manage User
@@ -15,7 +15,7 @@ You can create, delete and manage users of your instance. You can change the sca
 **Please note:**
 In LibrePhotos, the file system acts as the definitive source of photo organization. This means that folder structure dictates how photos are grouped and accessed within the application.
 
-To isolate users and their photo collections, create separate subfolders for each user on your host system (e.g., /data/user1, /data/user2, etc.). Then assign each user their respective subfolder as their scan directory in LibrePhotos. This ensures that users only see and interact with the photos in their designated directories.
+To isolate users and their photo collections, create a subfolder for each user inside the folder you set as `scanDirectory` in your `.env` file — the folder LibrePhotos mounts as `/data`. Inside LibrePhotos these show up as `/data/user1`, `/data/user2`, etc., and that is the path you assign as each user's scan directory. Create the folders before assigning them: LibrePhotos only accepts directories that already exist under `/data`. This ensures that users only see and interact with the photos in their designated directories.
 
 If multiple users are assigned the same scan directory (e.g., /data), all photos within that directory will be accessible to all users. LibrePhotos treats the directory as a global source of photos, meaning that every user linked to the directory will see all its contents.
 
@@ -29,9 +29,12 @@ Click on your Avatar → Admin Area to the user registration setting.
 
 You can also activate user registration, where user can create an account themselves. They cannot change the path, which means the admin is still in full control.
 
+A self-registered account is created without a scan directory, so the new user sees an empty library and is told to contact their administrator if they try to scan or upload. After someone signs up, open the Admin Area, edit their account in the user panel at the bottom of the page and set its scan path as described above.
+
 ## How to change the admin password, when you can't log in
 
-There are two ways to accomplish that:
+There are three ways to accomplish that:
 
-- 1. If you set the credentials of the admin in your environment variables, then the password should reset on a reboot
+- 1. If your `.env` sets the admin credentials, the password is reset every time the backend container starts. The keys are `userName`, `userPass` and `adminEmail` (passed to the backend as `ADMIN_USERNAME`, `ADMIN_PASSWORD` and `ADMIN_EMAIL`), and both the username and password must be non-empty. They are not in the shipped `librephotos.env` template, so add them yourself — see [Admin account variables](../installation/environment-variables.md#admin-account-variables) for the full behaviour.
 - 2. If you have access to your container, you can change the password by executing a Django management command `docker exec -it [backend container name] python manage.py changepassword [admin username]`
+- 3. If outgoing e-mail is configured on your instance, the login page shows a **Forgot your password?** link that e-mails a reset link to the address on your account. This only works once e-mail is set up (Admin Area → Site settings → Email) and the account has an e-mail address, so arrange both *before* you get locked out. Behind the bundled proxy, also set `frontendBaseUrl` in your `.env` (passed to the backend as `FRONTEND_BASE_URL`) so the emailed link points at your public address rather than the internal one.

--- a/apps/docs/docs/user-guide/missing-photos.md
+++ b/apps/docs/docs/user-guide/missing-photos.md
@@ -1,7 +1,7 @@
 ---
 title: "📂 Missing Photos"
-excerpt: "Understanding and managing missing photos in LibrePhotos"
-sidebar_position: 8
+description: "Understanding and managing missing photos in LibrePhotos"
+sidebar_position: 15
 ---
 
 ## What are Missing Photos?
@@ -21,12 +21,14 @@ LibrePhotos deliberately keeps missing photos in the database instead of immedia
 
 ## When Photos Get Marked as Missing
 
-LibrePhotos identifies missing photos during these operations:
+LibrePhotos only marks photos as missing during its missing-file check. This check runs automatically as one of the final steps of a photo scan, but only when:
 
-- **Photo scans** - Running the "Scan for Missing Photos" job checks all photos in the database
-- **File system scans** - Regular photo scans detect when previously indexed files are no longer present
-- **Photo access** - When attempting to view or serve a photo whose file doesn't exist
-- **File operations** - When LibrePhotos tries to access a file for processing
+- the scan is a **full scan** (a rescan of your whole library), or
+- the scan covers your configured scan directory without targeting a specific list of files.
+
+It is therefore skipped for scans that only cover a specific set of files or a single subdirectory — such as an upload — unless that scan is a full scan. The check looks at your own photos, and for each one whose file can no longer be found on disk, it marks the photo as missing.
+
+Simply opening, viewing, or downloading a photo whose file has gone does **not** mark it as missing — you will just get an error for that one photo. The missing-photo count only updates after a scan has run this check.
 
 Common scenarios that cause missing photos:
 
@@ -39,19 +41,19 @@ Common scenarios that cause missing photos:
 
 ## How to Identify Missing Photos
 
-LibrePhotos provides several ways to identify missing photos:
+LibrePhotos gives you two ways to spot missing photos:
 
-### Statistics Dashboard
+### Missing Photos Badge
 
-Navigate to your user statistics to see the count of missing photos. The statistics page displays `num_missing_photos` which shows how many photos in your library have missing files.
+Click your avatar in the top-right corner and select **Library**. If any of your photos are missing, a red **"N Missing Photos"** badge appears next to the **Photos** heading; it is hidden when the count is zero. Hover over the badge to read a short explanation of how LibrePhotos marks photos as missing.
 
-### Photo Labels
+:::caution
+Clicking the badge opens the **Remove missing photos** confirmation dialog, which permanently deletes those photos from the database. Hover only, unless deletion is what you intend.
+:::
 
-Photos with missing files are labeled with **["Missing"]** when viewed in the library or photo details.
+### In the Photo Details View
 
-### Admin Area
-
-Administrators can view detailed statistics about missing photos across all users in the Admin Area.
+A missing photo keeps its thumbnail, so it still appears normally in the timeline and albums. The difference only shows in the photo details view: because the file has been detached from the photo, the filename is shown as **"Unknown filename"** and the folder-path breadcrumb is hidden.
 
 ## Resolving Missing Photos
 
@@ -73,7 +75,7 @@ If the issue is related to mounting or storage:
 2. Check Docker volume mounts in your configuration
 3. Verify network storage is accessible
 4. Restart LibrePhotos after fixing storage issues
-5. Run "Scan for Missing Photos" job to detect restored files
+5. Run a scan from the **Library** page (avatar menu → **Library** → **Scan Library** → **Scan**) so LibrePhotos re-checks and relinks the restored files
 
 ### Option 3: Automatic Relinking
 
@@ -85,22 +87,25 @@ LibrePhotos automatically relinks photos when files reappear:
 
 To trigger automatic relinking:
 
-1. Go to Settings → Library Management
-2. Click "Scan Photos" to perform a new scan
+1. Click your avatar in the top-right corner and select **Library** (or press `Ctrl+K` and search for "Library")
+2. In the **Scan Library** row, click **Scan** to perform a new scan (a full re-read of every file is available as **Rescan** in the dropdown next to it)
 3. LibrePhotos will detect and relink matching files
 
 ### Option 4: Delete Missing Photos
 
 If you're certain the files are permanently gone:
 
-1. Go to Settings → Library Management
-2. Click "Delete Missing Photos"
-3. This will permanently remove all missing photos from the database, including:
+1. Open the **Library** page (avatar menu → **Library**)
+2. Next to the **Photos** heading, click the red **"N Missing Photos"** badge — it only appears when your library actually has missing photos
+3. In the **Remove missing photos** dialog, click **Confirm**
+4. This will permanently remove all missing photos from the database, including:
    - Photo metadata and EXIF information
    - Thumbnails
    - Face detections
    - Album associations
    - Ratings and captions
+
+The same action is also available from the Spotlight command palette (`Ctrl+K`) as **Delete Missing Photos**.
 
 :::caution
 Deleting missing photos is permanent. Make sure the files are truly gone and won't be restored before using this option.
@@ -125,14 +130,14 @@ Deleting missing photos is permanent. Make sure the files are truly gone and won
 1. Update your Docker configuration to use the original mount point, or
 2. Move your photos to match the new mount point
 3. Restart LibrePhotos
-4. Run "Scan for Missing Photos" to update the database
+4. Run a scan from the **Library** page to update the database
 
 ### Scenario: Files Moved to Different Folder
 
 **Problem**: You reorganized your photo collection using a file manager.
 
 **Solution**:
-1. If the new location is within your scanned directories, just run "Scan Photos"
+1. If the new location is within your scanned directories, just run a scan from the **Library** page (**Scan Library** → **Scan**)
 2. LibrePhotos will detect the files by hash and automatically relink them
 3. The original metadata, ratings, and face tags will be preserved
 
@@ -142,7 +147,7 @@ Deleting missing photos is permanent. Make sure the files are truly gone and won
 
 **Solution**:
 - If you want to keep them: Restore the files from trash and run a scan
-- If you want to remove them: Use "Delete Missing Photos" to clean up the database
+- If you want to remove them: Use the **"N Missing Photos"** badge on the Library page (or the **Delete Missing Photos** action in the Spotlight palette) to clean up the database
 
 ## Future Improvements
 
@@ -158,6 +163,6 @@ This real-time monitoring will use file system watchers (inotify on Linux, FSEve
 ## Related Documentation
 
 - [Trash Management](./trash.md) - Learn about LibrePhotos' trash system
-- [Job System](./job-system.md) - Understanding long-running jobs like "Scan for Missing Photos"
+- [Job System](./job-system.md) - Understanding long-running jobs such as "Delete Missing Photos", and how to monitor them in the Admin Area
 - [Auto Scan](./auto-scan.md) - Configure automatic photo scanning
 

--- a/apps/docs/docs/user-guide/mobile/index.md
+++ b/apps/docs/docs/user-guide/mobile/index.md
@@ -1,7 +1,7 @@
 ---
 title: "📱  Mobile Apps"
-excerpt: "Which apps does Librephotos have?"
-sidebar_position: 5
+description: "Which apps does Librephotos have?"
+sidebar_position: 25
 ---
 
 ## UhuruPhotos

--- a/apps/docs/docs/user-guide/mobile/librephotos-mobile/index.md
+++ b/apps/docs/docs/user-guide/mobile/librephotos-mobile/index.md
@@ -1,11 +1,17 @@
 ---
 title: "📱  LibrePhotos Mobile"
-excerpt: "Which apps does Librephotos have?"
-sidebar_position: 5
+description: "Which apps does Librephotos have?"
+sidebar_position: 1
 ---
 
 ## LibrePhotos Mobile
 
 [LibrePhotos Mobile](https://github.com/LibrePhotos/librephotos/tree/dev/apps/mobile) is the official app, which is at the proof-of-concept stage. It's written in react-native and in the future will share more code with the frontend.
 
-You can download the .apk [here](https://github.com/LibrePhotos/librephotos/releases/tag/mobile%2Fv1.0.3). It is technically possible to compile it to also work on iOS, but nobody stepped up to do that yet.
+You can download the .apk [here](https://github.com/LibrePhotos/librephotos/releases/tag/mobile%2Flatest). It is technically possible to compile it to also work on iOS, but nobody stepped up to do that yet.
+
+## Connecting to your server
+
+When you first open the app, enter your LibrePhotos server in the **Server Name** field — use the same address you use to reach LibrePhotos in a browser, for example `photos.example.com` or `192.168.1.10:3000`. The protocol is optional: the app tries `http://` first and falls back to `https://`, and it lowercases the address and drops any trailing slash for you.
+
+The app checks the server as you type. Wait for the green check mark, which means the server was reached. A red warning triangle and an "Unable to connect to the server" message means the address could not be reached — the check has a short timeout, so a slow or distant server may need a moment or a second try. Once the check is green, sign in with your LibrePhotos username and password.

--- a/apps/docs/docs/user-guide/mobile/librephotos-mobile/local-images.md
+++ b/apps/docs/docs/user-guide/mobile/librephotos-mobile/local-images.md
@@ -1,29 +1,28 @@
 ---
 title: "☁️ Local Images"
-excerpt: "How do local images work?"
-sidebar_position: 5
+description: "How do local images work?"
+sidebar_position: 2
 ---
 
 ## Sync status
 
 - ✅ Synced: The image is synced with the server and exists on your phone
-- 🔄 Syncing: The image is currently syncing with the server
 - ❌ Local: The image is not synced with the server and only exists on your phone
 - ☁️ Remote: The image is only on the server and not on your phone
 
-On the first load of the app, it will check for new local images. These will be shown together with the images from the server.
-When you upload images to the server, they will be marked as "Syncing" and will be synced with the server.
+Whenever you open the timeline (the "With Timestamp" tab), the app scans your camera roll for images that are newer than the previous scan and shows them together with the images from the server. Because the scan is incremental, images that reach your phone with an older date — restored backups, files copied from a computer, or imports that keep their original EXIF date — are not picked up. Use "Reset Local Images" in the settings to clear the local index and force a full rescan.
+When you upload images to the server, the Settings screen shows an "Uploading X%" progress indicator while the transfer runs. The image stays marked as "Local" until the upload finishes.
 When the upload is complete, the image will be marked as "Synced". If it finds a local image on the server with the same hash, it will be not uploaded, but still changed to synced.
 
 ## Permissions
 
 The app needs the following permissions:
 
-- Read external storage (Android <12)
-- Write external storage (Android <12)
-- Read media images (Android >12)
-- Read media video (Android >12)
-- Manage external storage (Android >12)
+- Read external storage (Android 12 and below, API ≤ 32)
+- Write external storage (Android 10 and below, API ≤ 29)
+- Read media images (Android 13+)
+- Read media video (Android 13+)
+- Manage external storage (Android 11+)
 
 The app will ask for these permissions on the first start. Most of these permissions are required to be able to read the images from your phone.
 

--- a/apps/docs/docs/user-guide/mobile/librephotos-mobile/upload.md
+++ b/apps/docs/docs/user-guide/mobile/librephotos-mobile/upload.md
@@ -1,12 +1,21 @@
 ---
 title: " 📁 Upload"
-excerpt: "How to upload photos with the LibrePhotos mobile app"
+description: "How to upload photos with the LibrePhotos mobile app"
 sidebar_position: 5
 ---
 
 ### Upload a single photo
 
 Click on a local photo and click on the upload button in the top left corner.
+
+### Prerequisites
+
+Two things have to be in place before the mobile app can upload, and both are set up by an admin:
+
+- **Uploads must be enabled** — the `Allow uploads` switch in the admin area has to be on (see [Activate / Deactivate the upload feature](#activate--deactivate-the-upload-feature) below).
+- **Your account must have a Scan Directory** — an admin has to set a Scan Directory for your user, and that directory must exist inside the server container. See [How to Change Your Scan Directory](../../first-steps.md#how-to-change-your-scan-directory).
+
+If the Scan Directory is missing or does not exist on the server, the upload is rejected. The mobile app currently does not surface this error: the photo simply stays unsynced. So if uploads never seem to complete, check with your admin that your Scan Directory is set correctly.
 
 ### What kinds of files are supported?
 
@@ -20,12 +29,12 @@ The upload process works in the following way:
 - If it is, don't upload it
 - If it isn't, upload it
 - We upload files in 1MB chunks
-- If all files are uploaded, we scan the your `scan folder + /upload/web`
+- When a file finishes uploading, the server saves it under `scan folder + /uploads/web` and queues a background job for that one photo (thumbnails, metadata, captions, geolocation, album date and face detection) — no separate folder scan is triggered
 - Mark the photo as synced
 
 ### Where are the files saved?
 
-- If all the chunks are uploaded, we combine them into a single file and put them in your `scan folder + /upload/web`
+- If all the chunks are uploaded, we combine them into a single file and put them in your `scan folder + /uploads/web`
 
 ### Backup all photos
 
@@ -42,4 +51,4 @@ It works by checking if the photo is synced and if it is, it deletes it from you
 
 ### Activate / Deactivate the upload feature
 
-You can activate / deactivate by navigating as an admin to the admin area and clicking on the `Allow uploads` switch. You can also set this by setting the environment variable `ALLOW_UPLOADS` to `true` or `false`.
+You can activate / deactivate by navigating as an admin to the admin area and clicking on the `Allow uploads` switch. This switch is the authoritative setting. The `ALLOW_UPLOAD` environment variable (set through `allowUpload` in `librephotos.env` for the Docker deployment) only supplies the initial default: once a value has been saved to the database — by toggling the switch, or by the first-time setup wizard — the stored setting wins and the environment variable is ignored. See [Environment variables](../../../installation/environment-variables.md).

--- a/apps/docs/docs/user-guide/offline-setup.md
+++ b/apps/docs/docs/user-guide/offline-setup.md
@@ -1,10 +1,10 @@
 ---
 title: "Offline Usage"
-excerpt: "Learn how to configure LibrePhotos for complete offline usage by manually downloading and placing the required machine learning models. This guide provides step-by-step instructions to ensure your LibrePhotos installation functions seamlessly without an Internet connection."
-sidebar_position: 5
+description: "Learn how to configure LibrePhotos for offline use by manually downloading and placing the required machine learning models. This guide provides step-by-step instructions so your LibrePhotos installation can run its machine learning features without an Internet connection."
+sidebar_position: 22
 ---
 
-To enable LibrePhotos to work completely offline by manually downloading and placing the required machine learning models, you can follow the steps outlined below. This guide assumes that you have access to the Internet initially to download the models and then configure LibrePhotos to run in an offline environment.
+To enable LibrePhotos to run its machine learning features offline, you can manually download and place the required models by following the steps outlined below. This guide assumes that you have access to the Internet initially to download the models and then configure LibrePhotos to run in an offline environment.
 
 ### Step 1: Download the Models Manually
 
@@ -18,21 +18,20 @@ Manually download the necessary models from their respective URLs. Below is a li
    - URL: `https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz`
 4. **resnet18** (Categories)
    - URL: `https://download.pytorch.org/models/resnet18-5c106cde.pth`
-5. **im2txt_onnx** (Captioning)
-   - URL: `https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/im2txt_onnx.tar.gz`
-6. **blip_base_capfilt_large** (Captioning) (optional)
+5. **blip_base_capfilt_large** (Captioning) (optional)
    - URL: `https://huggingface.co/derneuere/librephotos_models/resolve/main/blip_large.tar.gz?download=true`
-7. **mistral-7b-v0.1.Q5_K_M** (LLM) (optional)
-   - URL: `https://huggingface.co/TheBloke/Mistral-7B-v0.1-GGUF/resolve/main/mistral-7b-v0.1.Q5_K_M.gguf?download=true`
-8. **mistral-7b-instruct-v0.2.Q5_K_M** (LLM) (optional)
+6. **mistral-7b-instruct-v0.2.Q5_K_M** (LLM) (optional)
    - URL: `https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q5_K_M.gguf?download=true`
-9. **siglip2** (Tagging) (optional — only if using SigLIP 2 tagging model)
-    - Vision model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/vision_model.onnx`
-    - Text model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/text_model.onnx`
-    - Tokenizer: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/tokenizer.model`
-10. **buffalo_sc** (Face recognition — default model)
-    - URL: `https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip`
-    - Only download the model selected in **Site Settings → Face Recognition Model**. The other options use the same release, e.g. `buffalo_s.zip`, `buffalo_m.zip`, `buffalo_l.zip`, `antelopev2.zip`.
+7. **moondream** (Captioning / LLM) (optional)
+   - Text model: `https://huggingface.co/moondream/moondream-2b-2025-04-14-4bit/resolve/main/moondream2-text-model-f16.gguf?download=true`
+   - Multimodal projector (mmproj): `https://huggingface.co/moondream/moondream-2b-2025-04-14-4bit/resolve/main/moondream2-mmproj-f16.gguf?download=true`
+8. **siglip2** (Tagging) (optional — only if using SigLIP 2 tagging model)
+   - Vision model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/vision_model.onnx`
+   - Text model: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/text_model.onnx`
+   - Tokenizer: `https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/tokenizer.model`
+9. **buffalo_sc** (Face recognition — default model)
+   - URL: `https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip`
+   - Only download the model selected in **Site Settings → Face Recognition Model**. The other options use the same release, e.g. `buffalo_s.zip`, `buffalo_m.zip`, `buffalo_l.zip`, `antelopev2.zip`.
 
 ### Step 2: Place the Models in the Correct Location
 
@@ -42,20 +41,28 @@ Once the models are downloaded, place them in the following directory:
 <LibrePhotos Media Root Directory>/data_models/
 ```
 
-For example, if your `MEDIA_ROOT` is set to `/var/lib/librephotos`, then the models should be placed in `/var/lib/librephotos/data_models/`.
+`MEDIA_ROOT` is not something you set directly — it is derived from `BASE_DATA` (default `/`), so inside the container it is always `/protected_media`. On the host it is whichever directory you mounted to `/protected_media`. With the standard docker-compose install that is `${data}/protected_media`, which defaults to `./librephotos/data/protected_media/`, so the models go in `./librephotos/data/protected_media/data_models/`.
 
 - **im2txt.tar.gz** -> Unpack into `<MEDIA_ROOT>/data_models/im2txt/`
 - **clip-embeddings.tar.gz** -> Unpack into `<MEDIA_ROOT>/data_models/clip-embeddings/`
 - **places365.tar.gz** -> Unpack into `<MEDIA_ROOT>/data_models/places365/`
 - **resnet18-5c106cde.pth** -> Place directly as `<MEDIA_ROOT>/data_models/resnet18-5c106cde.pth`
-- **im2txt_onnx.tar.gz** -> Unpack into `<MEDIA_ROOT>/data_models/im2txt_onnx/`
 - **blip_large.tar.gz** -> Unpack into `<MEDIA_ROOT>/data_models/blip/`
-- **mistral-7b-v0.1.Q5_K_M.gguf** -> Place directly as `<MEDIA_ROOT>/data_models/mistral-7b-v0.1.Q5_K_M.gguf`
 - **mistral-7b-instruct-v0.2.Q5_K_M.gguf** -> Place directly as `<MEDIA_ROOT>/data_models/mistral-7b-instruct-v0.2.Q5_K_M.gguf`
+- **moondream2-text-model-f16.gguf** -> Place directly as `<MEDIA_ROOT>/data_models/moondream2-text-model-f16.gguf`
+- **moondream2-mmproj-f16.gguf** -> Place directly as `<MEDIA_ROOT>/data_models/moondream2-mmproj-f16.gguf`
 - **siglip2 vision_model.onnx** -> Place as `<MEDIA_ROOT>/data_models/siglip2/vision_model.onnx`
 - **siglip2 text_model.onnx** -> Place as `<MEDIA_ROOT>/data_models/siglip2/text_model.onnx`
 - **siglip2 tokenizer.model** -> Place as `<MEDIA_ROOT>/data_models/siglip2/tokenizer.model`
 - **buffalo_sc.zip** -> Unpack into `<MEDIA_ROOT>/data_models/face_recognition/models/buffalo_sc/` (the folder should contain the `.onnx` files)
+
+:::note
+Moondream needs **both** files placed directly in `data_models/`. If only `moondream2-text-model-f16.gguf` is present, the LLM service fails to start with `Moondream mmproj file not found`.
+:::
+
+:::note
+BLIP does not ship its text tokenizer inside `blip_large.tar.gz`. Loading the model always calls `BertTokenizer.from_pretrained("bert-base-uncased")`, which fetches from Hugging Face at runtime — this happens whether you place the model manually or let LibrePhotos download it from the Admin Area. While still online, set **Site Settings → Captioning Model** to *BLIP Base Capfilt Large* and generate one caption; the tokenizer is then cached under `/root/.cache/huggingface` inside the container, which the default compose file persists as `${data}/cache`. Preserve that `cache` directory when you move the install offline — a fresh or wiped `${data}/cache` makes the first offline BLIP caption fail.
+:::
 
 ### Step 3: Verify Model Placement
 
@@ -67,10 +74,10 @@ data_models/
     ├── clip-embeddings/
     ├── places365/
     ├── resnet18-5c106cde.pth
-    ├── im2txt_onnx/
     ├── blip/
-    ├── mistral-7b-v0.1.Q5_K_M.gguf
     ├── mistral-7b-instruct-v0.2.Q5_K_M.gguf
+    ├── moondream2-text-model-f16.gguf
+    ├── moondream2-mmproj-f16.gguf
     ├── siglip2/
     │   ├── vision_model.onnx
     │   ├── text_model.onnx
@@ -80,6 +87,13 @@ data_models/
             └── buffalo_sc/
 ```
 
-### Step 4: Run LibrePhotos
+### Step 4: Turn Off the Online Map Services
 
-You can now run LibrePhotos without an active Internet connection. The application will use the models you manually downloaded and placed in the `data_models` directory.
+Even with every model stored locally, two settings still reach the Internet by default:
+
+- **Site Settings → Map Tiles** defaults to **PhotoPrism (default)**, which loads the map background from `https://cdn.photoprism.app/maps/default.json` every time a map is shown. The **OpenStreetMap** option is not an offline alternative either — it fetches tiles from `tile.openstreetmap.org` and fonts from `fonts.openmaptiles.org`. On an offline install, select **None (hide map)**, which turns off map rendering and makes no external requests.
+- **Site Settings → Map Provider** (reverse geocoding) defaults to **Nominatim (OpenStreetMap)** and calls the public Nominatim service during scans to turn GPS coordinates into place names. Without Internet access these calls fail and are only logged as a warning, so photos keep their coordinates but get no place names and the Places albums stay empty. There is no offline geocoding provider, so this feature is unavailable offline.
+
+### Step 5: Run LibrePhotos
+
+You can now run LibrePhotos without an active Internet connection for the machine learning features. The application will use the models you manually downloaded and placed in the `data_models` directory.

--- a/apps/docs/docs/user-guide/places.md
+++ b/apps/docs/docs/user-guide/places.md
@@ -1,7 +1,7 @@
 ---
 title: "🗺 Places"
-excerpt: "An overview on how geolocation and places work in LibrePhotos"
-sidebar_position: 5
+description: "An overview on how geolocation and places work in LibrePhotos"
+sidebar_position: 7
 ---
 
 LibrePhotos can display your photos on an interactive map based on their GPS coordinates. This page explains how geolocation works and how to get the most out of the Places feature.
@@ -31,40 +31,53 @@ You can configure your preferred geocoding provider in **Admin Area → Site Set
 
 :::tip Recommended Setup
 **Nominatim** is the recommended option as it's completely free and doesn't require an API key. It uses OpenStreetMap data and works well for most use cases.
+
+To respect Nominatim's public terms of use, LibrePhotos limits itself to about one lookup per second for this provider, and that limit is shared across all background workers — adding more workers won't speed it up. The first scan of a large geotagged library will therefore take a while, and places keep filling in after the scan reports done. If you have tens of thousands of geotagged photos, a commercial provider with an API key geocodes far faster.
 :::
 
 ### 3. Map Display
 
-LibrePhotos uses **MapLibre GL** with vector tiles from PhotoPrism's free tile server. This provides:
+LibrePhotos renders maps with **MapLibre GL**. By default the map background (the "tiles") comes from PhotoPrism's free tile server, which provides:
 
 - Smooth, high-quality vector maps
 - Fast rendering and zooming
 - No API key required for map display
 - Works offline once tiles are cached
 
+Admins can change where tiles come from under **Admin Area → Site Settings → Map Tiles**, which sits directly below the Map Provider select. Three options are available:
+
+- **PhotoPrism (default)**: MapLibre vector tiles from `cdn.photoprism.app` and `maps.photoprism.app`.
+- **OpenStreetMap**: raster tiles from `tile.openstreetmap.org` (label glyphs from `fonts.openmaptiles.org`).
+- **None (hide map)**: no map is rendered anywhere; a placeholder is shown instead.
+
+This setting is global. Choosing **None** hides the map in every map view, including the Places page, album location maps, the photo-info mini-map, and the location picker. The initial value comes from the `MAP_TILE_PROVIDER` environment variable (default `photoprism`), but it is an admin-editable site setting thereafter, so you don't need to restart to change it.
+
 ## The Places Page
 
-The Places page (`/album/places`) shows all your geotagged photos on an interactive map:
+The Places page (`/album/places`) shows the places in your library on an interactive map. The map plots one marker per detected place name, not one per photo — reverse geocoding records several levels for each photo (country, region, city, point of interest), so a single photo can contribute several markers, and each distinct place name appears only once.
 
-- **Clustered markers**: When zoomed out, nearby photos are grouped into clusters showing the count
+- **Clustered markers**: When zoomed out, nearby places are grouped into clusters; the number shown on a cluster is how many distinct places it contains, not how many photos
 - **Click to zoom**: Click on a cluster to zoom in and see individual locations
 - **Filtered albums**: As you pan and zoom the map, the album grid below updates to show places visible in the current view
 - **Navigation controls**: Use the +/- buttons or scroll to zoom, drag to pan
 
 ## Setting Up Places
 
-### Step 1: Configure Geocoding Provider (Optional)
+### Step 1: Configure Map Providers (Optional)
 
 1. Go to **Admin Area → Site Settings**
-2. Select your preferred **Map API Provider**
-3. If using a commercial provider, enter your **API Key**
-4. Save the settings
+2. Select your preferred **Map Provider** — this is the geocoding service used to turn coordinates into place names
+3. If using a commercial provider, enter your key in the **API key for Map Provider** field
+4. Optionally, choose the **Map Tiles** source directly below (PhotoPrism, OpenStreetMap, or None) — this controls the map background rather than geocoding
+5. Save the settings
 
 ### Step 2: Scan Your Photos
 
-1. Go to **Settings → Scan Directory**
-2. Run a full scan of your photo library
-3. The scan will extract GPS coordinates and perform reverse geocoding
+1. Click your avatar (top right) and choose **Library**
+2. In the **Scan Library** card, click **Scan** to pick up newly added photos. If your photos are already indexed, open the dropdown next to the button and choose **Rescan** instead — a plain scan skips files that haven't changed
+3. The scan extracts GPS coordinates and performs reverse geocoding
+
+See [Library Management](./library.md) for the full list of Library page actions.
 
 ### Step 3: View Your Places
 
@@ -78,15 +91,28 @@ Once your photos have location data:
 - **Auto-albums with places**: Automatically created albums include location in their titles
 - **Location timeline**: See where you've been over time
 - **Place tree**: Hierarchical view of all your locations
-- **Photo info**: Individual photos show their location on a mini-map
+- **Photo info**: Individual photos show their location on a mini-map (when map display is enabled), and you can set or correct a photo's location from there
+
+## Setting a Location Manually
+
+If a photo has no GPS data, or has the wrong location, you can set it by hand:
+
+1. Open the photo and find the location line in the info sidebar.
+2. Click the pencil (**Update location**) next to it to open the **Pick location** dialog.
+3. Set the position by searching for a place name, clicking or dragging the marker on the map, or clicking the crosshair button to use your browser's current location.
+4. Click **Save**.
+
+The photo is reverse-geocoded immediately and added to the matching place albums — no rescan required. The pencil is not shown on publicly shared photos. If maps are turned off in Site Settings, the map pane is hidden but place-name search and "use my current location" still work.
 
 ## Troubleshooting
 
 ### Places tab is empty
 
 1. **Check if photos have GPS data**: Open a photo's info panel and look for GPS coordinates
-2. **Run a rescan**: If you recently added photos, run a new scan
-3. **Check geocoding provider**: Ensure your geocoding provider is configured correctly in Site Settings
+2. **Scan for new photos**: If you recently added photos, run a **Scan** from the Library page
+3. **Check geocoding provider**: Ensure your geocoding provider is configured correctly in **Admin Area → Site Settings**. A commercial provider with a missing or invalid API key fails silently — the scan reports success but no place names are stored
+4. **Run a full Rescan after fixing the provider**: Go to **Library → Scan Library**, open the dropdown next to the **Scan** button, and choose **Rescan**. The plain **Scan** button only geolocates photos added since the previous geolocation run, so it will not re-geocode your existing library
+5. **Give geocoding time to finish**: Geocoding runs as a background job after the scan. With Nominatim on a large library this can take a while, and places keep filling in after the scan reports done — wait before re-scanning
 
 ### Some photos don't show locations
 
@@ -95,15 +121,20 @@ Once your photos have location data:
 - Some cameras require GPS to be explicitly enabled
 - Check if location services were enabled when the photo was taken
 
+A rescan cannot add coordinates that were never in the file. To place such a photo yourself, see [Setting a Location Manually](#setting-a-location-manually).
+
 ### Map tiles not loading
 
 - Check your internet connection
-- The map uses PhotoPrism's tile server at `cdn.photoprism.app` and `maps.photoprism.app`
-- Ensure these domains aren't blocked by your firewall or ad blocker
+- Check **Admin Area → Site Settings → Map Tiles**. If it is set to **None**, maps are disabled on purpose
+- With **PhotoPrism (default)**, the tiles come from `cdn.photoprism.app` and `maps.photoprism.app`
+- With **OpenStreetMap**, they come from `tile.openstreetmap.org` and `fonts.openmaptiles.org` instead
+- Ensure the relevant domains aren't blocked by your firewall or ad blocker. If the PhotoPrism domains are unreachable, switching **Map Tiles** to **OpenStreetMap** (or **None** to hide the map) is an alternative
 
 ## Privacy Considerations
 
 - GPS coordinates in photos can reveal sensitive location information
 - When sharing photos, consider stripping EXIF data if privacy is a concern
 - LibrePhotos keeps your location data private within your instance
-- The map tile server only receives tile requests, not your photo locations
+- Opening a map fetches tiles for the area around your photos, which reveals their approximate location to the selected tile provider. The photo-info mini-map zooms in tightly, so the tiles it requests pinpoint that photo's location fairly precisely
+- You control this with **Map Tiles** in **Admin Area → Site Settings**: *PhotoPrism* (default, tiles from `cdn.photoprism.app` / `maps.photoprism.app`), *OpenStreetMap* (tiles from `tile.openstreetmap.org`, which shifts the exposure to a different provider rather than removing it), or *None* to disable map display entirely so no third-party tile requests are made

--- a/apps/docs/docs/user-guide/search.md
+++ b/apps/docs/docs/user-guide/search.md
@@ -1,7 +1,7 @@
 ---
 title: "🔎 Search"
-excerpt: "Find your photos using spotlight search, semantic search, and text search"
-sidebar_position: 11
+description: "Find your photos using spotlight search, semantic search, and text search"
+sidebar_position: 3
 ---
 
 LibrePhotos offers several ways to search through your photo library, from quick keyboard-driven navigation to AI-powered semantic search.
@@ -18,7 +18,13 @@ Press any of these keyboard shortcuts to open the spotlight:
 |----------|----------|
 | `Ctrl + K` | Windows / Linux |
 | `Cmd + K` | macOS |
+| `Ctrl + P` | Windows / Linux |
+| `Cmd + P` | macOS |
 | `/` | Any platform |
+
+:::note
+`Ctrl + P` / `Cmd + P` opens the spotlight rather than the browser's print dialog. Use the browser menu if you need to print the page.
+:::
 
 You can also click the search icon in the top menu bar.
 
@@ -42,10 +48,12 @@ Select "Search for [your query]" to perform a full search and see all matching r
 
 Quickly jump to any page in LibrePhotos:
 
-- Photos, Albums, People, Places, Things, Events, Folders
-- Favorites, Hidden, Videos, Recently Added, No Timestamp
-- Sharing, Faces Dashboard, Statistics
+- Photos, Albums, My Albums, People, Places, Things, Tags, Events, Folders
+- Favorites, Hidden, Videos, Trash, Recently Added, No Timestamp
+- Sharing, Faces Dashboard, Statistics — and its sub-pages Place Tree, Word Clouds, Timeline, Social Graph and Face Clusters
 - Settings, Profile, Library, Admin Area
+
+Settings and Profile also expose keyword shortcuts: typing something like `password`, `language`, `clustering`, `metadata` or `llm` surfaces entries such as Change Password, Change Language, Face Recognition Settings, Metadata Settings and AI & LLM Settings, each of which opens the matching Settings or Profile page.
 
 #### Actions
 
@@ -64,28 +72,33 @@ When you perform a search (either from the spotlight or the search bar), LibrePh
 - Photo captions (AI-generated and manual)
 - People's names
 - Location names (from reverse geocoding)
+- Keywords and tags embedded in the photo (XMP `Subject` and IPTC `Keywords`, including from `.xmp` sidecar files) — for example, tags applied in Lightroom or digiKam
 - File paths
 - Camera and lens information
 - File type
-- Time expressions (e.g. "January", "2024", "Thursday")
+- Date fragments in ISO form (e.g. `2024`, `2024-01`, `2024-01-15`) — the timestamp is matched as plain text, so month or weekday names such as "January" or "Thursday" do not match
+
+Every word in your query must match, though not necessarily in the same field: searching `beach sunset` returns only photos where both `beach` and `sunset` appear somewhere in the indexed text (caption, person name, location, file path, camera, and so on). Commas separate words the same way spaces do. To search for an exact phrase, wrap it in quotes — `"golden gate bridge"` matches only photos containing that whole phrase.
+
+The search results header also has an **All / Photos / Videos** toggle in the top right for narrowing the results to only photos or only videos.
 
 Results are displayed grouped by date, similar to the main timeline view.
 
 ## Semantic Search
 
-Semantic search uses AI (CLIP embeddings) to find photos by meaning rather than exact text matching. Instead of matching keywords, it understands the concept behind your query.
+Semantic search uses AI (CLIP embeddings) to find photos by meaning rather than exact text matching. It understands the concept behind your query, and those matches are added to the normal text-search results rather than replacing them — so a search returns both the photos whose captions or metadata contain your words and the photos that simply look like what you described. Because of this, a result may not contain every word of your query.
 
 For example, searching "sunset at the beach" will find photos that look like a sunset at a beach, even if none of those words appear in the photo's metadata or caption.
 
 ### Enabling Semantic Search
 
-Semantic search is disabled by default because the first search takes a moment to build the similarity index.
+Semantic search is disabled by default. It works from CLIP embeddings, which LibrePhotos computes for your photos during a scan, plus an in-memory similarity index built from those embeddings.
 
 1. Go to **Settings**
-2. Find the **Semantic Search** setting
-3. Set it to **Top 100**, **Top 50**, or **Top 10** (the number of results to return)
+2. Find the **Semantic search max results** setting
+3. Set it to **Top 100**, **Top 50**, or **Top 10** — the maximum number of semantically similar photos to add to your results. Matches that fall below an internal similarity threshold are dropped, so you may get fewer than this, and because keyword matches are still included the total number of results can be higher.
 
-Once enabled, your text searches will use semantic matching. The first search may take up to a minute while the index is built; subsequent searches are fast.
+Turning the setting on also queues a background job that computes CLIP embeddings for any photos that do not have one yet and then builds the similarity index. Semantic results only start appearing once that job has finished, which can take a while on a large library that has never been embedded. The index itself lives in memory in the image-similarity service and is rebuilt automatically each time the backend container starts; the first query after a restart can take a moment while the CLIP model loads, after which queries are fast.
 
 :::tip
 You need to have the **CLIP embedding** calculation job completed for semantic search to work. This runs automatically during photo scanning, or you can trigger it manually from the Library page.
@@ -96,7 +109,7 @@ You need to have the **CLIP embedding** calculation job completed for semantic s
 1. During scanning, LibrePhotos computes a CLIP embedding for each photo — a numerical representation of the image's visual content
 2. When you search, your text query is also converted to a CLIP embedding
 3. Photos whose embeddings are closest to your query embedding are returned as results
-4. Results are ranked by similarity rather than grouped by date
+4. Matching photos are returned as a single flat list instead of being grouped by date. The list is not sorted by similarity score — the CLIP ranking only decides *which* photos come back (the top N you configured), not the order they appear in
 
 ## Similar Photos
 

--- a/apps/docs/docs/user-guide/settings/date-rules.md
+++ b/apps/docs/docs/user-guide/settings/date-rules.md
@@ -1,7 +1,7 @@
 ---
 title: "📅 Using date rules"
-excerpt: "How to use the date rules"
-sidebar_position: 4
+description: "How to use the date rules"
+sidebar_position: 1
 ---
 
 ## Background information
@@ -33,8 +33,12 @@ the timezone of the location where the photo/video was taken. Both "source_tz" a
 should be one of the following:
 
 - "utc" - UTC timezone
-- "gps_timezonefinder" - the timezone of the GPS location associated with the photo/video - "name:<timezone_name>"
-- the timezone with the name <timezone_name>
+- "gps_timezonefinder" - the timezone of the GPS location associated with the photo/video
+- "user_default" - the **Default timezone** set in your user settings; several of the built-in rules rely on this, including "Video creation datetime in user default timezone"
+- "server_local" - the local timezone of the machine running LibrePhotos (in Docker this is normally UTC unless you set a `TZ` for the container)
+- "name:&lt;timezone_name&gt;" - the timezone with the name &lt;timezone_name&gt;, e.g. "name:Europe/Berlin"
+
+The settings UI only offers "gps_timezonefinder" and "user_default" for "report_tz"; the other values are accepted by the backend when a rule is edited directly.
 
 If either "source_tz" or "report_tz" could not be obtained, the rule is considered to be not applicable.
 
@@ -54,25 +58,28 @@ Currently, supported rule types:
 
 - "exif" - local time is taken using exif tag params["exif_tag"] as obtained with exiftool
 - "path" - time is taken from the filename using a regular expression matching
-- "fs" - time is taken from file property. Since these are UNIX timestamps without timezones
-  they are always translated to local time using UTC.
-- "user defined" - the date time defined by the user from the frontend
+- "filesystem" - time is taken from a file property. params["file_property"] must be "mtime"
+  (file modified time) or "ctime" (file created time). Since these are UNIX timestamps without
+  timezones they are always translated to local time using UTC.
+- "user_defined" - the date time defined by the user from the frontend
 
 ## How to use it
 
 ### Adding optional rules
 
-To add a new rule, go to settings and navigate to the date time parsing rules. Click on the button "Add rule". You can now add optional rules like using the modified time or to create time from the file.
+To add a new rule, go to settings and navigate to the date time parsing rules. Click on the **Add Rule** button. You can now add optional rules, such as using the file's modified or created time.
+
+To remove a rule again, click the X (**Delete rule**) at the right-hand end of its row. The **Reset To Defaults** button next to **Add Rule** puts the list back to the rules LibrePhotos ships with; it is greyed out while your list already matches the default rules in their default order.
 
 ### Changing the order
 
-The top rules will be applied first, and the bottom rules be applied last. To change the order, drag and drop one of the cards and save them by clicking on update.
+The top rules are applied first and the bottom rules last. To change the order, drag and drop the rules. Adding, deleting, reordering and resetting rules only take effect once you save your settings — LibrePhotos prompts you with **Save changes?** and you confirm by clicking **Update**.
 
 ### Applying the rules
 
-The date rules are applied on each scan. If you changed the rules to your liking, click on "Rescan all Photos" and then the new rules will be applied.
+The date rules are applied on each scan. Once your rules are how you want them, open the **Library** page (from the profile menu in the top-right corner, choose **Library**; or press Ctrl+K and search for "Library"). In the **Scan Library** section, click the arrow next to the **Scan** button and choose **Rescan**. The same action is available from the command palette (Ctrl+K) as **Rescan All Photos**.
 
-Use **"Rescan all Photos"** specifically. An ordinary scan only looks at files that are new or whose contents changed since the last scan, so it will walk straight past a library that is already indexed and nothing will appear to happen. "Rescan all Photos" re-reads every file and re-runs the rules over all of them.
+Use **Rescan** specifically, not a plain **Scan**. An ordinary scan only looks at files that are new or whose contents changed since the last scan, so it will walk straight past a library that is already indexed and nothing will appear to happen. **Rescan** re-reads every file and re-runs the rules over all of them.
 
 ### Troubleshooting
 
@@ -82,4 +89,8 @@ If your whole library is shifted by a constant amount — and that amount happen
 
 **A rule change had no effect at all.**
 
-Check that you used "Rescan all Photos" rather than a normal scan (see above), and that the rule you expect to win is above the one currently matching — the first rule that can produce a time is the one that is used. A rule that names an EXIF tag your files do not carry is silently skipped, so it is worth confirming the tag actually exists in your photos.
+Check that you used **Rescan** rather than a normal scan (see above), and that the rule you expect to win is above the one currently matching — the first rule that can produce a time is the one that is used. A rule that names an EXIF tag your files do not carry is silently skipped, so it is worth confirming the tag actually exists in your photos.
+
+**One particular photo ignores every rule.**
+
+If you once corrected that photo's date by hand, LibrePhotos remembered it. The first rule in the default list, *Timestamp set by user*, replays that hand-set value on every rescan, so no rule below it can win for that photo. To hand the photo back to the automatic rules, open it, edit its date and clear the value you set, then save — with no manual timestamp left to replay, the rules below take over again. Moving *Timestamp set by user* down the list, or deleting it, also works, but it applies to your whole library, which means hand-set dates will no longer stick for any photo.

--- a/apps/docs/docs/user-guide/settings/index.md
+++ b/apps/docs/docs/user-guide/settings/index.md
@@ -1,7 +1,7 @@
 ---
 title: "🔧 Settings"
-excerpt: "Short explainer where the settings are"
-sidebar_position: 4
+description: "Short explainer where the settings are"
+sidebar_position: 19
 ---
 
 There are three kinds of settings at the moment.
@@ -10,13 +10,11 @@ There are three kinds of settings at the moment.
 
 You can find your profile settings by clicking in the top right corner and click on `Profile`.
 
-Here you can change your name, photo, e-mail address and preferences regarding thumbnail size, dark mode and language. You can also set if you want your profile to be accessible globally or not.
+Here you can change your name, photo, e-mail address, password and language. You can also set whether you want your profile to be accessible globally or not.
 
 - `Avatar`, `First name`, `Last name` will be shown if you share pictures with other users or when your profile is publically accessible
-- `E-mail` is not used at the moment.
+- `E-mail` is the address your password-reset link is sent to. The **Forgot your password?** link only appears on the login page once an administrator has configured outgoing e-mail (Admin Area → Site Settings → Email (SMTP)), and resetting your own password only works if your account has an e-mail address set. If it does not, an administrator can still reset your password for you under Admin Area → Users.
 - `Change password` is for changing your password
-- `Thumbnail size` will change the size of the pictures in the timeline view
-- `Dark mode` will change the theme from light to dark
 - `Language` will change the settings
 - `Public Sharing` will set if you can be found globally
 
@@ -42,9 +40,30 @@ If you set this to `Top 100`,`Top 50`, `Top 10` you will get semantic search res
 
 Here you can set how timestamps are parsed. You can find more information [here](./date-rules)
 
+### Set burst detection rules
+
+Below the date and time rules is a **Burst Detection Rules** editor. It defines the ordered list of rules used when [stack detection](../stacks-and-file-variants.md) looks for burst sequences — photos taken in rapid succession.
+
+Rules fall into two categories, shown as a **Hard** or **Soft** badge:
+
+- **Hard** rules are deterministic and enabled by default: `EXIF Burst Mode Tag`, `EXIF Sequence Number` and `Filename Burst Pattern` (for names such as `IMG_001_BURST001` or `photo (1)`).
+- **Soft** rules are estimates and are present but disabled by default: `Timestamp Proximity` (photos within about two seconds from the same camera) and `Visual Similarity` (visually similar consecutive photos).
+
+For each rule you can toggle it on or off, delete it, or drag it to reorder the list. **Add Rule** opens a searchable catalogue of further rules — including `Filename Burst Suffix Only`, `Custom Filename Pattern` and a looser `Timestamp Proximity (Loose)` (about five seconds, any camera). **Reset to Defaults** restores the default set. Each rule's parameters are fixed and shown for reference only; there is no parameter editor here.
+
 ### Experimental options
 
 Always transcode videos will transcode all videos on demand to h264 to improve compatibility. This is not yet well optimized.
+
+### Large Language Model Settings
+
+These switches enhance generated captions with the large language model an administrator selects in the Admin Area (`Large Language Model`). If that is set to `None`, the switches have no effect. All are off by default.
+
+- `Enable Large Language Model For Captions` turns on LLM post-processing of image captions. Default `Off`
+- `Add Persons to the Captions` includes the name of a recognised person in the prompt so it can appear in the caption. Only available while the switch above is on. Default `Off`
+- `Add Locations to the Captions` includes the photo's location in the prompt. Only available while the switch above is on. Default `Off`
+
+See [Image Captioning](../image-captioning.md) for the captioning model itself.
 
 ### Slideshow Options
 
@@ -54,9 +73,15 @@ Always transcode videos will transcode all videos on demand to h264 to improve c
 
 - `Inferred faces confidence` set the value, which inferred faces need to have to be shown in person albums.
 
-### Scan Options
+### Face Options
 
-- `Stack RAW+JPEG` when enabled, RAW and JPEG file pairs with the same basename will be automatically grouped as file variants of a single photo during scanning.
+Most of these settings control how [face clustering](../face-recognition.md) groups the faces in your library, which is what you work with when labelling people.
+
+- `Minimum Cluster Size` changes how clusters form; a smaller value results in more clusters. Options are `Auto`, `2`, `4`, `8` and `16`. Default `Auto`, which lets LibrePhotos choose for you.
+- `Minimum Samples` changes how conservative clustering is; a smaller value is less conservative. Options are `1`, `2`, `4`, `8` and `16`. Default `1`
+- `Cluster Selection Epsilon` determines which clusters get merged; a higher value merges more clusters. Options are `Off` (0), `Small` (0.025), `Normal` (0.05), `High` (0.1) and `Very High` (0.2). Default `Normal`
+- `Confidence when Matching Unknown - Other Faces` a confidence level between 0 and 1. Faces in the "Unknown - Other" group are matched to a named person only when the confidence is higher than this value; `0` disables the feature. Default `0.50`
+- `Write face tags to image files` when enabled, face labels are written as XMP MWG-RS region tags to your image files (or to a sidecar file, depending on `Synchronize metadata to disk`) whenever you label a face, so face data stays portable across apps like Lightroom, digiKam and XnView. Default `Off`
 
 ### Public Sharing Defaults
 
@@ -68,19 +93,27 @@ Configure default visibility settings for publicly shared albums. These defaults
 - `Show captions` - Whether to display photo captions
 - `Show faces` - Whether to display recognized faces
 
+### Duplicate Detection
+
+These are your personal defaults for the **Detection Options** dropdown on the Duplicates page — they pre-fill that dropdown before you click **Detect Duplicates**, rather than running anything on their own. See [Duplicate Detection](../duplicate-detection.md) for the review workflow.
+
+- The **Visual sensitivity** default controls how aggressively visual duplicates are matched: `Strict` (fewest matches, highest confidence), `Normal` (the balanced default) or `Loose` (most matches, but may include false positives). Default `Normal`
+- The **Clear pending duplicates** default determines whether previously pending duplicate results are cleared before a new detection run starts. Default `Off`
+
 ## Admin Area
 
-These are settings that apply to the whole instance.
+These are settings that apply to the whole instance. Besides the panels below, the Admin Area also hosts the **Services** and **Server Logs** panels, documented in [Library Management](../library.md).
 
 ## Site Settings
 
 - `Allow user registration` will enable a sign up button on the login page.
 - `Allow uploads` sets if uploading should be possible or not
 - `Skip patterns` Comma delimited list of patterns to ignore (e.g. '@eaDir,#recycle' for synology devices)
-- `Map API Provider` Select which geocoding service to use for converting GPS coordinates to place names. Options include Nominatim (free, no key required), Mapbox, MapTiler, OpenCage, and TomTom.
-- `Map API Key` Required only if using a commercial geocoding provider (Mapbox, MapTiler, OpenCage, or TomTom). Not needed for Nominatim.
+- `Map Provider` Select which geocoding service converts GPS coordinates into place names. Options are Nominatim (free, no key required), Mapbox, MapTiler, OpenCage, and TomTom.
+- `API key for Map Provider` Only shown after you select a commercial provider (Mapbox, MapTiler, OpenCage, or TomTom), where it is required. It is not shown for Nominatim, which needs no key.
+- `Map Tiles` Where the map background is loaded from. Options are PhotoPrism (the default), OpenStreetMap, or None to hide maps entirely. Opening a map reveals the approximate location of your photos to the selected provider. This is separate from the map **provider** above, which only affects reverse geocoding.
 - `Captioning Model` Select which AI model to use for image captioning. See [Image Captioning](../image-captioning.md).
-- `LLM Model` Select which LLM to use for enhanced captioning (None, Mistral, Moondream). When set to "None", no LLM models will be downloaded.
+- `Large Language Model` Select which LLM to use for enhanced captioning (None, Mistral, Moondream). When set to "None", no LLM models will be downloaded.
 - `Tagging Model` Select which AI model to use for auto-tagging photos. Options:
   - **Places365** — Scene recognition (default). Classifies photos into scene categories like "kitchen", "beach", "forest".
   - **SigLIP 2** — Google's vision-language model using zero-shot classification against a curated vocabulary of 900+ real-world photo tags. Returns the top 10 most relevant tags.
@@ -91,7 +124,22 @@ These are settings that apply to the whole instance.
   - **buffalo_s** / **buffalo_m** / **buffalo_l** — Progressively larger and more accurate, at the cost of more memory and compute.
   - **antelopev2** — High-accuracy model for the best recognition quality.
 
-  Changing the model downloads the corresponding model files on the next run. After switching, run **Train faces** so all faces are re-encoded with the selected model. See [Face recognition](../face-recognition.md).
+  Saving a new model queues a **Download models** job immediately (if the model pack is not already present). Only faces encoded *after* the switch use the new model — existing faces keep the embeddings they were created with. **Train faces** does not re-encode them; it only generates embeddings for faces that have none yet and then re-clusters. For this reason, choose a model before your first face scan: switching later leaves your library comparing embeddings produced by two different models. See [Face recognition](../face-recognition.md).
+
+### Email (SMTP)
+
+Directly below the Site Settings card is an **Email (SMTP)** card that configures outgoing e-mail. Outgoing e-mail must be set up here, or the **Forgot your password?** flow silently does nothing (the server logs the failure but never reveals whether an address exists).
+
+- `Provider` chooses how mail is sent: `Disabled`, `Custom SMTP server`, `SendGrid`, `Mailgun`, `Postmark`, `Brevo`, `SMTP2GO` or `Amazon SES`. The hosted providers use built-in server presets, so you only supply a `From address`, `Username` and API key. `Custom SMTP server` (and `Amazon SES`, for the host) additionally shows the `SMTP host`; `Custom SMTP server` also shows `Port`, `Use STARTTLS` and `Use implicit SSL`.
+- `From address` is the address mail is sent from.
+- `Username` is the login for the provider. For SendGrid, leave this blank — it uses the literal username `apikey`.
+- `Password / API key` is write-only: it is encrypted before it is stored and never returned by the API. Leaving the field blank keeps the existing credential unchanged; use **Remove the stored credential** to delete it.
+- **Send test email** sends a test message to your own account's e-mail address to check the configuration end to end. It stays disabled until the configuration is valid.
+
+## Admin Tools
+
+- **Delete all auto created albums** removes every automatically generated event album in one step. Your photos are not affected.
+- **Download Server Stats** saves a `serverstats.json` report — see [Server Stats](../library.md#server-stats) for what it contains.
 
 ## Users
 

--- a/apps/docs/docs/user-guide/sharing.md
+++ b/apps/docs/docs/user-guide/sharing.md
@@ -1,7 +1,7 @@
 ---
 title: "🔗 Sharing"
-excerpt: "Share photos and albums with other users or publicly via links"
-sidebar_position: 9
+description: "Share photos and albums with other users or publicly via links"
+sidebar_position: 5
 ---
 
 LibrePhotos offers multiple ways to share your photos and albums — with other users on your instance, or publicly with anyone via a link.
@@ -10,31 +10,32 @@ LibrePhotos offers multiple ways to share your photos and albums — with other 
 
 The **Sharing** page (accessible from the navigation) is your central hub for all sharing activity. It provides an overview of:
 
-- **Public Users** — Other users on your instance who have made their profile public
-- **Shared With You** — Photos and albums that others have shared with you
-- **You Shared** — Photos and albums you have shared with others
-- **Public Links** — Albums you've shared publicly via link
+- **Public photos** — Other users on your instance who have made their profile public
+- **Shared with you** — Photos and albums that others have shared with you
+- **You shared** — Photos and albums you have shared with others
+- **Public Links** — Albums and photos you've shared publicly via link
 
 ## Sharing Albums with Users
 
 You can share any user album with other users on your LibrePhotos instance:
 
 1. Navigate to the album you want to share
-2. Select any photo to activate the selection toolbar
-3. Click the **three-dot menu** (⋮) → **"Sharing"**
-4. Search for users and toggle sharing on or off for each
+2. In the toolbar above the photo grid, open the **three-dot menu** (⋮) and, under **Album Actions**, choose **"Sharing"** — no photo selection is needed
+3. Search for users and toggle sharing on or off for each
 
-Shared albums appear in the recipient's **Sharing → Shared With Me → Albums** section.
+You can also open the same dialog from the share action on the album's card under **Albums**. The toolbar only appears on albums that already contain at least one photo.
+
+Shared albums show up in the recipient's sharing area: they open **Sharing**, click the **Shared with you** tile, then the **Albums** tab (the page is titled *Albums others shared*).
 
 ## Sharing Photos with Users
 
 You can share individual photos (or a selection of photos) with other users:
 
 1. Select one or more photos from any view
-2. Click the **three-dot menu** (⋮) → **"Share"**
+2. Click the **three-dot menu** (⋮) and, under **Photo Actions**, choose **"Sharing"**
 3. Search for users and toggle sharing on or off for each
 
-Shared photos appear in the recipient's **Sharing → Shared With Me → Photos** section, grouped by the person who shared them.
+Shared photos show up in the recipient's sharing area, grouped by the person who shared them: they open **Sharing**, click the **Shared with you** tile, then the **Photos** tab (the page is titled *Photos others shared*).
 
 ## Public Album Sharing via Link
 
@@ -51,33 +52,33 @@ The public album is accessible at `https://your-instance/public/s/{slug}`.
 
 ### Configuring Public Link Settings
 
-When public sharing is enabled, you can configure:
+When public sharing is enabled, click **Show settings** in the sharing dialog to expand the configuration panel. From there you can configure:
 
 #### Custom Slug
-Change the URL slug to something memorable (3–64 characters). For example: `summer-vacation-2025` → `/public/s/summer-vacation-2025`.
+Change the URL slug to something memorable — 3–64 characters using only lowercase letters, digits and hyphens. Capitals you type are converted to lowercase automatically; spaces, underscores and other punctuation are rejected. Slugs must be unique across the instance, and the field checks availability as you type. For example: `summer-vacation-2025` → `/public/s/summer-vacation-2025`.
 
 #### Expiration
-Set when the link should expire:
-- **7 days**
-- **30 days**
-- **90 days**
-- **Never** (no expiration)
+Expiration is optional. Pick any expiry date and time with the date picker (down to the second), or use the built-in **7 days**, **30 days** or **90 days** presets in the picker's dropdown for a quick choice. Click **Never** (or clear the field) to remove the expiry so the link never expires. After expiration, the link no longer works.
 
-After expiration, the link will no longer work.
+#### Photo Details
 
-#### Privacy Controls
-
-Fine-tune what information visitors can see on the public album page:
+The **Photo Details** panel fine-tunes what information visitors can see when they open a photo in a public album:
 
 | Setting | What it controls |
 |---------|-----------------|
-| **Show timestamps** | Whether photo dates and times are visible |
-| **Show location** | Whether GPS coordinates and place names are shown |
-| **Show camera info** | Whether camera model, lens, focal length, aperture, ISO, and shutter speed are shown |
-| **Show captions** | Whether AI-generated or manual captions are visible |
-| **Show faces** | Whether recognized people's names are displayed |
+| **Share photo timestamps** | Whether photo dates and times are visible |
+| **Share location information** | Whether GPS coordinates and place names are shown |
+| **Share camera information** | Whether camera model, lens, focal length, aperture, ISO, and shutter speed are shown |
+| **Share captions** | Whether AI-generated or manual captions are visible |
+| **Share detected faces** | Whether recognized people's names are displayed |
 
-Each of these settings can be toggled independently per album. When set to `null` (default), the **user-level defaults** from your settings are used. You can configure your defaults in **Settings → Public Sharing Defaults**.
+Each of these settings can be toggled independently per album. When left unset, the **user-level defaults** from your settings are used; you can configure those in **Settings → Public Sharing Defaults**.
+
+**All five are off by default** — both as the built-in fallback and as the initial value of your user-level defaults, following a privacy-first, opt-in approach. So on a brand-new public link, visitors don't see any of these per-photo details until you turn the relevant options on.
+
+:::caution
+Changes to the slug, expiration and Photo Details settings are **not applied until you click "Save link settings"** at the bottom of the settings panel. That button stays disabled until you change something; the **Public sharing** toggle itself only saves the on/off state.
+:::
 
 ### The Public Album Experience
 
@@ -85,29 +86,48 @@ Visitors to a public album link see:
 
 - A photo grid with the album's photos
 - A lightbox viewer for browsing individual photos
-- Photo details (subject to your privacy control settings)
+- Photo details (subject to the album's Photo Details settings)
 - No login required
+
+## Making Individual Photos Public
+
+Besides sharing whole albums, you can make individual photos public without putting them in an album:
+
+1. Select one or more photos from any view
+2. Click the **three-dot menu** (⋮) and, under **Photo Actions**, choose **"Make Public"**
+
+When you select photos individually, direct image links (`https://your-instance/media/photos/<hash>.jpg`) are copied to your clipboard so you can paste them straight away. In *select all* mode the photos are still made public, but no links are copied.
+
+These are raw image-file URLs, so they behave differently from public album links. There is no album page, no custom slug, no expiration and no Photo Details toggles — anyone with the link can open the image file directly. If you need those controls, share a public album instead.
+
+Public photos appear under the **Photos** tab of your **Public Links** page, on your public profile at `https://your-instance/public/<username>`, and in your own [My Public Photos](./viewing-photos.md#my-public-photos) view.
+
+To reverse this, select the photos again and choose **"Make Private"** from the same menu.
+
+:::caution
+Making a photo private stops it from being served through the public views, but it cannot retroactively invalidate a direct link that someone has already opened or saved a copy of the image from.
+:::
 
 ## Managing Your Shared Content
 
 ### Shared By Me
 
-Navigate to **Sharing → By Me** to see:
+Open **Sharing** and click the **You shared** tile (the pages are titled *Photos you shared* and *Albums you shared*) to see:
 
 - **Photos tab** — All photos you've shared, grouped by recipient
 - **Albums tab** — All albums you've shared, grouped by recipient
 
 ### Shared With Me
 
-Navigate to **Sharing → With Me** to see:
+Open **Sharing** and click the **Shared with you** tile (the pages are titled *Photos others shared* and *Albums others shared*) to see:
 
 - **Photos tab** — Photos others have shared with you, grouped by sender
 - **Albums tab** — Albums others have shared with you, grouped by sender
 
 ### Public Links
 
-Navigate to **Sharing → Links** to see all albums you've made publicly accessible, with quick access to copy or manage each link.
+Open **Sharing** and click the **Public Links** tile to see everything you've made publicly accessible. It has two tabs: **Albums** (albums with a public link) and **Photos** (individual photos you've marked public).
 
 ## Public User Profiles
 
-Users can make their profile publicly accessible by enabling **Public Sharing** in their profile settings. When enabled, other users on the instance can browse their public photos via the **Sharing → Public** page.
+Users can make their profile publicly accessible by enabling **Public Sharing** in their profile settings. Other users on the instance can then find them in the **Public photos** section of the **Sharing** page, which lists every user with public sharing enabled along with their public photo count. A user's public photos are browsable at `https://your-instance/public/<username>`.

--- a/apps/docs/docs/user-guide/stacks-and-file-variants.md
+++ b/apps/docs/docs/user-guide/stacks-and-file-variants.md
@@ -1,7 +1,7 @@
 ---
 title: "📚 Stacks & File Variants"
-excerpt: "How LibrePhotos handles RAW+JPEG pairs, Live Photos, bursts, and other related photo groups"
-sidebar_position: 7
+description: "How LibrePhotos handles RAW+JPEG pairs, Live Photos, bursts, and other related photo groups"
+sidebar_position: 13
 ---
 
 LibrePhotos can automatically detect and group related photos together. There are two distinct concepts: **file variants** (same capture in different formats) and **stacks** (different captures grouped together).
@@ -22,47 +22,56 @@ Live Photos (common on iPhones) consist of a still image and a short video clip.
 
 LibrePhotos uses a two-phase scan to group file variants:
 
-1. **Phase 1 — Grouping**: Before processing, all files are grouped by their directory and base filename. For example, `IMG_001.jpg`, `IMG_001.CR2`, and `IMG_001.xmp` in the same folder become one group.
+1. **Phase 1 — Grouping**: Before processing, all image and video files are grouped by their directory and base filename. For example, `IMG_001.jpg` and `IMG_001.CR2` in the same folder become one group. XMP sidecars are set aside at this stage.
 
-2. **Phase 2 — Processing**: Each group is processed together, creating one Photo entity with all files attached as variants. The main display file is chosen automatically by priority: JPEG → Video → RAW → Metadata.
+2. **Phase 2 — Processing**: Each group is processed together, creating one Photo entity with all files attached as variants. The main display file is chosen automatically by priority: JPEG → Video → RAW. Once all image groups have finished, any XMP sidecars are processed and attached to the photo they belong to.
 
-After each scan, a **Repair File Variants** job runs automatically to fix any files that were previously scanned separately before the variant system was introduced.
+After each scan, a **Repair File Variants** job runs automatically. It looks for RAW files that ended up as their own photo and merges them into the matching image photo (same folder, same base name — JPEG, HEIC, PNG or TIFF), and corrects the main display file when a RAW file is still marked as the main one. Live Photo videos that were already scanned as separate photos are not merged by this job.
 
 ### Viewing File Variants
 
 When viewing a photo that has file variants:
 
 - A **RAW badge** appears on the thumbnail in the photo grid
-- The **File Variants** section in the lightbox sidebar lists all variants with type badges (RAW, Live Photo, etc.)
-- The primary variant is marked with a **Main** badge
-- You can download individual variants or include all variants when downloading as a zip
+- In the lightbox sidebar, next to the filename (beside the dimensions and file size), a photo with extra formats shows a **+N format(s)** link. Expanding it lists the non-primary variants, each with a format badge (**JPG**, **RAW**, **VIDEO**, **META**, or **FILE**).
+- When you download photos as a zip, all file variants of each photo are included automatically.
 
 ### Settings
 
 In **Settings**, you can configure:
 
-- **Stack RAW+JPEG** — Toggle whether RAW+JPEG pairs should be automatically grouped during scanning
+- **Stack RAW+JPEG** — a legacy switch, left over from when RAW+JPEG pairs were modelled as stacks. RAW+JPEG pairs are now always grouped as file variants during scanning, so turning this off currently has no effect.
 
 ## Stacks
 
 Stacks group different but related captures together. Unlike file variants (same shot, different format), stacks contain separate photos that belong together logically.
 
+:::note
+Once photos are stacked, only the stack's cover photo appears in your timeline — the other photos stay in your library but are collapsed behind the stack. Open the stack to reach them, use **Set Cover** to change which one is shown, or **Unstack** to bring them all back.
+:::
+
 ### Stack Types
 
 | Type | Description | Detection |
 |------|-------------|-----------|
-| **Burst** | A rapid sequence of photos taken in burst mode | Automatic (via EXIF data, filename patterns, and timestamp proximity) |
-| **Bracket** | Exposure brackets for HDR | Manual |
+| **Burst** | A rapid sequence of photos taken in burst mode | Automatic (rule-based: EXIF burst/sequence tags and filename patterns by default) |
+| **Bracket** | Exposure brackets for HDR | Reserved — not currently created; there is no bracket detection, and **Create Stack** always makes a Manual stack |
 | **Manual** | Any photos you want to group together | Manual |
 
 ### Automatic Stack Detection
 
-LibrePhotos can automatically detect burst sequences by analyzing:
+Burst detection runs a list of rules stored per user. Enabled by default (hard criteria):
 
-- **EXIF data** — Burst mode flags and sequence metadata
-- **Filename patterns** — Common burst naming conventions
-- **Timestamp proximity** — Photos taken within milliseconds of each other
-- **Visual similarity** — Comparing photo content
+- **EXIF Burst Mode Tag** — camera burst / continuous-drive flags
+- **EXIF Sequence Number** — sequence metadata written by the camera
+- **Filename Burst Pattern** — naming conventions such as `IMG_001_BURST001` or `photo (1)`
+
+Available but **disabled by default** (soft criteria — these estimate, and can group unrelated photos):
+
+- **Timestamp Proximity** — photos taken within a configurable interval of each other (2 seconds by default) on the same camera
+- **Visual Similarity** — perceptual-hash comparison of consecutive photos
+
+Open **Settings** and use the **Burst Detection Rules** panel to enable, disable, reorder, add or remove these rules (including extra presets such as a looser 5-second timestamp rule or a custom filename pattern). Changes apply the next time you run **Detect Stacks**.
 
 You can trigger stack detection from the **Organizing → Stacks** page by clicking **"Detect Stacks"** and choosing which types to detect.
 
@@ -73,7 +82,7 @@ The **Organizing** page (accessible from the navigation) is your central hub for
 #### Stacks Tab
 
 - Browse all detected stacks
-- Filter by stack type (All, Burst, Bracket, Manual)
+- Filter by stack type — the dropdown offers **All Types** plus each type you actually have stacks of
 - Click a stack to open the **Stack Modal** showing all photos in the group with details (resolution, file size, camera, date)
 - **Set Cover** — Choose which photo represents the stack in the timeline
 - **Unstack** — Remove the grouping
@@ -84,15 +93,14 @@ The **Organizing** page (accessible from the navigation) is your central hub for
 1. Select multiple photos from any view
 2. Open the selection actions menu (three-dot menu)
 3. Click **"Create Stack"**
-4. The selected photos are grouped into a manual stack
+4. The selected photos are grouped into a manual stack, and only the cover photo remains visible in your timeline
 
 #### Managing Stacks
 
 From the selection actions menu, you can also:
 
 - **Merge Stacks** — Combine multiple stacks into one
-- **Remove from Stack** — Take selected photos out of a stack
-- **Set as Cover** — Choose the primary photo for a stack
+- **Break Apart Stacks** — Remove the selected photos from every manual stack they belong to (a stack is deleted automatically if fewer than 2 photos remain)
 
 ### Stacks in the Lightbox
 

--- a/apps/docs/docs/user-guide/statistics.md
+++ b/apps/docs/docs/user-guide/statistics.md
@@ -1,19 +1,21 @@
 ---
 title: "📊 Statistics & Data Visualization"
-excerpt: "Explore your photo library through interactive visualizations"
-sidebar_position: 10
+description: "Explore your photo library through interactive visualizations"
+sidebar_position: 9
 ---
 
-LibrePhotos includes a **Statistics** section with several interactive visualizations that help you explore patterns in your photo library. You can access it from the main navigation.
+LibrePhotos includes a **Statistics** section with several interactive visualizations that help you explore patterns in your photo library. It is not in the main sidebar — open it from the **Statistics / Explore charts** card at the top of the **Library** page (reach the Library page from the avatar menu in the top-right corner → **Library**), or press `Ctrl+K` (`Cmd+K` on macOS) and search for "Statistics". You can also go straight to `/statistics`. The section opens on the **Place Tree** view, and a tab bar at the top lets you switch between the five views.
 
 ## Place Tree
 
 The Place Tree shows all your photo locations organized in a hierarchical tree — from countries down to regions and cities. This gives you a bird's-eye view of everywhere you've taken photos.
 
-- **Multiple layouts** — Switch between vertical, horizontal, and radial tree layouts
+- **Multiple layouts** — Switch between the tree layout (shown horizontally or vertically) and a radial layout
+- **Link style** — Switch the connectors between curved, step and straight lines
 - **Expand / collapse** — Click on any node to expand or collapse its children
-- **Zoom** — Scroll to zoom in and out of the tree
-- **Click to search** — Click on a location node to search for photos taken there
+- **Pan** — Drag anywhere on the canvas to move around the tree
+- **Zoom** — Scroll to zoom, or use the zoom in / out / reset buttons; the keyboard shortcuts `+`, `-` and `0` (reset) also work
+- **Hover** — Hover over a node to see its full name and photo count
 
 ## Timeline
 
@@ -25,7 +27,7 @@ A bar chart showing how many photos you took each month. This makes it easy to s
 
 ### Location Duration
 
-A stacked bar chart showing how much time you spent at different locations over time. Each color represents a different location, and the bar height shows the duration. This is great for seeing travel patterns at a glance.
+A single horizontal stacked bar spanning your whole library, laid out chronologically. Each colored segment is one continuous stay at a location, and the segment's **width** shows how long that stay lasted. Hover over a segment to see the location name and the month-and-year range it covers; the color legend underneath lists every segment. Note that each stay gets its own color, so a place you visited more than once appears more than once. This is great for seeing travel patterns at a glance.
 
 ## Word Clouds
 
@@ -33,26 +35,34 @@ Three interactive word clouds generated from your photo library:
 
 | Cloud | Based on |
 |-------|----------|
-| **Locations** | Place names from reverse geocoding |
-| **Captions & Things** | AI-generated captions and detected objects |
-| **People** | Recognized people in your photos |
+| **Places** | Place names from reverse geocoding (postcodes and points of interest are skipped) |
+| **Things** | Scene tags from the Places365 classifier — its scene categories, scene attributes and the indoor/outdoor label. The categories and attributes are also what populate your Things albums. |
+| **People** | Names of recognized people in your photos |
 
-Larger words appear more frequently in your library. **Click on any word** to search for photos matching that term.
+Each cloud shows at most the top 100 terms, and larger words appear more frequently in your library. **Click on any word** to search for photos matching that term.
+
+:::note
+The **Things** cloud is only populated when your photos are tagged with the Places365 model. With the SigLIP 2 tagging model its tags are stored differently, so this cloud stays empty.
+:::
 
 ## Social Graph
 
 A force-directed graph showing the relationships between people in your photos. Each node represents a person, and edges connect people who appear together in the same photos.
 
-- **Node size** reflects how many photos a person appears in
-- **Edge thickness** reflects how often two people appear together
+- **Nodes** are all drawn the same size and labeled with the person's name; a node's outline turns orange when you hover over it
+- **Edges** connect people who appear together in at least one photo — the graph is unweighted, so every node and edge is drawn the same size
 - **Drag** nodes to rearrange the layout
 - **Zoom** to explore dense areas of the graph
 
-This is a fun way to see social connections and who you photograph together most often.
+This is a fun way to see who shows up in photos together.
 
 ## Face Clusters
 
-A visualization of your face recognition clusters. Shows face thumbnails grouped by person, giving you an overview of how the face clustering algorithm has grouped the detected faces.
+A scatter plot of every detected face in your library. Each dot is one face, positioned by a projection of its face embedding, so faces that look alike land close together — this gives you an overview of how well face recognition has separated people.
 
-- Click on any face thumbnail to open that photo in the lightbox
+- **Color** identifies the person; unlabeled faces are drawn as small gray dots
+- **Hover** over a dot to preview the face thumbnail and the person's name
+- **Click** a dot to open that photo in the lightbox
+- **Filter by person** — Click a name badge above the plot to highlight that person's faces and dim everyone else's. The badges list the people with the most detected faces, plus **All** to clear the filter and **Unknown** for faces not yet assigned to anyone (shown only when you have unlabeled faces). Click the active badge again to deselect.
+- **Summary** — The cards below the plot show how many people were identified and the total number of faces in the plot.
 - Useful for spotting clustering errors or finding unlabeled faces

--- a/apps/docs/docs/user-guide/trash.md
+++ b/apps/docs/docs/user-guide/trash.md
@@ -1,16 +1,17 @@
 ---
 title: "🗑️ Trash"
-excerpt: "A overview on how Trash works"
-sidebar_position: 5
+description: "A overview on how Trash works"
+sidebar_position: 16
 ---
 
 ### Deleting images
 
 1. Mark file as "deleted". Select the image you want to delete, go to the action button and click on "Move to Trash"
 2. Navigate to Trash.
-3. Select images you want to delete forever.
+3. Select the images you want to delete forever.
+4. Click the red trash icon in the selection bar (tooltip *Delete permanently*, or *Delete N photos permanently* when more than one is selected), then confirm in the **Delete Images** dialog by clicking the red **Delete** button. This cannot be undone.
 
-You can also remove the status "deleted", by click on the undo button.
+You can also restore a photo instead of deleting it: select it in Trash and click the blue undo-arrow icon (tooltip *Restore photo*) to remove the "deleted" status.
 
 Deleting the images from the file system only works, if LibrePhotos has the access to the images. If it is read only, files will not be deleted.
 
@@ -21,4 +22,6 @@ Missing images can happen, when you moved files outside of the LibrePhotos photo
 There are two ways to deal with that:
 
 1. Move the files back to the LibrePhotos folder and do a rescan
-2. Delete the metadata of the missing images
+2. Delete the metadata of the missing images. On the **Library** page, whenever missing files have been detected, a red **Missing Photos** badge (showing how many) appears next to the *Photos* heading. Click it and confirm in the **Remove missing photos** dialog. This permanently deletes those photos from the database, along with their metadata, faces, ratings, captions and album assignments, and cannot be undone.
+
+See [Missing Photos](./missing-photos.md) for more on how missing files are detected and resolved.

--- a/apps/docs/docs/user-guide/upload.md
+++ b/apps/docs/docs/user-guide/upload.md
@@ -1,7 +1,7 @@
 ---
 title: " ⬆ Upload"
-excerpt: "How to upload photos to LibrePhotos"
-sidebar_position: 5
+description: "How to upload photos to LibrePhotos"
+sidebar_position: 12
 ---
 
 ![](../../static/img/upload-image.png)
@@ -19,7 +19,7 @@ The upload process works in the following way:
 - If it is, don't upload it
 - If it isn't, upload it
 - We upload files in 1MB chunks
-- If all files are uploaded, we scan the your `scan folder + /uploads/web`
+- When each file finishes uploading, the backend registers that one photo and queues a background job chain for it (metadata and thumbnails, caption, geolocation, album dates, face extraction). No directory scan is triggered.
 
 ### Where are the files saved?
 
@@ -30,18 +30,18 @@ The upload behavior depends on whether the user has a scan directory configured:
 - This is the normal and expected behavior
 - Files are stored in the mounted host directory and are persistent
 
-#### When scan directory is NOT configured (⚠️ Problem):
-- Files are saved to: `uploads/web/{filename}` (relative path)
-- This resolves to `/code/uploads/web/{filename}` inside the container
-- **Files are stored inside the container's filesystem**
-- **Files will be lost when the container is restarted or recreated**
-- This is the issue described in [librephotos-docker#144](https://github.com/LibrePhotos/librephotos-docker/issues/144)
+#### When scan directory is NOT configured:
+Uploads are blocked and nothing is written to disk.
+
+- If your account has no scan directory set, the upload button is disabled and shows the tooltip *"Scan directory not configured - contact administrator"*.
+- If a scan directory is set but the path does not exist on the server, the button stays active, but the upload is rejected once the final chunk is submitted.
+- In both cases the API responds with HTTP 400 — `"Upload failed: No scan directory configured…"` or `"Upload failed: Scan directory '<path>' does not exist…"` — and no file is saved.
 
 ### Prerequisites for upload
 
 To use the upload feature properly, you **must** have:
 
-1. **Upload feature enabled**: Set `ALLOW_UPLOAD=true` in your environment variables or enable it in the admin panel
+1. **Upload feature enabled**: Turn on `Allow uploads` in the admin area. Docker Compose users can pre-enable it by adding `allowUpload=true` to their `.env` before the first start — Compose passes it to the backend as `ALLOW_UPLOAD` (note the variable in `.env` is `allowUpload`, not `ALLOW_UPLOAD`)
 2. **Scan directory configured**: Every user must have a scan directory set up by an admin
 
 ### How to configure scan directory
@@ -55,7 +55,7 @@ To use the upload feature properly, you **must** have:
 
 ![](../../static/img/allow-uploading.png)
 
-You can activate / deactivate by navigating as an admin to the admin area and clicking on the `Allow uploads` switch. You can also set this by setting the environment variable `ALLOW_UPLOADS` to `true` or `false`.
+You can activate / deactivate by navigating as an admin to the admin area and clicking on the `Allow uploads` switch. This switch is the authoritative setting. The `ALLOW_UPLOAD` environment variable (set through `allowUpload` in your `.env` for the Docker Compose deployment) only supplies the initial default: once a value has been saved to the database — by toggling the switch, or by the first-time setup wizard — the stored setting wins and the environment variable is ignored.
 
 ### Scanning uploaded photos
 
@@ -66,9 +66,17 @@ After upload, you can scan the uploaded photos in two ways:
 
 ### Troubleshooting
 
-#### Files disappear after container restart
-**Cause**: This happens when the user doesn't have a scan directory configured.
-**Solution**: Set up a scan directory for the user via the admin panel.
+#### Upload button is greyed out
+**Cause**: Your account has no scan directory configured. Hovering the button shows *"Scan directory not configured - contact administrator"*.
+**Solution**: Ask an admin to set your scan directory (see [How to configure scan directory](#how-to-configure-scan-directory)).
+
+#### Upload fails with "Scan directory does not exist"
+**Cause**: The configured scan directory path is not present inside the backend container.
+**Solution**: Check that the path matches the `${scanDirectory}:/data` bind mount in your compose file, and that the directory exists on the host.
+
+#### Uploaded files disappear after container restart
+**Cause**: The data root is not backed by a host directory. A scan directory has to live inside the backend's data root (`/data` by default) — anything outside it is rejected with *"Scan directory must be inside the data root."* — so the upload itself succeeds, but if `/data` is not bind-mounted, everything written there lives only in the container's filesystem and is lost when the container is recreated.
+**Solution**: Make sure your compose file mounts a host directory at `/data` (the `${scanDirectory}:/data` line on the `backend` service) and that `scanDirectory` in your `.env` points at a real, persistent path on the host.
 
 #### Upload fails with permission errors
 **Cause**: The container doesn't have write permissions to the scan directory.
@@ -76,17 +84,4 @@ After upload, you can scan the uploaded photos in two ways:
 
 #### Upload button not visible
 **Cause**: Upload feature is disabled.
-**Solution**: Enable uploads via environment variable `ALLOW_UPLOAD=true` or in the admin panel.
-
-### Docker configuration for uploads
-
-If you're using Docker and want to ensure uploads are properly mounted (workaround for missing scan directory):
-
-```yaml
-backend:
-  volumes:
-    - ${scanDirectory}:/data
-    - ${data}/uploads:/code/uploads  # Workaround for users without scan directory
-```
-
-However, the proper solution is to ensure all users have scan directories configured rather than relying on this workaround.
+**Solution**: Toggle `Allow uploads` on in the admin area. Note that the `allowUpload` environment variable only supplies the *default* value: once the setting has been saved from the admin area or the first-run setup wizard, the value lives in the database and changing the env var has no effect.

--- a/apps/docs/docs/user-guide/viewing-photos.md
+++ b/apps/docs/docs/user-guide/viewing-photos.md
@@ -1,6 +1,6 @@
 ---
 title: "🖼️ Viewing Photos"
-excerpt: "Photo views, the lightbox, and the photo details sidebar"
+description: "Photo views, the lightbox, and the photo details sidebar"
 sidebar_position: 2
 ---
 
@@ -14,7 +14,7 @@ The default view showing all your photos grouped by date, from newest to oldest.
 
 ### Favorites
 
-Photos you've marked as favorites. To favorite a photo, click the heart icon in the lightbox toolbar or use the selection actions menu.
+Photos you've marked as favorites. To favorite a photo, click the star icon in the lightbox toolbar (or press `f`), or use the selection actions menu. The star turns yellow once the photo's rating reaches the **Minimum image rating to interpret as favorite** value in your user settings.
 
 ### Hidden
 
@@ -22,7 +22,7 @@ Photos you've hidden from the main timeline. Hiding a photo removes it from the 
 
 ### Recently Added
 
-Photos ordered by when they were added to LibrePhotos (import date rather than capture date), grouped by "Added on [date]".
+Shows only your most recent batch of imports — the photos whose *added* date falls on the same calendar day as the most recently added photo in your library. They appear in a single flat grid under one **"Added on …"** line in the page header; there is no per-day grouping. Older imports are not listed here — use the Timeline to browse your whole library.
 
 ### Photos Only
 
@@ -42,7 +42,7 @@ Photos you've marked as publicly visible, accessible at your public profile URL.
 
 ### Folders
 
-Browse your photos by filesystem directory structure. The root view shows your scan directory's subfolders with aggregated photo counts. Click into any folder to see its photos and subfolders. This mirrors the actual file organization on disk.
+Browse your photos by filesystem directory structure. The root view shows the subfolders of your scan directory, each with a count of the photos inside it (including photos in nested subfolders). Click into any folder to see its photos and subfolders. Only folders that contain indexed photos are listed — folders that are empty, hidden (names starting with `.`), or not yet scanned will not appear.
 
 ---
 
@@ -58,17 +58,22 @@ When you click on any photo in LibrePhotos, it opens in the photo viewer (also k
 
 ### Toolbar
 
-The toolbar at the top provides quick actions:
+The toolbar at the top provides quick actions. From left to right:
 
-- **Toggle sidebar** - Show or hide the photo details panel
-- **Favorite** - Mark the photo as a favorite
-- **Download** - Download the original photo (with options for stacked/variant photos)
-- **Share** - Share the photo with other users
-- **Delete** - Move the photo to trash
-- **Rotate counter-clockwise** - Rotate the photo 90° counter-clockwise (see [Rotating Photos](#rotating-photos))
-- **Rotate clockwise** - Rotate the photo 90° clockwise (see [Rotating Photos](#rotating-photos))
-- **Fullscreen** - Enter fullscreen mode for distraction-free viewing
-- **Slideshow** - Start an automatic slideshow with configurable interval
+- **Slideshow** - Start or stop an automatic slideshow. While it runs, a dropdown lets you choose the interval (3, 5, 10, 15 or 30 seconds).
+- **Zoom in / Zoom out** - Magnify the image. Available for still photos only, not videos.
+- **Fullscreen** - Enter or leave fullscreen mode for distraction-free viewing.
+- **Hide / Show** (eye icon) - Hide the photo from the main timeline, or unhide it.
+- **Favorite** (star icon) - Mark the photo as a favorite, or remove the mark.
+- **Make public / Make private** (globe icon) - Toggle the photo's public visibility. Toggling in either direction also copies a link to the photo to your clipboard.
+- **Delete** - Move the photo to trash.
+- **Rotate counter-clockwise** / **Rotate clockwise** - Rotate the photo 90° in either direction (see [Rotating Photos](#rotating-photos)).
+- **Toggle info panel** - Show or hide the photo details sidebar.
+- **Close** - Return to the gallery.
+
+The Hide, Favorite, Make public, Delete and Rotate controls are only shown when you are signed in. On a public or shared album page the toolbar shows just the slideshow, zoom, fullscreen, info-panel and close buttons.
+
+There is no download or share button in the lightbox itself. To download photos, select them in the gallery grid and choose **Download** from the selection actions menu; the download dialog can also include the other photos from each selected photo's stack. To share photos with other users, select them in the grid and choose **Sharing** from the same menu.
 
 ### Rotating Photos
 
@@ -81,7 +86,7 @@ Rotation in LibrePhotos is **non-destructive**:
 - The change applies to the photo for every viewer, not just your own session.
 - Rotation is only available for still images. Videos cannot be rotated from the lightbox.
 
-If you have **"Save metadata to disk"** enabled in your user settings, LibrePhotos will additionally write the combined EXIF Orientation tag back to the original file (or its XMP sidecar), so the new orientation is also visible in external tools. With that setting disabled — the default — only the LibrePhotos database and thumbnails are updated and the file on disk stays byte-for-byte identical.
+Your **Synchronize metadata to disk** setting (Settings → Metadata) controls whether the rotation also reaches the filesystem. This is a three-way choice, not an on/off toggle. With **Save to media file**, LibrePhotos writes the combined EXIF Orientation tag into the original file; with **Save to sidecar**, it writes it to the photo's XMP sidecar instead — either way the new orientation becomes visible in external tools. With **Off** — the default — only the LibrePhotos database and thumbnails are updated, and the file on disk stays byte-for-byte identical.
 
 ## Photo Details Sidebar
 
@@ -91,15 +96,19 @@ The sidebar displays detailed information about the current photo and provides q
 
 Shows when the photo was taken. You can click the edit button to modify the date and time if needed.
 
+### File & Camera Info
+
+Near the top of the sidebar, LibrePhotos shows a summary of the current file: the filename (a link that opens the original file in a new tab), the image dimensions and file size, and — when the photo has more than one file — the **+N formats** toggle described under [File Variants](#file-variants) below. When the photo carries camera EXIF, a second line lists the camera and lens with the aperture, shutter speed, focal length and ISO; this line is hidden if the photo has no camera information. A **Show more** button reveals additional details such as the file path, subject distance, digital zoom ratio, 35 mm-equivalent focal length and any duplicate file copies. For the full list of EXIF fields, see [EXIF Data](./exif-data.md).
+
 ### File Variants
 
-If a photo has multiple file variants (e.g., RAW+JPEG pairs, Live Photos with embedded video, or edited copies), they will be displayed here. You can click on any variant to view it, and when downloading, you can choose to include all variants in a zip file. A RAW badge overlay is shown on photos that have RAW file variants.
+If a photo has multiple file variants (e.g., RAW+JPEG pairs, Live Photos with embedded video, or edited copies), the file info row shows a **+N formats** toggle that lists them with type badges (JPG, RAW, VIDEO, META). Downloading a photo always includes every one of its file variants in the zip — there is no separate option for that. The download dialog's only checkbox, **"Include all photos from stacks"**, controls whether the other photos from the same *stack* (bursts, brackets, manual stacks) are added as well. A RAW badge overlay is shown on photos that have RAW file variants.
 
 For more details on how file variants and stacks work, see [Stacks & File Variants](./stacks-and-file-variants.md).
 
 ### Location
 
-Displays the location where the photo was taken (if GPS data is available). A small map preview shows the exact location, and clicking it will open a larger map view. You can also edit the location if it's missing or incorrect.
+Displays the location where the photo was taken (if GPS data is available). An interactive map shows where the shot was made — you can pan and zoom it with the on-map navigation controls, and clicking the marker opens a small popup with the photo's thumbnail. To set or correct a location, click the pencil icon next to the place name to open the **Pick location** dialog. (The pencil is hidden on publicly shared photos.)
 
 ### People
 
@@ -113,12 +122,26 @@ Shows faces detected in the photo. You can:
 
 The AI-generated or manually entered caption for the photo. You can:
 
-- View auto-generated tags from the active tagging model, displayed as color-coded badges (green for SigLIP 2, blue for Places365)
+- View auto-generated tags from the active tagging model, displayed as color-coded badges. SigLIP 2 shows a **Tags** list with green badges; Places365 shows a **Scene** block split into **Attributes** (blue badges) and **Categories** (teal badges)
 - Edit the caption manually — type `#` to get autocomplete suggestions for thing album tags
 - Generate a new AI caption using the suggestion button
 - Use the **AI suggestion button** to quickly fill in a machine-generated caption
 
-Tags from each model are stored independently. The lightbox shows tags from all models that have been run on the photo, so you can see results side by side.
+Tags from each model are stored independently, but the lightbox only shows tags from the model currently selected in your site settings. Switching the tagging model changes which tags appear; previously generated tags stay in the database.
+
+### Tags
+
+Your own tags for the photo, shown as teal badges. This section always appears in the sidebar when you are signed in, showing **No tags** when none are set. Click the pencil button to open an editor where you can add or remove tags — separate entries with a comma, and existing tags are offered as autocomplete suggestions — then use the check to save or the X to cancel. Click a tag badge to open that tag's album.
+
+These are not the same as the automatic **Tags** list SigLIP 2 adds under the caption: those come from the tagging model and are not editable here.
+
+Tags are not shown on public or shared album pages.
+
+### Keywords
+
+Keywords stored in the photo's own metadata (XMP `Subject` and IPTC `Keywords`). This section always appears in the sidebar when you are signed in, showing **No keywords** when none are set. Click the pencil button to open an editor where you can add or remove keywords — separate entries with a comma or a space — then use the check to save or the X to cancel. Saved keywords are written back through the photo metadata. Click any keyword badge to search your library for that term.
+
+Keywords are not shown on public or shared album pages.
 
 ### Albums
 
@@ -146,8 +169,15 @@ Click on any similar photo to view it directly.
 |-----|--------|
 | `←` / `→` | Previous / Next photo |
 | `Escape` | Close photo viewer |
+| `Space` | Play / pause (videos only) |
+| `z` | Toggle zoom (still images only) |
 | `i` | Toggle sidebar |
-| `f` | Toggle fullscreen |
-| `Delete` | Delete photo |
+| `f` | Toggle favorite |
+| `h` | Hide / unhide photo |
+| `p` | Make public / private (copies the link to your clipboard) |
+| `d` | Move photo to trash |
+| `g` | Toggle fullscreen |
 | `s` | Start / stop slideshow |
+
+The `f`, `h`, `p` and `d` shortcuts act on the current photo and are disabled on public (unauthenticated) album pages.
 


### PR DESCRIPTION
Every page under `apps/docs/docs` was reviewed against the actual source and the discrepancies fixed. 51 of 54 pages changed.

The conceptual material held up well — duplicate detection (BK-tree/pHash), the face pipeline (SCRFD/ArcFace/HDBSCAN), the two-phase scan, thumbnail engine selection and the date-parsing rules all matched the code. What had drifted was everything *operational and referential*: button labels, env var names, file paths, source citations, and the list of what actually ships.

## What changed

**Post-monorepo path rot.** `codedir` is dead in every compose file, but `dev-install.md` still called it "CRITICAL" and blamed it in a troubleshooting entry. `contribution/index.md` told contributors to fork "the relevant LibrePhotos repository". `backend/missing-photos.md` cited 20 source files under a `librephotos/api/...` prefix that doesn't exist. `contribution/docker.md` built with `docker-compose.gpu.yml`, a file that has never existed in this repo.

**Redux is gone; the docs hadn't noticed.** Neither `apps/frontend` nor `apps/mobile` contains a Redux reference any more, but six pages still walked contributors through `UploadSlice`, `LocalImagesSlice`, `redux-persist` and `redux-query`, and the two `to-do.md` pages solicited a migration that is finished — toward libraries the project never adopted.

**Stale UI labels.** "Scan photos (file system)" is now "Scan"; "Start Detection", "Create Public Link" and "Settings → Library Management" don't exist; `f` is bound to favourite, not fullscreen; the favourite control is a star, not a heart. `missing-photos.md`'s four resolution paths all dead-ended on controls that aren't there. Labels are now taken from `locales/en/translation.json` rather than from memory.

**ML credits predated the stack.** Face detection is InsightFace (SCRFD detector + ArcFace embeddings), not `ageitgey/face_recognition`; clustering is `hdbscan`; CLIP + FAISS semantic search and SigLIP 2 tagging were missing entirely. `offline-setup.md` told users to download two models that are no longer in `ML_MODELS` and omitted Moondream, which needs two files.

**Broken auth contract for scripted clients.** Every `/media/...` route and both chunked-upload endpoints authenticate *only* from the `jwt` cookie and ignore `Authorization: Bearer` — which is exactly what `api-authentication.md` recommended for "pure API calls".

**`unified-deployment.md`'s external-Postgres path could not work as written.** `DB_HOST=localhost` cannot reach a sibling container, and `GRANT ALL PRIVILEGES ON DATABASE` has not been sufficient for `manage.py migrate` since PostgreSQL 15. It now creates a shared network, uses the container name, and makes the app user the database owner. Also documents `CSRF_TRUSTED_ORIGINS`, which this deployment needs behind a reverse proxy, and corrects the generated key file to `/logs/secret.key`.

**The env var reference was a stub.** `SECRET_KEY`, `CSRF_TRUSTED_ORIGINS`, `FRONTEND_BASE_URL` and the whole `DB_*` set were undocumented, and `ALLOW_UPLOAD` was documented twice under the plural `ALLOW_UPLOADS` — a silent no-op.

**Frontmatter and navigation.** The Jekyll `category:` key that Docusaurus ignores is removed; `excerpt:` becomes `description:` so pages actually emit a meta description; colliding `sidebar_position` values are resolved; and the User Guide index is no longer a blank page sitting in front of 27 children.

## Verification

- Full `docusaurus build` passes. The config sets `onBrokenLinks: "throw"`, so this proves every internal page link resolves.
- Docusaurus 2.4.3 does not validate *anchors*, so those were checked separately — all anchor links across the 54 pages resolve to real headings.
- No `sidebar_position` collisions, no missing frontmatter, no legacy keys remaining.
- Only `.md` files are touched; no source code, no build artifacts.

## Deliberately not included

- **No source changes.** This is docs-only. Findings that turned out to be code bugs are listed below rather than patched here.
- **The competitor table in `features.md` is untouched.** Its 13 product columns can't be verified from this repo. Four LibrePhotos-column cells were confirmed wrong and are listed below.
- **Three undocumented features still have no page**: SMTP/email config plus the self-service password reset, the Face Options clustering knobs, and the burst-detection rules editor. These need screenshots and product decisions. Note `managing-users.md` no longer claims "E-mail is not used at the moment", but nothing documents the feature yet.

## Code bugs surfaced by the audit

These need your intent, not a doc edit — worth separate issues:

- `api/stats.py` `get_count_stats`: unparenthesised `Q(owner=user) & Q(files=None) | Q(main_file=None)` counts other users' photos. Same precedence bug already fixed in `delete_missing_photos`.
- `api/models/photo_caption.py` compares `CAPTIONING_MODEL`/`LLM_MODEL` against `"None"` (capital) while the UI stores lowercase `"none"`, so selecting None never short-circuits.
- `api/ml_models.py` keys the Moondream download off `LLM_MODEL` instead of `CAPTIONING_MODEL`.
- `api/views/albums.py` `AlbumDateListViewSet`: `?public=true` appends `Q(owner__username=username)` with no `if username:` guard, so it always returns empty.
- `api/views/stacks.py` `DetectStacksView` forwards only `detect_bursts` and silently drops `detect_raw_jpeg` — the Stack RAW+JPEG switch is dead end to end.
- `cleanup_deleted_photos` filters `last_modified__gte=now-30d`, which purges *recently* trashed photos.
- `createuser`/`createadmin` call `User.objects.make_random_password()`, removed in Django 5.1 (pin is 5.2.16).
- Frontend: three navigations to `/user/<username>/`, a route that doesn't exist in `routeTree.gen.ts` — likely `/public/<username>`.
- Frontend: the Duplicate Detection card's i18n keys have no entries in `translation.json`, so those controls render raw keys.
- Mobile: `configStore.ts` has swapped logic/strings — turning logging *on* logs "Disabled" and calls `FileLogger.deleteLogFiles()`.
- Mobile: `uploadActions.ts` swallows upload errors with `console.log` and abandons the rest of the batch.
- `FEATURE_PROCESS_EMBEDDED_MEDIA` isn't forwarded by the bundled compose and is the only toggle still using the strict `== "True"` parser.
- Husky pre-commit doesn't install under the monorepo layout (`prepare` runs in `apps/frontend`, which has no `.git`), so nothing is linted on commit.

## Decisions I left to you

- **Is Kubernetes supported?** `deploy/k8s/` ships manifests but is pinned to image tag `2023w31` and `postgres:13`, while `installation/index.md` says there are "two main installation methods". Document it or mark it unmaintained.
- **The `reallibrephotos/singleton` Docker Hub badge** on `features.md` points at an image this repo has never built.
- **The `features.md` LibrePhotos column.** Four cells are verifiably wrong (XMP support, reading/writing face data, share albums by user/link, time-limited sharing — all ✔️, currently ❔), and roughly 16 more look stale. A single holistic pass would beat piecemeal edits.
- **DB volume path divergence**: `deploy/compose/docker-compose.yml` uses `${data}/db:/var/lib/postgresql` while `deploy/docker/unified/docker-compose.no-proxy.yml` uses `${data}/dbcursor:/var/lib/postgresql/data`, which breaks the standard→unified migration that `deploy/docker/unified/README.md` describes as a simple compose swap.
- **Screenshot currency.** This verified that referenced images *resolve*, not that they still depict the current UI.

## Method

Each page was audited by an independent agent that had to ground every finding in a `file:line` citation; a second agent then tried to *refute* each finding, and only survivors were applied (about a fifth were thrown out as misquotes, stale evidence or style opinions). A third pass reviewed the resulting diff for build breakage, invented facts, broken links and spliced-in contradictions — it caught a fabricated iOS version, two false API claims and two frontmatter collisions, which are fixed here.

Worth knowing when reviewing: agents were forbidden from inventing labels, paths or defaults, and had to skip a fix rather than guess. The review pass treated a plausible-but-invented fact as a blocker. Still, this is a large mechanical change — the per-page diffs are individually small and readable, and the highest-value ones to eyeball are `installation/unified-deployment.md`, `installation/environment-variables.md` and `user-guide/api-authentication.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
