### PR TITLE
feat: selectable live text over photos with OCR results

### DIFF
--- a/apps/backend/api/directory_watcher/processing_jobs.py
+++ b/apps/backend/api/directory_watcher/processing_jobs.py
@@ -396,6 +396,8 @@ def _run_ocr_for_photo(photo: Photo):
         defaults={
             "text": ocr_text,
             "blocks": data.get("blocks", []) or [],
+            "source_width": data.get("image_width"),
+            "source_height": data.get("image_height"),
             "engine": ocr_model,
             "mean_confidence": data.get("mean_confidence"),
             "text_area_fraction": text_area_fraction,

--- a/apps/backend/api/migrations/0137_photo_ocr_source_dimensions.py
+++ b/apps/backend/api/migrations/0137_photo_ocr_source_dimensions.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0136_stackreview_monotonic_pk"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="photoocr",
+            name="source_width",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="photoocr",
+            name="source_height",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+    ]

--- a/apps/backend/api/models/photo_ocr.py
+++ b/apps/backend/api/models/photo_ocr.py
@@ -25,6 +25,11 @@ class PhotoOcr(models.Model):
     # exceeds ~2704 bytes. Full-text search over OCR text comes later via FTS.
     text = models.TextField(blank=True, null=True)
     blocks = models.JSONField(default=list, blank=True)
+    # Pixel dimensions of the image the block boxes are expressed in (the OCR
+    # source: original file or big thumbnail). Needed to normalize the geometry
+    # for display; null for rows stored before these fields existed.
+    source_width = models.PositiveIntegerField(null=True, blank=True)
+    source_height = models.PositiveIntegerField(null=True, blank=True)
     engine = models.CharField(max_length=64, blank=True, default="")
     mean_confidence = models.FloatField(null=True, blank=True)
     text_area_fraction = models.FloatField(null=True, blank=True)

--- a/apps/backend/api/serializers/photos.py
+++ b/apps/backend/api/serializers/photos.py
@@ -10,6 +10,7 @@ from api.image_similarity import search_similar_image
 from api.models import AlbumDate, File, Photo
 from api.models.album_place import get_album_place
 from api.models.photo_metadata import PhotoMetadata
+from api.models.photo_ocr import PhotoOcr
 from api.serializers.photo_metadata import PhotoMetadataSummarySerializer
 from api.serializers.simple import SimpleUserSerializer
 
@@ -352,6 +353,8 @@ class PhotoSerializer(serializers.ModelSerializer):
     stacks = serializers.SerializerMethodField()
     # Structured metadata with edit history support
     metadata = serializers.SerializerMethodField()
+    # OCR text and normalized block geometry for the "live text" overlay
+    ocr = serializers.SerializerMethodField()
 
     # Backwards-compatible fields from PhotoMetadata (for API compatibility)
     height = serializers.SerializerMethodField()
@@ -409,6 +412,7 @@ class PhotoSerializer(serializers.ModelSerializer):
             "file_variants",
             "stacks",
             "metadata",
+            "ocr",
             "local_orientation",
         )
 
@@ -460,6 +464,60 @@ class PhotoSerializer(serializers.ModelSerializer):
     def get_subjectDistance(self, obj) -> float | None:
         # Not stored in PhotoMetadata (rarely used field)
         return None
+
+    def get_ocr(self, obj) -> dict | None:
+        """OCR text plus block geometry normalized to [0, 1], owner-only.
+
+        OCR text is privacy-sensitive (receipts, letters, IDs), so it is served
+        exclusively to the photo's owner: the detail endpoint also answers for
+        shared and public photos (even anonymously), and those viewers must not
+        receive the extracted text. Without a request in the serializer context
+        the owner cannot be verified, so nothing is exposed.
+
+        The stored boxes are pixel coordinates in the OCR source image (the
+        original file or the big thumbnail, whichever was fed to the sidecar).
+        Both share the photo's aspect ratio, so dividing by the stored source
+        dimensions yields display-agnostic fractions the frontend can lay over
+        any rendition. Rows written before the dimensions were stored get their
+        text but no blocks (no overlay is possible without a reference frame).
+        """
+        request = self.context.get("request")
+        if request is None or request.user != obj.owner:
+            return None
+
+        try:
+            ocr = obj.ocr
+        except PhotoOcr.DoesNotExist:
+            return None
+
+        blocks = []
+        width = ocr.source_width or 0
+        height = ocr.source_height or 0
+        if width > 0 and height > 0 and isinstance(ocr.blocks, list):
+            for block in ocr.blocks:
+                box = block.get("box") if isinstance(block, dict) else None
+                text = block.get("text") if isinstance(block, dict) else None
+                if not text or not isinstance(box, list) or len(box) != 4:
+                    continue
+                try:
+                    normalized = [
+                        [
+                            min(1.0, max(0.0, float(x) / width)),
+                            min(1.0, max(0.0, float(y) / height)),
+                        ]
+                        for x, y in box
+                    ]
+                except (TypeError, ValueError):
+                    continue
+                blocks.append(
+                    {
+                        "text": text,
+                        "box": normalized,
+                        "confidence": block.get("confidence"),
+                    }
+                )
+
+        return {"text": ocr.text or "", "blocks": blocks}
 
     def get_similar_photos(self, obj) -> list:
         res = search_similar_image(obj.owner, obj, threshold=90)

