### PR TITLE
fix(frontend): move Screenshots from the sidebar into the photos dropdown

### DIFF
--- a/apps/frontend/src/components/menubars/navigation.tsx
+++ b/apps/frontend/src/components/menubars/navigation.tsx
@@ -3,7 +3,6 @@ import type { Icon } from "@tabler/icons-react";
 import {
   IconAlbum as Album,
   IconPhoto as Photo,
-  IconScreenshot as Screenshot,
   IconLayersSubtract as Stacks,
   IconTrash as Trash,
   IconUsers as Users,
@@ -32,7 +31,6 @@ type MenuItem = {
 export function getNavigationItems(t: TFunction<"translation", undefined>, isAuthenticated: boolean): Array<MenuItem> {
   return [
     { label: t("sidemenu.photos"), link: "/", icon: Photo, color: "green" },
-    { label: t("sidemenu.screenshots"), link: "/screenshots", icon: Screenshot, color: "grape" },
     { label: t("sidemenu.albums"), link: "/album", icon: Album, color: "blue" },
     {
       label: t("sidemenu.sharing"),

--- a/apps/frontend/src/components/photolist/DefaultHeader.tsx
+++ b/apps/frontend/src/components/photolist/DefaultHeader.tsx
@@ -7,6 +7,7 @@ import {
   IconGlobe as Globe,
   IconFolderSearch,
   IconPhoto as Photo,
+  IconScreenshot as Screenshot,
   IconStar as Star,
   IconVideo as Video,
 } from "@tabler/icons-react";
@@ -72,7 +73,8 @@ export function DefaultHeader(props: Props) {
       path.startsWith("/recent") ||
       path.startsWith("/user/") ||
       path.startsWith("/photos") ||
-      path.startsWith("/videos")
+      path.startsWith("/videos") ||
+      path.startsWith("/screenshots")
     );
   };
 
@@ -211,6 +213,13 @@ export function DefaultHeader(props: Props) {
 
                   <Menu.Item leftSection={<Video color="pink" size={14} />} onClick={() => navigate({ to: "/videos" })}>
                     {t("sidemenu.videos")}
+                  </Menu.Item>
+
+                  <Menu.Item
+                    leftSection={<Screenshot color="violet" size={14} />}
+                    onClick={() => navigate({ to: "/screenshots" })}
+                  >
+                    {t("sidemenu.screenshots")}
                   </Menu.Item>
 
                   <Menu.Item


### PR DESCRIPTION
Follow-up to #1943, which landed the Screenshots view as its own top-level sidebar entry. That put a media category next to structural destinations (Albums, Sharing, Organizing, Trash). It belongs with its peers instead — the photos title dropdown already switches between Photos, Videos, Hidden, Favorites and the timestamp views.

## Changes

- **`navigation.tsx`** — drop the `/screenshots` sidebar item. This removes it from the mobile `FooterMenu` too, since both render from the same list.
- **`DefaultHeader.tsx`** — add a Screenshots entry to the photos title dropdown, right after Videos.
- **`DefaultHeader.tsx`** — add `/screenshots` to `isMenuView()`, so the dropdown stays rendered on the screenshots page itself. Without it the page has no way back out through the same menu.

Nothing else moves: the "Go to Screenshots" command-palette action and the Screenshots option in the media-type filter on the photos header are unchanged.

## Note on the icon color

The entry uses the CSS keyword `violet`, not Mantine's `grape` that the sidebar item had. These `leftSection` icons pass `color` straight through to the SVG stroke, so a Mantine theme token is not a valid value there and would silently fall back to `currentColor` — the same class of failure as the leftover v6 style props.

## Test plan

- `eslint` clean on both files; `prettier --check` clean.
- `tsc --noEmit` reports no new errors for either file (the three pre-existing `DefaultHeader.tsx` errors, in the user-details/scan-directory code, are untouched).
- Manual: open the photos title dropdown → Screenshots navigates to `/screenshots`; the dropdown is still present there and can navigate back; the sidebar no longer lists Screenshots on desktop or in the mobile footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
