### PR TITLE
fix: give StackReview a monotonic pk so its ordering is a total order

### DIFF
--- a/apps/backend/api/migrations/0136_stackreview_monotonic_pk.py
+++ b/apps/backend/api/migrations/0136_stackreview_monotonic_pk.py
@@ -1,0 +1,80 @@
+"""Give StackReview a monotonic primary key so its ordering is a total order.
+
+Meta.ordering was ["-created_at"]. created_at is auto_now_add, so two rows
+written in the same clock tick hold the same value, and with a random uuid4 pk
+there was nothing to break the tie: the database could return such rows in
+either order, which lets one move between pages of an offset-paginated response
+and be served twice or skipped.
+
+The tiebreak has to follow insertion order to be chronologically honest, and
+Django only allows an auto-incrementing column as the primary key (fields.E100,
+"AutoFields must set primary_key=True"), so the monotonic column cannot be a
+separate "seq" field - it has to be the pk. The uuid4 is kept as `uuid`, a
+unique non-pk column, so rows stay externally nameable by the same value they
+were nameable by before and no sequential counter leaks into the API.
+
+Written out by hand rather than taken from makemigrations, which generates a
+bare AlterField from UUIDField to BigAutoField. That is silently destructive:
+Postgres cannot cast uuid to bigint at all, and SQLite's table rebuild would
+coerce the uuid strings to integers. The same applies to adding `uuid` unique
+in one step - AddField evaluates a default once and writes that single value to
+every row, so the unique constraint would fail on any table with two rows.
+
+Reversing this migration is only sound on an empty table: the reverse of the pk
+swap re-adds a UUIDField pk, and AddField would again write one shared default
+into every row.
+"""
+
+import uuid
+
+from django.db import migrations, models
+from django.db.models import F
+
+
+def copy_pk_to_uuid(apps, schema_editor):
+    """Preserve each row's existing pk as its external identifier."""
+    StackReview = apps.get_model("api", "StackReview")
+    StackReview.objects.update(uuid=F("id"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0135_ocr_text_fts_index"),
+    ]
+
+    operations = [
+        # Nullable and non-unique first, so the column can exist before it has
+        # per-row values.
+        migrations.AddField(
+            model_name="stackreview",
+            name="uuid",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, null=True),
+        ),
+        migrations.RunPython(copy_pk_to_uuid, migrations.RunPython.noop),
+        # Every row now holds its old pk, so unique and NOT NULL can be applied.
+        migrations.AlterField(
+            model_name="stackreview",
+            name="uuid",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+        # Swap the pk as a drop and an add rather than an AlterField: there is
+        # no cast from uuid to bigint, and the new values have to come from the
+        # sequence, not from the old column.
+        migrations.RemoveField(
+            model_name="stackreview",
+            name="id",
+        ),
+        migrations.AddField(
+            model_name="stackreview",
+            name="id",
+            field=models.BigAutoField(primary_key=True, serialize=False),
+        ),
+        migrations.AlterModelOptions(
+            name="stackreview",
+            options={
+                "ordering": ["-created_at", "-id"],
+                "verbose_name": "Stack Review",
+                "verbose_name_plural": "Stack Reviews",
+            },
+        ),
+    ]

--- a/apps/backend/api/models/stack_review.py
+++ b/apps/backend/api/models/stack_review.py
@@ -44,7 +44,16 @@ class StackReview(models.Model):
         # User marked as "not actually duplicates"
         DISMISSED = "dismissed", "Dismissed"
 
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # Monotonic primary key. Meta.ordering below needs a tiebreak that follows
+    # insertion order, and Django only allows an auto-incrementing column as the
+    # primary key (fields.E100, "AutoFields must set primary_key=True"), so the
+    # sortable column has to be the pk rather than a separate "seq" field.
+    id = models.BigAutoField(primary_key=True)
+
+    # Stable external identifier. This is the value that used to be the primary
+    # key, so the pk swap does not make the row externally unnameable, and it
+    # keeps the row count out of any identifier the API might hand out.
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
 
     stack = models.OneToOneField(
         PhotoStack,
@@ -85,7 +94,14 @@ class StackReview(models.Model):
     note = models.TextField(blank=True, null=True)
 
     class Meta:
-        ordering = ["-created_at"]
+        # created_at is not a total order on its own: it is auto_now_add, so two
+        # rows written in the same clock tick hold the same value and the
+        # database is free to return them in either order. Under offset
+        # pagination that lets a row move between pages, so a client can be
+        # served it twice or never see it. id is monotonic, so it breaks the tie
+        # in insertion order - the nearest thing to the order created_at would
+        # have given if it had the resolution to tell the rows apart.
+        ordering = ["-created_at", "-id"]
         verbose_name = "Stack Review"
         verbose_name_plural = "Stack Reviews"
         indexes = [

--- a/apps/backend/api/tests/test_stack_review.py
+++ b/apps/backend/api/tests/test_stack_review.py
@@ -52,13 +52,35 @@ class StackReviewModelTestCase(TestCase):
         self.assertEqual(review.trashed_count, 0)
         self.assertIsNone(review.reviewed_at)
 
-    def test_uuid_primary_key(self):
-        """Review ID should be a valid UUID."""
+    def test_monotonic_primary_key(self):
+        """Review pk should be an integer from the sequence, not a random UUID.
+
+        The pk doubles as the tiebreak in Meta.ordering, so it has to follow
+        insertion order.
+        """
         review = StackReview.objects.create(
             stack=self.stack,
             reviewer=self.user,
         )
-        self.assertIsInstance(review.id, uuid.UUID)
+        self.assertIsInstance(review.id, int)
+
+    def test_uuid_external_identifier(self):
+        """Review should still carry a UUID for external reference."""
+        review = StackReview.objects.create(
+            stack=self.stack,
+            reviewer=self.user,
+        )
+        self.assertIsInstance(review.uuid, uuid.UUID)
+
+    def test_uuid_is_unique_per_review(self):
+        """Each review should get its own UUID."""
+        stack2 = PhotoStack.objects.create(
+            owner=self.user,
+            stack_type=PhotoStack.StackType.MANUAL,
+        )
+        review1 = StackReview.objects.create(stack=self.stack, reviewer=self.user)
+        review2 = StackReview.objects.create(stack=stack2, reviewer=self.user)
+        self.assertNotEqual(review1.uuid, review2.uuid)
 
     def test_one_to_one_with_stack(self):
         """Stack should have at most one review."""
@@ -122,11 +144,9 @@ class StackReviewModelTestCase(TestCase):
             stack=stack2,
             reviewer=self.user,
         )
-        # Space the two timestamps out by hand. created_at is auto_now_add, so
-        # back-to-back creates can land in the same clock tick, and the model
-        # orders on created_at alone - its pk is a random UUID, so it is no
-        # tiebreak - which left this test resolving a tie by coin flip. Use
-        # queryset.update() because auto_now_add ignores an assigned value.
+        # Space the two timestamps out by hand so this tests created_at and not
+        # the pk tiebreak behind it. Use queryset.update() because auto_now_add
+        # ignores a value assigned on the instance.
         now = timezone.now()
         StackReview.objects.filter(pk=review1.pk).update(
             created_at=now - timedelta(minutes=1)
@@ -139,6 +159,56 @@ class StackReviewModelTestCase(TestCase):
         # review2 was created later, should come first
         self.assertEqual(reviews[0], review2)
         self.assertEqual(reviews[1], review1)
+
+    def test_same_created_at_orders_by_insertion(self):
+        """Rows sharing a created_at should still come back newest-first.
+
+        created_at is auto_now_add, so rows written in the same clock tick share
+        a value. With only -created_at to sort by, the database was free to
+        return them in either order, which under offset pagination lets a row
+        move between pages and be served twice or skipped. The pk is monotonic,
+        so it resolves the tie the way created_at would have if it could tell
+        the rows apart.
+        """
+        reviews = []
+        for _ in range(5):
+            stack = PhotoStack.objects.create(
+                owner=self.user,
+                stack_type=PhotoStack.StackType.MANUAL,
+            )
+            reviews.append(StackReview.objects.create(stack=stack, reviewer=self.user))
+
+        # Collapse every row onto one timestamp - the worst case for the sort.
+        tick = timezone.now()
+        StackReview.objects.update(created_at=tick)
+
+        ordered = list(StackReview.objects.all())
+        self.assertEqual(ordered, list(reversed(reviews)))
+
+    def test_ordering_is_stable_across_queries(self):
+        """The same tied rows should come back in the same order every time.
+
+        This is the property offset pagination depends on: page 2 is computed by
+        a second query, so an unstable sort is what lets a row repeat or vanish.
+        """
+        for _ in range(5):
+            stack = PhotoStack.objects.create(
+                owner=self.user,
+                stack_type=PhotoStack.StackType.MANUAL,
+            )
+            StackReview.objects.create(stack=stack, reviewer=self.user)
+
+        StackReview.objects.update(created_at=timezone.now())
+
+        first = [r.pk for r in StackReview.objects.all()]
+        second = [r.pk for r in StackReview.objects.all()]
+        self.assertEqual(first, second)
+
+        # Walked in pages, every row is seen exactly once.
+        paged = []
+        for start in range(0, 5, 2):
+            paged.extend(r.pk for r in StackReview.objects.all()[start : start + 2])
+        self.assertEqual(paged, first)
 
 
 class DecisionChoicesTestCase(TestCase):


### PR DESCRIPTION
## The problem

`StackReview.Meta.ordering` was `["-created_at"]`. `created_at` is `auto_now_add`, so two rows written in the same clock tick hold the same value, and with a random uuid4 pk there was nothing to break the tie — the database was free to return such rows in either order. Under offset pagination that lets a row move between pages and be served twice or skipped.

#1935 fixed the flaky test that exposed this (`test_ordering_by_created_at_descending`, failing about one run in three) by spacing the two timestamps by hand, and deliberately left the model alone because changing it needs a migration.

## Why not just add `-pk`

A uuid4 tiebreak makes ties deterministic but in an arbitrary order — it fixes pagination without ordering the tie the way `created_at` would have. To be chronologically honest the tiebreak has to follow insertion order.

Django only allows an auto-incrementing column as the primary key:

```
fields.E100: AutoFields must set primary_key=True.
```

So the monotonic column cannot be a separate `seq` field — it has to be the pk. `id` is now a `BigAutoField`, and the uuid4 moves to `uuid`, a unique non-pk column, so rows stay externally nameable by the same value as before and no sequential counter has to leak into an API.

The alternatives were weighed and rejected:

- **A real database sequence via `db_default`** keeps the uuid pk, but it is Postgres-only and the suite runs on SQLite (`test-backend.yml`).
- **A unique constraint on `created_at`** turns a benign tie into an `IntegrityError` on the write path — a 500 traded for a pagination glitch.

## The migration

Written by hand, because `makemigrations` generates a bare `AlterField` from `UUIDField` to `BigAutoField`, which is **silently destructive**: Postgres cannot cast `uuid` to `bigint` at all, and SQLite's table rebuild would coerce the uuid strings to integers. Adding `uuid` unique in one step fails from the other end, since `AddField` evaluates a default once and writes that single value to every row.

`0136_stackreview_monotonic_pk` instead adds the column nullable, copies each row's old pk into it, applies the unique constraint, and only then swaps the pk.

## Blast radius

`StackReview` has no serializer, view, url or admin, and no frontend or mobile reference. Its only callers are two order-independent `.filter().update()` calls in `api/views/photos.py`, so nothing downstream changes — the pagination hazard this fixes was latent rather than live.

## Verification

- Full backend suite on this branch: **1879 tests, OK** (21 skipped, 2 expected failures).
- `test_stack_review`: 46 → 50 tests. Retargeted `test_uuid_primary_key`, and added coverage for the property actually being fixed — same-tick rows ordering by insertion, and a paged walk seeing every row exactly once.
- The migration was applied to a **populated** SQLite database: existing pks survive into `uuid`, `id` becomes a sequence, and same-tick rows come back in insertion order, stably across repeated queries.
- `ruff check` and `ruff format --check` clean.

**Not verified on Postgres** — no local instance was available. The drop-uuid-pk / add-identity-pk step is where the two backends could differ, so that is the part worth a second look before merging. Related: on Postgres the new ids for pre-existing rows are assigned in physical scan order rather than `created_at` order, which only matters for legacy rows that share a timestamp, where the true order is unrecoverable anyway. Reversing the migration is only sound on an empty table, which the migration docstring says.

## Two things this deliberately does not do

1. **It leaves `StackReview` inconsistent with `MetadataEdit`**, which hit the identical bug and took the uuid4 tiebreak in #1921 — documented there as determinism rather than chronology, with a state-only migration. Worth deciding whether both models should end up on the same answer.

2. **It does not touch `Duplicate`**, which has the same defect and, unlike `StackReview`, a live offset-paginated endpoint — `DuplicateListView` orders by `-created_at` alone behind `Paginator` + a `page` param, on real data. That is the case actually reaching users today. It is out of scope here because `Photo` reaches `Duplicate` through a ManyToMany, so the same pk swap is not cheap there and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