--- a/apps/backend/api/tests/test_ocr_search.py
+++ b/apps/backend/api/tests/test_ocr_search.py
@@ -1,4 +1,4 @@
-"""OCR text is searchable, owner-scoped, and never leaks through the API.
+"""OCR text is searchable, owner-scoped, and only the owner's detail view serves it.
 
 Work package B/4. These tests run on SQLite (the CI backend), so they exercise
 the ``ocr__text__icontains`` fallback path of the OCR search integration in
@@ -118,9 +118,20 @@ class OcrSearchTest(TestCase):
 
 
 class OcrPrivacyTest(TestCase):
-    """OCR text must never be serialized to any API surface."""
+    """OCR text reaches exactly one API surface: the owner's photo detail.
+
+    OCR text is privacy-sensitive (receipts, letters, IDs). The "live text"
+    overlay needs it on the detail endpoint, but only for the photo's owner —
+    the same endpoint also answers for shared and public photos (anonymously,
+    even), and those viewers must never receive the extracted text. Search and
+    every other serializer keep excluding it entirely.
+    """
 
     SENTINEL = "topsecret invoice total 42.99 acct 8891"
+
+    # The single serializer allowed to expose OCR; its get_ocr gates on the
+    # requesting user being the photo's owner.
+    ALLOWED_SERIALIZERS = {"PhotoSerializer"}
 
     def setUp(self):
         self.user = create_test_user()
@@ -138,15 +149,35 @@ class OcrPrivacyTest(TestCase):
         self.assertNotIn("topsecret", resp.content.decode())
         self.assertNotIn(self.SENTINEL, resp.content.decode())
 
-    def test_photo_detail_excludes_ocr_text(self):
+    def test_photo_detail_includes_ocr_text_for_owner(self):
         resp = self.client.get(f"/api/photos/{self.photo.image_hash}/")
         self.assertEqual(resp.status_code, 200)
-        self.assertNotIn("topsecret", resp.content.decode())
-        self.assertNotIn(self.SENTINEL, resp.content.decode())
+        self.assertEqual(resp.json()["ocr"]["text"], self.SENTINEL)
 
