### PR TITLE
fix(backend): return the on-disk spelling of a Live Photo companion

### DIFF
--- a/apps/backend/api/stacks/live_photo.py
+++ b/apps/backend/api/stacks/live_photo.py
@@ -10,6 +10,7 @@ This module moves embedded media extraction from directory_watcher to
 a dedicated stacks-aware component for better organization.
 """
 
+import os
 from mmap import ACCESS_READ, mmap
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -126,6 +127,41 @@ def extract_embedded_motion_video(path: str, output_hash: str) -> str | None:
         return None
 
 
+def _path_as_stored(candidate: Path) -> Path:
+    """
+    Return a path spelled the way the filesystem actually stores it.
+
+    ``Path.exists()`` matches case-insensitively on Windows, on macOS and on
+    case-insensitive mounts (an SMB share is a common scan directory), so a
+    candidate we built from an extension list can resolve to a file that is
+    stored under a different spelling. The scanner records paths exactly as
+    ``os.scandir`` reports them and ``File.path`` is unique, so handing back
+    the constructed spelling would create a second File row for a file that is
+    already known.
+
+    Args:
+        candidate: Path that is known to exist
+
+    Returns:
+        The matching directory entry, or ``candidate`` unchanged if the real
+        spelling cannot be determined
+    """
+    try:
+        entries = os.listdir(candidate.parent)
+    except OSError:
+        return candidate
+
+    if candidate.name in entries:
+        return candidate
+
+    folded = candidate.name.casefold()
+    for entry in entries:
+        if entry.casefold() == folded:
+            return candidate.with_name(entry)
+
+    return candidate
+
+
 def find_apple_live_photo_video(image_path: str) -> str | None:
     """
     Find the companion .mov file for an Apple Live Photo.
@@ -137,7 +173,8 @@ def find_apple_live_photo_video(image_path: str) -> str | None:
         image_path: Path to the image file
 
     Returns:
