### PR TITLE
fix: stop the constance admin 500ing on FACE_RECOGNITION_MODEL

### DIFF
--- a/apps/backend/api/tests/test_constance_config.py
+++ b/apps/backend/api/tests/test_constance_config.py
@@ -1,0 +1,67 @@
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+
+from api.tests.utils import create_test_user
+
+
+class ConstanceAdminTest(TestCase):
+    """The constance admin has to render for every key in CONSTANCE_CONFIG.
+
+    ConstanceForm walks the whole config on __init__, so a single malformed
+    entry takes the entire page down rather than just its own row.
+    """
+
+    def setUp(self):
+        self.admin = create_test_user(is_admin=True)
+        self.client.force_login(self.admin)
+
+    def test_constance_changelist_renders(self):
+        response = self.client.get(reverse("admin:constance_config_changelist"))
+        self.assertEqual(response.status_code, 200)
+
+
+class ConstanceAdditionalFieldsTest(TestCase):
+    """Guard the class of bug, not just the one instance of it.
+
+    A CONSTANCE_CONFIG entry may declare its type either as a Python type or as
+    the name of a CONSTANCE_ADDITIONAL_FIELDS entry. constance tells the two
+    apart with ``config_type not in settings.ADDITIONAL_FIELDS and not
+    isinstance(default, config_type)`` -- so a name with no matching additional
+    field falls through to ``isinstance(default, "some_string")``, which raises
+    TypeError and 500s the admin on every install.
+    """
+
+    def test_every_named_field_type_is_defined(self):
+        named_types = {
+            name: options[2]
+            for name, options in settings.CONSTANCE_CONFIG.items()
+            if len(options) == 3 and isinstance(options[2], str)
+        }
+        undefined = {
+            name: field_type
+            for name, field_type in named_types.items()
+            if field_type not in settings.CONSTANCE_ADDITIONAL_FIELDS
+        }
+        self.assertEqual(
+            undefined,
+            {},
+            "CONSTANCE_CONFIG entries name a custom field type that is missing "
+            "from CONSTANCE_ADDITIONAL_FIELDS; the constance admin raises "
+            "TypeError on these",
+        )
+
+    def test_defaults_are_valid_choices_for_named_field_types(self):
+        """A default outside its own choice list makes the admin form invalid."""
+        for name, options in settings.CONSTANCE_CONFIG.items():
+            if len(options) != 3 or not isinstance(options[2], str):
+                continue
+            field = settings.CONSTANCE_ADDITIONAL_FIELDS.get(options[2])
+            if not field or len(field) < 2:
+                continue
+            choices = field[1].get("choices")
+            if not choices:
+                continue
+            with self.subTest(key=name):
+                values = [value for value, _label in choices]
+                self.assertIn(str(options[0]).lower(), [v.lower() for v in values])

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -214,6 +214,23 @@ CONSTANCE_ADDITIONAL_FIELDS = {
             ),
         },
     ],
+    "face_recognition_model": [
+        "django.forms.fields.ChoiceField",
+        {
+            "widget": "django.forms.Select",
+            # The InsightFace model packs carried by api.ml_models.ML_MODELS
+            # under MlTypes.FACE_RECOGNITION, labelled as the frontend's
+            # selector labels them (SiteSettings.tsx). There is no "none" entry:
+            # face recognition cannot be turned off from here.
+            "choices": (
+                ("buffalo_sc", "buffalo_sc (lightweight, default)"),
+                ("buffalo_s", "buffalo_s"),
+                ("buffalo_m", "buffalo_m"),
+                ("buffalo_l", "buffalo_l (most accurate)"),
+                ("antelopev2", "antelopev2"),
+            ),
+        },
+    ],
 }
 CONSTANCE_CONFIG = {
     "ALLOW_REGISTRATION": (False, "Publicly allow user registration", bool),


### PR DESCRIPTION
## The bug

`GET /admin/constance/config/` returns a 500 on every install — not just ones that have touched a face recognition setting:

```
File "constance/admin.py", line 93, in changelist_view
    form = form_cls(initial=initial, request=request)
File "constance/forms.py", line 94, in __init__
    if config_type not in settings.ADDITIONAL_FIELDS and not isinstance(default, config_type):
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

The site settings admin page is the only UI for a handful of keys that the React settings page does not expose, so this takes all of them out.

## Why

A `CONSTANCE_CONFIG` entry may declare its type either as a Python type or as the *name* of a `CONSTANCE_ADDITIONAL_FIELDS` entry. `FACE_RECOGNITION_MODEL` declared the latter:

```python
"FACE_RECOGNITION_MODEL": (
    "buffalo_sc",
    "Face recognition model",
    "face_recognition_model",
),
```

…but `"face_recognition_model"` was never added to `CONSTANCE_ADDITIONAL_FIELDS`, which defined only `map_api_provider`, `map_tile_provider`, `captioning_model`, `llm_model`, `tagging_model` and `ocr_model`.

constance tells the two forms apart with a single short-circuit:

```python
if config_type not in settings.ADDITIONAL_FIELDS and not isinstance(default, config_type):
```

An undefined name fails the first test, so evaluation falls through to `isinstance("buffalo_sc", "face_recognition_model")` — a string as the second argument — and raises `TypeError`.

`ConstanceForm` builds the form for the **whole** config in `__init__`, so one malformed entry takes down the entire changelist rather than just its own row.

## The fix

Add the missing `ChoiceField`, mirroring the sibling model entries. The choices are the five `MlTypes.FACE_RECOGNITION` packs carried by [`api/ml_models.py`](https://github.com/LibrePhotos/librephotos/blob/dev/apps/backend/api/ml_models.py), labelled the way the frontend's selector labels them in [`SiteSettings.tsx`](https://github.com/LibrePhotos/librephotos/blob/dev/apps/frontend/src/components/settings/SiteSettings.tsx#L66):

| value | `ML_MODELS` id |
|---|---|
| `buffalo_sc` | 5 |
| `buffalo_s` | 7 |
| `buffalo_m` | 10 |
| `buffalo_l` | 12 |
| `antelopev2` | 13 |

The two lists already agreed exactly, so nothing here is invented — the dropdown now offers what the REST API has been accepting all along.

Unlike the `llm_model` and `ocr_model` siblings there is no `none` entry: face recognition cannot be switched off from this setting, and `_is_model_selected()` compares `FACE_RECOGNITION_MODEL` by equality rather than through `_is_model_not_selected()`.

The single-container image inherits this for free — since #1947 `production_noproxy.py` is an overlay on `production.py`, and `test_settings_noproxy.py` already pins the two to the same constance surface.

## Tests

`api/tests/test_constance_config.py` guards the class of bug rather than this one instance of it:

- **`test_every_named_field_type_is_defined`** — every string-typed entry in `CONSTANCE_CONFIG` must exist in `CONSTANCE_ADDITIONAL_FIELDS`. Fails with `{'FACE_RECOGNITION_MODEL': 'face_recognition_model'} != {}` before the fix. This is the one that matters: the next setting added this way is caught at test time instead of in the admin.
- **`test_defaults_are_valid_choices_for_named_field_types`** — every such default must be a valid choice of its own field. This covers the adjacent failure where the page renders but refuses to save; it passed before this change and is here to keep passing.
- **`test_constance_changelist_renders`** — the actual 500 repro, hitting the changelist as a superuser.

Verification:

- Full backend suite: 1891 tests, OK (21 skipped, 2 expected failures)
- `ruff check` / `ruff format --check` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