-    def test_no_serializer_declares_ocr_field(self):
+    def test_photo_detail_excludes_ocr_text_for_shared_viewer(self):
+        viewer = create_test_user()
+        self.photo.shared_to.add(viewer)
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+
+        resp = client.get(f"/api/photos/{self.photo.image_hash}/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.json()["ocr"])
+        self.assertNotIn("topsecret", resp.content.decode())
+
+    def test_photo_detail_excludes_ocr_text_for_anonymous_public_viewer(self):
+        self.photo.public = True
+        self.photo.save()
+
+        resp = APIClient().get(f"/api/photos/{self.photo.image_hash}/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.json()["ocr"])
+        self.assertNotIn("topsecret", resp.content.decode())
+
+    def test_no_other_serializer_declares_ocr_field(self):
         # Statically walk every serializer class in api.serializers and assert
-        # none names an "ocr" field (guards against a future accidental add).
+        # none but the allowlisted owner-gated one names an "ocr" field (guards
+        # against a future accidental add).
         offenders = []
         for module_info in pkgutil.iter_modules(serializers_pkg.__path__):
             module = importlib.import_module(
@@ -157,6 +188,8 @@ class OcrPrivacyTest(TestCase):
                 if not isinstance(attr, type) or not issubclass(
                     attr, serializers.BaseSerializer
                 ):
+                    continue
+                if attr.__name__ in self.ALLOWED_SERIALIZERS:
                     continue
                 meta = getattr(attr, "Meta", None)
                 fields = getattr(meta, "fields", None)

--- a/apps/backend/api/tests/test_photo_ocr.py
+++ b/apps/backend/api/tests/test_photo_ocr.py
@@ -44,7 +44,9 @@ class _SyncAsyncTask:
         return self.func(*self.args, **self.kwargs)
 
 
-def _ok_response(text="hello world", blocks=None, mean_conf=0.91, area=0.12):
+def _ok_response(
+    text="hello world", blocks=None, mean_conf=0.91, area=0.12, width=200, height=100
+):
     response = MagicMock()
     response.ok = True
     response.status_code = 201
@@ -55,6 +57,8 @@ def _ok_response(text="hello world", blocks=None, mean_conf=0.91, area=0.12):
         else [{"text": "hello", "box": [0, 0, 10, 10], "confidence": 0.9}],
         "mean_confidence": mean_conf,
         "text_area_fraction": area,
+        "image_width": width,
+        "image_height": height,
     }
     return response
 
@@ -163,6 +167,8 @@ class GenerateOcrWorkerTest(TestCase):
         self.assertEqual(ocr.blocks[0]["text"], "hello")
         self.assertAlmostEqual(ocr.mean_confidence, 0.91)
         self.assertAlmostEqual(ocr.text_area_fraction, 0.12)
+        self.assertEqual(ocr.source_width, 200)
+        self.assertEqual(ocr.source_height, 100)
 
         job = LongRunningJob.objects.get(job_id=str(job_id))
         self.assertTrue(job.finished)
@@ -215,6 +221,141 @@ class GenerateOcrWorkerTest(TestCase):
         job = LongRunningJob.objects.get(job_id=str(job_id))
         self.assertEqual(job.result.get("error_count"), 1)
         self.assertTrue(job.finished)
+
+
+class PhotoSerializerOcrFieldTest(TestCase):
+    """The ``ocr`` field on PhotoSerializer: owner-gated, normalized geometry.
+
+    The owner/other-viewer gating at the API level is covered by
+    ``api.tests.test_ocr_search.OcrPrivacyTest``; here the serializer method is
+    exercised directly with a stub request in the context.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user)
+
+    def _serialize_ocr(self, user=None):
+        from types import SimpleNamespace
+
+        from api.serializers.photos import PhotoSerializer
+
+        request = SimpleNamespace(user=user if user is not None else self.user)
+        return PhotoSerializer(context={"request": request}).get_ocr(self.photo)
+
+    def test_no_ocr_row_serializes_as_none(self):
+        self.assertIsNone(self._serialize_ocr())
+
+    def test_without_request_context_serializes_as_none(self):
+        from api.serializers.photos import PhotoSerializer
+
+        PhotoOcr.objects.create(photo=self.photo, text="hi", engine=ACTIVE_MODEL)
+        self.assertIsNone(PhotoSerializer().get_ocr(self.photo))
+
+    def test_non_owner_gets_none(self):
+        PhotoOcr.objects.create(photo=self.photo, text="hi", engine=ACTIVE_MODEL)
+        other = create_test_user()
+        self.assertIsNone(self._serialize_ocr(user=other))
+
+    def test_blocks_normalized_to_unit_square(self):
+        PhotoOcr.objects.create(
+            photo=self.photo,
+            text="hello",
+            blocks=[
+                {
+                    "text": "hello",
+                    "box": [[0, 0], [100, 0], [100, 25], [0, 25]],
+                    "confidence": 0.9,
+                }
+            ],
+            source_width=200,
+            source_height=100,
+            engine=ACTIVE_MODEL,
+        )
+        data = self._serialize_ocr()
+        self.assertEqual(data["text"], "hello")
+        self.assertEqual(len(data["blocks"]), 1)
+        block = data["blocks"][0]
+        self.assertEqual(block["text"], "hello")
+        self.assertEqual(block["confidence"], 0.9)
+        self.assertEqual(
+            block["box"], [[0.0, 0.0], [0.5, 0.0], [0.5, 0.25], [0.0, 0.25]]
+        )
+
+    def test_out_of_bounds_coordinates_are_clamped(self):
+        PhotoOcr.objects.create(
+            photo=self.photo,
+            text="edge",
+            blocks=[
+                {
+                    "text": "edge",
+                    "box": [[-5, -5], [250, -5], [250, 110], [-5, 110]],
+                    "confidence": 0.8,
+                }
+            ],
+            source_width=200,
+            source_height=100,
+            engine=ACTIVE_MODEL,
+        )
+        block = self._serialize_ocr()["blocks"][0]
+        self.assertEqual(block["box"], [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+
+    def test_legacy_row_without_dimensions_has_text_but_no_blocks(self):
+        PhotoOcr.objects.create(
+            photo=self.photo,
+            text="legacy text",
+            blocks=[
+                {
+                    "text": "legacy",
+                    "box": [[0, 0], [10, 0], [10, 5], [0, 5]],
+                    "confidence": 0.7,
+                }
+            ],
+            engine=ACTIVE_MODEL,
+        )
+        data = self._serialize_ocr()
+        self.assertEqual(data["text"], "legacy text")
+        self.assertEqual(data["blocks"], [])
+
+    def test_malformed_blocks_are_skipped(self):
+        PhotoOcr.objects.create(
+            photo=self.photo,
+            text="ok",
+            blocks=[
+                {"text": "no box", "confidence": 0.9},
+                {"text": "bad box", "box": [0, 0, 10, 10], "confidence": 0.9},
+                {"text": "", "box": [[0, 0], [1, 0], [1, 1], [0, 1]]},
+                "not even a dict",
+                {
+                    "text": "good",
+                    "box": [[0, 0], [20, 0], [20, 10], [0, 10]],
+                    "confidence": 0.95,
+                },
+            ],
+            source_width=200,
+            source_height=100,
+            engine=ACTIVE_MODEL,
+        )
+        blocks = self._serialize_ocr()["blocks"]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["text"], "good")
+
+    def test_full_serializer_includes_ocr_field(self):
+        from types import SimpleNamespace
+
+        from api.serializers.photos import PhotoSerializer
+
+        PhotoOcr.objects.create(
+            photo=self.photo,
+            text="hello",
+            blocks=[],
+            source_width=200,
+            source_height=100,
+            engine=ACTIVE_MODEL,
+        )
+        context = {"request": SimpleNamespace(user=self.user)}
+        data = PhotoSerializer(self.photo, context=context).data
+        self.assertEqual(data["ocr"], {"text": "hello", "blocks": []})
 
 
 @override_config(OCR_MODEL=ACTIVE_MODEL)

--- a/apps/backend/service/ocr/ppocr/engine.py
+++ b/apps/backend/service/ocr/ppocr/engine.py
@@ -167,6 +167,8 @@ class PPOCREngine:
             return {
                 "text_area_fraction": area_fraction,
                 "box_count": len(boxes),
+                "image_width": width,
+                "image_height": height,
             }
 
         crops = [get_rotate_crop_image(image, box) for box in boxes]
@@ -198,4 +200,8 @@ class PPOCREngine:
             "blocks": ordered,
             "text_area_fraction": area_fraction,
             "mean_confidence": mean_confidence,
+            # Dimensions of the image the boxes are expressed in, so callers can
+            # normalize block geometry without re-reading the file.
+            "image_width": width,
+            "image_height": height,
         }

--- a/apps/frontend/src/api_client/photos/types.test.ts
+++ b/apps/frontend/src/api_client/photos/types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
-import { MetadataHistoryResponse, Photo, PhotoMetadata, Photoset } from "./types";
+import { MetadataHistoryResponse, Photo, PhotoMetadata, PhotoOcrData, Photoset } from "./types";
 
 /**
  * Regression coverage for the PhotoMetadata zod schema drifting from the
@@ -208,6 +208,47 @@ describe("Screenshots media category", () => {
   test("Photo.is_screenshot round-trips a true value", () => {
     const schema = Photo.pick({ video: true, is_screenshot: true });
     expect(schema.parse({ video: false, is_screenshot: true }).is_screenshot).toBe(true);
+  });
+});
+
+describe("Photo OCR (live text) schema", () => {
+  // What PhotoSerializer.get_ocr emits for a photo with stored geometry.
+  const ocrPayload = {
+    text: "TOTAL 12.34",
+    blocks: [
+      {
+        text: "TOTAL 12.34",
+        box: [
+          [0.1, 0.1],
+          [0.6, 0.1],
+          [0.6, 0.2],
+          [0.1, 0.2],
+        ],
+        confidence: 0.95,
+      },
+    ],
+  };
+
+  test("accepts the serializer payload", () => {
+    const parsed = PhotoOcrData.parse(ocrPayload);
+    expect(parsed.blocks[0].box).toHaveLength(4);
+    expect(parsed.blocks[0].box[1]).toEqual([0.6, 0.1]);
+  });
+
+  test("accepts a legacy row: text without blocks", () => {
+    expect(PhotoOcrData.parse({ text: "legacy", blocks: [] }).blocks).toEqual([]);
+  });
+
+  test("rejects a box that is not a four-corner quad", () => {
+    const flatBox = { text: "x", blocks: [{ text: "x", box: [0, 0, 10, 10], confidence: 0.9 }] };
+    expect(PhotoOcrData.safeParse(flatBox).success).toBe(false);
+  });
+
+  test("Photo.ocr is optional (older backend) and nullable (no OCR row)", () => {
+    const schema = Photo.pick({ video: true, ocr: true });
+    expect(schema.parse({ video: false })).toEqual({ video: false });
+    expect(schema.parse({ video: false, ocr: null }).ocr).toBeNull();
+    expect(schema.parse({ video: false, ocr: ocrPayload }).ocr?.text).toBe("TOTAL 12.34");
   });
 });
 

--- a/apps/frontend/src/api_client/photos/types.ts
+++ b/apps/frontend/src/api_client/photos/types.ts
@@ -165,6 +165,25 @@ export const PhotoMetadataSummary = z.object({
 });
 export type PhotoMetadataSummary = z.infer<typeof PhotoMetadataSummary>;
 
+// One recognized OCR text block. `box` holds the four [x, y] quad corners in
+// clockwise order starting top-left, normalized to [0, 1] of the OCR source
+// image — multiply by the displayed media size to lay the block over any
+// rendition of the photo (they all share the same aspect ratio).
+export const PhotoOcrBlock = z.object({
+  text: z.string(),
+  box: z.number().array().length(2).array().length(4),
+  confidence: z.number().nullable().optional(),
+});
+export type PhotoOcrBlock = z.infer<typeof PhotoOcrBlock>;
+
+// OCR payload on the photo details response. `blocks` is empty when the row
+// predates geometry storage (text was extracted, but no overlay is possible).
+export const PhotoOcrData = z.object({
+  text: z.string(),
+  blocks: PhotoOcrBlock.array(),
+});
+export type PhotoOcrData = z.infer<typeof PhotoOcrData>;
+
 export const Photo = z.object({
   id: z.string().uuid(),
   camera: z.string().nullable(),
@@ -217,6 +236,9 @@ export const Photo = z.object({
     .lazy(() => PhotoMetadataSummary)
     .nullable()
     .optional(),
+  // OCR text + normalized block geometry; null when the photo has no OCR row,
+  // absent on older backends.
+  ocr: PhotoOcrData.nullable().optional(),
 });
 export type Photo = z.infer<typeof Photo>;
 

--- a/apps/frontend/src/components/lightbox/ContentViewer.tsx
+++ b/apps/frontend/src/components/lightbox/ContentViewer.tsx
@@ -40,6 +40,8 @@ export function ContentViewer({
   const [playing, setPlaying] = useState(true);
   const [rotationAngle, setRotationAngle] = useState(0);
   const [imageCacheKey, setImageCacheKey] = useState(0);
+  // "Live text": overlay selectable OCR text on the photo
+  const [showOcrText, setShowOcrText] = useState(false);
   // Tracks whether we should skip the rotation CSS transition on next render
   // (used to silently reset angle to 0 once the server-rotated image has loaded)
   const [suppressRotationTransition, setSuppressRotationTransition] = useState(false);
@@ -72,6 +74,7 @@ export function ContentViewer({
     setSlideshowProgress(0);
     setRotationAngle(0);
     setImageCacheKey(0);
+    setShowOcrText(false);
     pendingRotationReset.current = false;
     setSuppressRotationTransition(false);
   }, [mainSrc]);
@@ -121,6 +124,13 @@ export function ContentViewer({
   // Toggle slideshow function
   const toggleSlideshow = useCallback(() => {
     setIsSlideshowActive(prev => !prev);
+  }, []);
+
+  const ocrBlocks = photoDetails?.ocr?.blocks;
+  const hasOcrText = type === "photo" && !!ocrBlocks && ocrBlocks.length > 0;
+
+  const toggleOcrText = useCallback(() => {
+    setShowOcrText(prev => !prev);
   }, []);
 
   // Re-enable the CSS rotation transition after we have silently snapped back to 0.
@@ -255,6 +265,7 @@ export function ContentViewer({
     ],
     ["g", toggleFullscreen], // Toggle fullscreen mode
     ["s", toggleSlideshow], // Toggle slideshow mode
+    ["t", () => hasOcrText && toggleOcrText()], // Toggle live text selection
   ]);
 
   const bind = useGesture({
@@ -338,6 +349,9 @@ export function ContentViewer({
               slideshowInterval={slideshowInterval}
               setSlideshowInterval={setLocalSlideshowInterval}
               slideshowProgress={slideshowProgress}
+              hasOcrText={hasOcrText}
+              showOcrText={showOcrText}
+              toggleOcrText={toggleOcrText}
             />
 
             {/* Main photo/video with swipe navigation */}
@@ -411,6 +425,8 @@ export function ContentViewer({
                         imageCacheKey={imageCacheKey}
                         suppressRotationTransition={suppressRotationTransition}
                         onImageLoad={handleImageLoad}
+                        ocrBlocks={ocrBlocks ?? undefined}
+                        showOcrText={showOcrText}
                         {...(photoDetails ? { photoDetails } : {})}
                       />
                     </motion.div>

--- a/apps/frontend/src/components/lightbox/LightboxControls.tsx
+++ b/apps/frontend/src/components/lightbox/LightboxControls.tsx
@@ -11,6 +11,7 @@ import {
   IconRotate2 as RotateCCW,
   IconRotateClockwise2 as RotateCW,
   IconStar as Star,
+  IconTextRecognition as TextRecognition,
   IconTrash as Trash,
   IconX as X,
   IconZoomIn as ZoomIn,
@@ -57,6 +58,9 @@ export function LightboxControls({
   slideshowInterval,
   setSlideshowInterval,
   slideshowProgress,
+  hasOcrText,
+  showOcrText,
+  toggleOcrText,
 }: LightboxControlsProps) {
   const { t } = useTranslation();
 
@@ -206,8 +210,19 @@ export function LightboxControls({
 
       <Divider orientation="vertical" color="rgba(255,255,255,0.2)" />
 
-      {/* Group 2: View controls - Zoom & Fullscreen */}
+      {/* Group 2: View controls - Live text, Zoom & Fullscreen */}
       <Group gap={4} align="center">
+        {hasOcrText && (
+          <Tooltip
+            label={showOcrText ? t("lightbox.controls.livetextoff") : t("lightbox.controls.livetext")}
+            position="bottom"
+            withArrow
+          >
+            <ActionIcon variant="subtle" color={showOcrText ? "blue" : "gray"} onClick={toggleOcrText} size={28}>
+              <TextRecognition size={18} />
+            </ActionIcon>
+          </Tooltip>
+        )}
         {enableZoom && type === "photo" && (
           <Tooltip label={t("lightbox.controls.zoom")} position="bottom" withArrow>
             <ActionIcon variant="subtle" color="gray" onClick={toggleZoom} size={28}>

--- a/apps/frontend/src/components/lightbox/MediaDisplay.tsx
+++ b/apps/frontend/src/components/lightbox/MediaDisplay.tsx
@@ -1,7 +1,9 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { serverAddress } from "../../api_client/apiClient";
+import type { PhotoOcrBlock } from "../../api_client/photos/types";
 import { FaceOverlay } from "./FaceOverlay";
 import type { FaceLocationType } from "./lightbox.types";
+import { OcrTextOverlay } from "./OcrTextOverlay";
 import { VideoPlayer } from "./VideoPlayer";
 
 export type MediaDisplayProps = {
@@ -23,6 +25,8 @@ export type MediaDisplayProps = {
   imageCacheKey?: number;
   suppressRotationTransition?: boolean;
   onImageLoad?: () => void;
+  ocrBlocks?: PhotoOcrBlock[];
+  showOcrText?: boolean;
 };
 
 export function MediaDisplay({
@@ -44,8 +48,18 @@ export function MediaDisplay({
   imageCacheKey = 0,
   suppressRotationTransition = false,
   onImageLoad,
+  ocrBlocks,
+  showOcrText = false,
 }: MediaDisplayProps) {
   const imgRef = useRef<HTMLImageElement | null>(null);
+  // Natural pixel size of the loaded image; drives the OCR overlay's aspect
+  // ratio and is reset while a different image is loading.
+  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
+
+  const mediaKey = `${image_hash || id}-${imageCacheKey}`;
+  useEffect(() => {
+    setNaturalSize(null);
+  }, [mediaKey]);
 
   if (!id) return null;
 
@@ -99,6 +113,18 @@ export function MediaDisplay({
       ? `${serverAddress}/media/photos/${mediaHash}${cacheBustingParam}`
       : `${serverAddress}/media/thumbnails_big/${mediaHash}${cacheBustingParam}`;
 
+  const handleLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget;
+    setNaturalSize({ width: naturalWidth, height: naturalHeight });
+    if (isMainContent) onImageLoad?.();
+  };
+
+  // Shared by the image and the OCR overlay so the selectable text tracks
+  // zoom, pan and rotation exactly.
+  const mainTransition = isMainContent && !suppressRotationTransition ? "transform 0.3s ease-out" : "none";
+  const mainTransform = isMainContent
+    ? `translate(${offset.x}px, ${offset.y}px) scale(${scale}) rotate(${rotationAngle}deg)`
+    : "none";
   return (
     <div
       {...(isMainContent && bind ? bind() : {})}
@@ -120,12 +146,13 @@ export function MediaDisplay({
           loading="eager"
           onDragStart={handleDragStart}
           onDoubleClick={isMainContent && toggleZoom ? toggleZoom : undefined}
-          onLoad={isMainContent ? onImageLoad : undefined}
+          onLoad={handleLoad}
           style={{
-            transition: isMainContent && !suppressRotationTransition ? "transform 0.3s ease-out" : "none",
-            transform: isMainContent
-              ? `translate(${offset.x}px, ${offset.y}px) scale(${scale}) rotate(${rotationAngle}deg)`
-              : "none",
+            transition: mainTransition,
+            transform: mainTransform,
+            // Block display so the wrapper matches the image exactly — the
+            // inline baseline gap would offset the overlays a few pixels.
+            display: "block",
             maxHeight: "82vh",
             maxWidth: "100%",
             borderRadius: 8,
@@ -135,6 +162,19 @@ export function MediaDisplay({
             boxShadow: isMainContent ? "0 4px 16px rgba(0,0,0,0.1)" : "none",
           }}
         />
+        {isMainContent && showOcrText && ocrBlocks && ocrBlocks.length > 0 && naturalSize && naturalSize.width > 0 && (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              transition: mainTransition,
+              transform: mainTransform,
+              willChange: "transform",
+            }}
+          >
+            <OcrTextOverlay blocks={ocrBlocks} aspectRatio={naturalSize.height / naturalSize.width} />
+          </div>
+        )}
         {isMainContent && faceLocation && <FaceOverlay faceLocation={faceLocation} imageDimensions={imageDimensions} />}
       </div>
     </div>

--- a/apps/frontend/src/components/lightbox/OcrTextOverlay.test.tsx
+++ b/apps/frontend/src/components/lightbox/OcrTextOverlay.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for the "live text" OCR overlay.
+ *
+ * The backend serializer (PhotoSerializer.get_ocr) delivers blocks whose `box`
+ * is a four-corner quad normalized to [0, 1] of the OCR source image. The
+ * overlay maps those quads into a 1000-unit-wide SVG viewBox whose height
+ * follows the image aspect ratio, so x and y share one scale and the invisible
+ * selectable glyphs line up with the printed text underneath.
+ */
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PhotoOcrBlock } from "../../api_client/photos/types";
+import { OcrTextOverlay, placeBlock } from "./OcrTextOverlay";
+
+const axisAlignedBlock: PhotoOcrBlock = {
+  text: "TOTAL 12.34",
+  // Top-left quarter strip of the image: x 10%..60%, y 10%..20%
+  box: [
+    [0.1, 0.1],
+    [0.6, 0.1],
+    [0.6, 0.2],
+    [0.1, 0.2],
+  ],
+  confidence: 0.95,
+};
+
+describe("placeBlock", () => {
+  // A 2:1 landscape image -> viewBox is 1000 x 500 units.
+  const viewHeight = 500;
+
+  it("maps a normalized axis-aligned quad into viewBox units", () => {
+    const placed = placeBlock(axisAlignedBlock, viewHeight);
+    expect(placed).not.toBeNull();
+    expect(placed!.x).toBeCloseTo(100);
+    expect(placed!.y).toBeCloseTo(50);
+    expect(placed!.width).toBeCloseTo(500);
+    expect(placed!.height).toBeCloseTo(50);
+    expect(placed!.angle).toBeCloseTo(0);
+  });
+
+  it("derives the rotation angle from the top edge", () => {
+    // Top edge rises to the right in a square viewBox: 45 degrees downward
+    // slope in SVG coordinates (y grows down).
+    const rotated: PhotoOcrBlock = {
+      text: "slanted",
+      box: [
+        [0.1, 0.1],
+        [0.2, 0.2],
+        [0.15, 0.25],
+        [0.05, 0.15],
+      ],
+      confidence: 0.9,
+    };
+    const placed = placeBlock(rotated, 1000);
+    expect(placed).not.toBeNull();
+    expect(placed!.angle).toBeCloseTo(45);
+  });
+
+  it("rejects degenerate and malformed blocks", () => {
+    expect(
+      placeBlock(
+        {
+          text: "zero area",
+          box: [
+            [0.5, 0.5],
+            [0.5, 0.5],
+            [0.5, 0.5],
+            [0.5, 0.5],
+          ],
+        },
+        500
+      )
+    ).toBeNull();
+    expect(placeBlock({ text: "", box: axisAlignedBlock.box }, 500)).toBeNull();
+  });
+});
+
+describe("OcrTextOverlay", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = (blocks: PhotoOcrBlock[], aspectRatio = 0.5) => {
+    act(() => {
+      root.render(<OcrTextOverlay blocks={blocks} aspectRatio={aspectRatio} />);
+    });
+  };
+
+  it("renders each block's text as selectable transparent glyphs", () => {
+    render([axisAlignedBlock]);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    // viewBox height follows the aspect ratio so glyphs stay undistorted.
+    expect(svg!.getAttribute("viewBox")).toBe("0 0 1000 500");
+    const text = container.querySelector("text");
+    expect(text).not.toBeNull();
+    expect(text!.textContent).toBe("TOTAL 12.34");
+    expect(text!.getAttribute("fill")).toBe("transparent");
+    expect(text!.getAttribute("textLength")).not.toBeNull();
+  });
+
+  it("keeps the svg transparent to pointer events, glyphs interactive", () => {
+    render([axisAlignedBlock]);
+    const svg = container.querySelector("svg");
+    expect(svg!.style.pointerEvents).toBe("none");
+    const text = container.querySelector("text") as SVGTextElement;
+    expect(text.style.pointerEvents).toBe("auto");
+  });
+
+  it("renders nothing when every block is unplaceable", () => {
+    render([{ text: "", box: axisAlignedBlock.box }]);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("stops pointerdown on glyphs from bubbling out (would start a swipe)", () => {
+    render([axisAlignedBlock]);
+    let escaped = false;
+    const listener = () => {
+      escaped = true;
+    };
+    container.addEventListener("pointerdown", listener);
+    const text = container.querySelector("text") as SVGTextElement;
+    // jsdom lacks PointerEvent; a bubbling Event with the right type is enough
+    // to exercise the native capture-free stopPropagation listener.
+    text.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    container.removeEventListener("pointerdown", listener);
+    expect(escaped).toBe(false);
+  });
+});

--- a/apps/frontend/src/components/lightbox/OcrTextOverlay.tsx
+++ b/apps/frontend/src/components/lightbox/OcrTextOverlay.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import type { PhotoOcrBlock } from "../../api_client/photos/types";
+
+// The viewBox is a fixed 1000 user units wide; its height follows the image
+// aspect ratio so x and y use the same scale and glyphs are not distorted.
+const VIEW_WIDTH = 1000;
+
+export type OcrTextOverlayProps = {
+  blocks: PhotoOcrBlock[];
+  // naturalHeight / naturalWidth of the displayed image
+  aspectRatio: number;
+};
+
+type PlacedBlock = {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  // Rotation of the block's top edge, in degrees
+  angle: number;
+};
+
+// Turn a normalized quad into a translated/rotated rectangle in viewBox units.
+// The quad corners arrive clockwise from top-left, so the top edge gives the
+// baseline direction and the left edge the line height.
+export function placeBlock(block: PhotoOcrBlock, viewHeight: number): PlacedBlock | null {
+  if (!block.text || !Array.isArray(block.box) || block.box.length !== 4) return null;
+  const corners = block.box.map(([nx, ny]) => ({ x: nx * VIEW_WIDTH, y: ny * viewHeight }));
+  const [topLeft, topRight, , bottomLeft] = corners;
+  const width = Math.hypot(topRight.x - topLeft.x, topRight.y - topLeft.y);
+  const height = Math.hypot(bottomLeft.x - topLeft.x, bottomLeft.y - topLeft.y);
+  if (width <= 0 || height <= 0) return null;
+  const angle = (Math.atan2(topRight.y - topLeft.y, topRight.x - topLeft.x) * 180) / Math.PI;
+  return { text: block.text, x: topLeft.x, y: topLeft.y, width, height, angle };
+}
+
+/**
+ * Selectable "live text" layer over a photo, Apple Photos style.
+ *
+ * Renders each OCR block as an invisible SVG <text> stretched to its detected
+ * box, so the browser's native selection, copy, and context menu all work on
+ * text that visually sits on the image. The SVG root ignores pointer events —
+ * only the glyphs are interactive — so clicks on textless areas still reach
+ * the image below (zoom, pan, swipe).
+ */
+export function OcrTextOverlay({ blocks, aspectRatio }: OcrTextOverlayProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const viewHeight = VIEW_WIDTH * aspectRatio;
+
+  const placed = useMemo(
+    () => blocks.map(block => placeBlock(block, viewHeight)).filter((b): b is PlacedBlock => b !== null),
+    [blocks, viewHeight]
+  );
+
+  // Selection drags must not start a carousel swipe or a pan. Embla and
+  // use-gesture see events before React's synthetic handlers would, so the
+  // propagation stop has to be a native listener. It only fires for events
+  // originating on the glyphs — everything else passes through the svg.
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return undefined;
+    const stop = (event: Event) => event.stopPropagation();
+    const events = ["pointerdown", "mousedown", "touchstart"];
+    events.forEach(name => svg.addEventListener(name, stop));
+    return () => events.forEach(name => svg.removeEventListener(name, stop));
+  }, []);
+
+  if (!placed.length || !(viewHeight > 0)) return null;
+
+  return (
+    <svg
+      ref={svgRef}
+      data-testid="ocr-text-overlay"
+      viewBox={`0 0 ${VIEW_WIDTH} ${viewHeight}`}
+      preserveAspectRatio="none"
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+        pointerEvents: "none",
+        userSelect: "text",
+        WebkitUserSelect: "text",
+      }}
+    >
+      {placed.map((block, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <g key={index} transform={`translate(${block.x} ${block.y}) rotate(${block.angle})`}>
+          {/* Faint backdrop marking the block as selectable, like Live Text's glow */}
+          <rect
+            width={block.width}
+            height={block.height}
+            rx={Math.min(block.height * 0.2, 8)}
+            fill="rgba(255, 255, 255, 0.16)"
+            stroke="rgba(255, 255, 255, 0.35)"
+            strokeWidth={0.5}
+            pointerEvents="none"
+          />
+          <text
+            x={block.width / 2}
+            y={block.height / 2}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={block.height * 0.8}
+            textLength={block.width * 0.95}
+            lengthAdjust="spacingAndGlyphs"
+            fill="transparent"
+            style={{ pointerEvents: "auto", cursor: "text", whiteSpace: "pre" }}
+          >
+            {block.text}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/apps/frontend/src/components/lightbox/index.ts
+++ b/apps/frontend/src/components/lightbox/index.ts
@@ -4,5 +4,6 @@ export * from "./ImagePreloader";
 export * from "./Lightbox";
 export * from "./LightboxControls";
 export * from "./MediaDisplay";
+export * from "./OcrTextOverlay";
 export * from "./ThumbnailNavigation";
 export * from "./lightbox.types";

--- a/apps/frontend/src/components/lightbox/lightbox.types.ts
+++ b/apps/frontend/src/components/lightbox/lightbox.types.ts
@@ -78,6 +78,10 @@ export type LightboxControlsProps = {
   slideshowInterval: number;
   setSlideshowInterval: (interval: number) => void;
   slideshowProgress: number; // 0-100 percentage for progress ring
+  // Live text (selectable OCR text overlay)
+  hasOcrText: boolean;
+  showOcrText: boolean;
+  toggleOcrText: () => void;
 };
 
 export type ThumbnailNavigationProps = {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -502,7 +502,9 @@
       "zoom": "Zoom (Z)",
       "close": "Close (Escape)",
       "slideshow": "Slideshow (S)",
-      "stopslideshow": "Stop Slideshow (S)"
+      "stopslideshow": "Stop Slideshow (S)",
+      "livetext": "Select text in photo (T)",
+      "livetextoff": "Stop selecting text (T)"
     },
     "toolbar": {
       "pauseVideo": "Pause video (Space)",


### PR DESCRIPTION
Adds Apple Photos-style **live text** to the lightbox: when a photo has OCR results, you can toggle a text layer and select/copy the recognized text directly on the image.

Builds on the OCR pipeline from #1943 (now merged into `dev`); the branch is rebased onto `dev`, so the diff is just the live-text change.

## How it works

**Backend**
- The PP-OCR sidecar now returns `image_width`/`image_height` of the image it OCR'd; `PhotoOcr` stores them as `source_width`/`source_height` (migration 0137 (renumbered past #1944s 0136)). Block boxes are pixel coords in the OCR source (original file *or* big thumbnail depending on decodability), so without these dimensions the geometry has no reference frame.
- `PhotoSerializer` gains an `ocr` field: `{ text, blocks: [{ text, box, confidence }] }` with each `box` a 4-corner quad normalized to `[0, 1]` — display-agnostic, since every rendition shares the photo's aspect ratio. Legacy rows without stored dimensions serialize with `blocks: []` (text only, no overlay) until re-OCR'd.

**Privacy** ⚠️ deliberate contract change, please review
- `OcrPrivacyTest` previously asserted OCR text never reaches *any* API surface. Live text needs it on the photo detail endpoint — but that endpoint also answers for shared and public photos (anonymously, even). The `ocr` field is therefore **owner-gated**: `get_ocr` checks the request user against the photo owner and returns `null` for everyone else (and when there is no request context at all).
- The privacy tests now enforce the narrowed contract: search responses and all other serializers still never contain OCR text; shared viewers and anonymous public viewers get `ocr: null`; a static sweep asserts no serializer other than the allow-listed `PhotoSerializer` declares an `ocr` field.

**Frontend**
- New `OcrTextOverlay`: an SVG layer over the image rendering each block as *transparent* selectable text stretched to its detected quad (`textLength` + per-block rotation), pdf.js-text-layer style — native browser selection, copy, and context menu work right on the photo. A faint backdrop marks selectable regions.
- The overlay div shares the image's CSS transform, so text tracks zoom, pan, and rotation exactly. The SVG root ignores pointer events (clicks on textless areas still zoom/pan/swipe); native `pointerdown` listeners on the glyphs stop propagation so selection drags don't start an embla swipe or a pan.
- Toggle button (Tabler `IconTextRecognition`) in the lightbox controls, shown only when the current photo actually has OCR blocks, plus a `T` keyboard shortcut. State resets per photo.
- `Photo` zod schema gains `ocr` (optional + nullable, so older backends and photos without OCR keep parsing).

## Tests
- Backend: 41 tests in `test_photo_ocr` + `test_ocr_search` cover dimension storage, normalization/clamping, malformed-block skipping, legacy rows, and the new owner/shared/anonymous privacy matrix. Full suite: 1851 tests, green except 4 pre-existing Windows-environment failures unrelated to this change (cp1252 emoji prints in trash tests, case-insensitive `.MOV` glob, a perf-timing flake).
- Frontend: geometry unit tests for `placeBlock` (mapping, rotation, degenerate quads), rendering/selection-isolation tests for `OcrTextOverlay`, and zod schema tests. Full vitest suite green (95 tests); eslint clean; `tsc --noEmit` diffed against the branch baseline — no new errors.

## Notes
- Existing OCR rows predate the dimension fields, so the overlay appears only after photos are (re-)OCR'd (`full_scan`, or the engine-mismatch path when switching models).
- Word-level selection inside a line works via native character-level selection; blocks are PP-OCR detection lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