-        Path to companion video file, or None if not found
+        Path to the companion video file as it is spelled on disk, or None if
+        not found
     """
     base_path = Path(image_path)
     stem = base_path.stem
@@ -146,7 +183,7 @@ def find_apple_live_photo_video(image_path: str) -> str | None:
     for ext in APPLE_LIVE_PHOTO_EXTENSIONS:
         video_path = parent / f"{stem}{ext}"
         if video_path.exists():
-            return str(video_path)
+            return str(_path_as_stored(video_path))
 
     return None
 

--- a/apps/backend/api/tests/test_live_photo.py
+++ b/apps/backend/api/tests/test_live_photo.py
@@ -205,6 +205,24 @@ class FindAppleLivePhotoVideoTestCase(TestCase):
         result = find_apple_live_photo_video(image_path)
         self.assertEqual(result, video_path)
 
+    def test_returns_companion_spelled_as_stored_on_disk(self):
+        """Should return the directory entry, not the constructed spelling.
+
+        The extension list is probed in a fixed case, but a case-insensitive
+        filesystem (Windows, macOS, an SMB mount) matches a candidate against a
+        file stored under a different spelling. The scanner records paths as
+        os.scandir reports them and File.path is unique, so returning the
+        constructed spelling would create a second File row for the same file.
+        """
+        image_path = os.path.join(self.temp_dir, "IMG_005.HEIC")
+        Path(image_path).touch()
+        Path(os.path.join(self.temp_dir, "IMG_005.MOV")).touch()
+
+        result = find_apple_live_photo_video(image_path)
+
+        self.assertIsNotNone(result)
+        self.assertIn(os.path.basename(result), os.listdir(self.temp_dir))
+
     def test_returns_none_when_no_companion(self):
         """Should return None if no companion video exists."""
         image_path = os.path.join(self.temp_dir, "IMG_003.jpg")

--- a/apps/backend/api/tests/test_trash_api.py
+++ b/apps/backend/api/tests/test_trash_api.py
@@ -22,13 +22,8 @@ class TrashAPITest(TestCase):
         photo_to_delete.removed = False
         photo_to_delete.save()
 
-        print(f"Created test photo with hash: {photo_to_delete.image_hash}")
-        print(f"Photo in trashcan: {photo_to_delete.in_trashcan}")
-
         # Test the trash API endpoint
         response = self.client.get("/api/albums/date/list/?in_trashcan=true")
-
-        print(f"API Response Status: {response.status_code}")
 
         # Check that the API responds successfully
         self.assertEqual(response.status_code, 200)
@@ -38,23 +33,14 @@ class TrashAPITest(TestCase):
         # Check that we get the expected response structure
         self.assertIn("results", data)
 
-        print(f"Number of results: {len(data['results'])}")
-
         # Verify that we can call the API successfully
         # (We might not have trashed albums with photos, but the API should work)
         if data["results"]:
-            print("✅ Got album results - trash API is working")
             # If we have results, check the structure
             album = data["results"][0]
             self.assertIn("id", album)
             self.assertIn("date", album)
             self.assertIn("photo_count", album)
-        else:
-            print(
-                "ℹ️ Got empty results (no trashed albums with photos) - but API structure is correct"
-            )
-
-        print("✅ Trash API test completed successfully")
 
     def test_trash_api_without_folder_parameter(self):
         """Test that the trash API works correctly when no folder parameter is provided"""
@@ -69,5 +55,3 @@ class TrashAPITest(TestCase):
 
         # Check that we get the expected response structure
         self.assertIn("results", data)
-
-        print("✅ Trash API without folder parameter works correctly")


### PR DESCRIPTION
## What

Two independent Windows-only test failures, one of which turned out to be a real bug rather than a test artifact.

### 1. `find_apple_live_photo_video()` returned a constructed path (real bug)

The function probes `.mov` then `.MOV` and returned the candidate path it had just built:

```python
video_path = parent / f"{stem}{ext}"
if video_path.exists():
    return str(video_path)     # <- the spelling we guessed, not the one on disk
```

On a case-insensitive filesystem `Path.exists()` matches a constructed `IMG_002.mov` against an on-disk `IMG_002.MOV`, so the function returns a spelling no directory entry actually has.

That is not merely cosmetic:

- the scanner records paths exactly as `os.scandir` reports them (`api/directory_watcher/utils.py`),
- `File.path` is unique and `File.create()` is a `get_or_create` on it,
- so a mis-cased path **creates a second `File` row for a file the scanner already knows about**, and the `File.objects.filter(path=video_path)` lookup in `_create_apple_live_photo_stack()` misses that existing record.

Fixed by resolving the confirmed-existing candidate to its real directory entry.

Two deliberate choices, both of which cut against the obvious implementation:

- **No `sys.platform` gate.** Gating the lookup on Windows/macOS would miss the most common real deployment — LibrePhotos scan directories are frequently SMB/CIFS mounts, which are case-insensitive on Linux too.
- **Cost is negligible anyway.** The `listdir` runs only *after* a companion video has been confirmed found, i.e. only for actual Live Photos, which already trigger file hashing and DB writes. Photos with no companion never pay for it.

The helper also corrects a differing stem case (image `IMG_002.HEIC`, video stored as `img_002.MOV`), and falls back to the candidate unchanged if the directory cannot be read.

### 2. Emoji `print()`s in `test_trash_api.py`

`test_trash_api_returns_deleted_images` and `test_trash_api_without_folder_parameter` printed U+2705 / U+2139, which raises `UnicodeEncodeError` on a cp1252 console and turned two *passing* tests into errors on Windows. They were debug noise rather than assertions, so they are simply gone; every `assert*` call is untouched.

## Testing

- Added `test_returns_companion_spelled_as_stored_on_disk`, asserting the returned basename appears verbatim in `os.listdir()`. That is the actual invariant, and unlike the existing uppercase test it is meaningful on Linux CI too rather than passing there for free.
- Verified in both directions on Windows rather than only confirming the green run: the old code returns `IMG_002.mov` with `in listdir? -> False`; the new code returns `IMG_002.MOV`, `True`.
- Full backend suite on Windows: **1812 tests, `OK (skipped=21)`** — zero failures. These were the last three Windows-only failures, so a red Windows run can now be read as a real regression instead of known noise.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
