### PR TITLE
fix(backend): never let a failed model download land in the model directory

### DIFF
--- a/apps/backend/api/ml_models.py
+++ b/apps/backend/api/ml_models.py
@@ -241,37 +241,45 @@ def _model_target_exists(model_folder, model):
     return True
 
 
+def _unpack_archive(archive_path, model_folder, model):
+    unpack_command = model["unpack-command"]
+    if unpack_command == "tar -zxC":
+        with tarfile.open(archive_path, mode="r:gz") as tar:
+            tar.extractall(path=model_folder)
+    elif unpack_command == "tar -xvf":
+        with tarfile.open(archive_path, mode="r:") as tar:
+            tar.extractall(path=model_folder)
+    elif unpack_command == "zip":
+        target_dir = model_folder / model["target-dir"]
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(path=target_dir)
+
+
 def download_model(model):
     model = model.copy()
     if not _is_model_selected(model):
         util.logger.info(f"Skipping unselected model {model['name']}")
         return
 
-    util.logger.info(f"Downloading model {model['name']}")
     model_folder = Path(settings.MEDIA_ROOT) / "data_models"
 
     if _model_target_exists(model_folder, model):
         util.logger.info(f"Model {model['name']} already downloaded")
         return
 
+    util.logger.info(f"Downloading model {model['name']}")
     target_path = _get_download_target(model_folder, model)
 
     _download_file(model["url"], target_path, model["name"])
 
-    if model["unpack-command"] == "tar -zxC":
-        with tarfile.open(target_path, mode="r:gz") as tar:
-            tar.extractall(path=model_folder)
-        os.remove(target_path)
-    if model["unpack-command"] == "tar -xvf":
-        with tarfile.open(target_path, mode="r:") as tar:
-            tar.extractall(path=model_folder)
-        os.remove(target_path)
-    if model["unpack-command"] == "zip":
-        target_dir = model_folder / model["target-dir"]
-        target_dir.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(target_path) as archive:
-            archive.extractall(path=target_dir)
-        os.remove(target_path)
+    if model["unpack-command"]:
+        try:
+            _unpack_archive(target_path, model_folder, model)
+        finally:
+            # Drop the archive whether or not extraction worked: a corrupt one
+            # left behind is never useful and would only be re-read next run.
+            Path(target_path).unlink(missing_ok=True)
 
     if model.get("additional_files"):
         for additional_file in model["additional_files"]:
@@ -285,34 +293,68 @@ def download_model(model):
 
 
 def _download_file(url, target_path, model_name):
-    """Helper function to download a single file with progress tracking"""
+    """Download a single file with progress tracking.
+
+    The download is streamed to a temporary sibling and only moved into place
+    once it completed successfully. Nothing that is not a fully downloaded file
+    ever reaches ``target_path``, so a failed transfer cannot leave behind a
+    corrupt archive or - worse, for models that are stored unpacked - a file
+    that later checks happily accept as an installed model.
+    """
     target_path = Path(target_path)
     target_path.parent.mkdir(parents=True, exist_ok=True)
-    response = requests.get(url, stream=True, allow_redirects=True)
-    total_size = int(response.headers.get("content-length", 0))
-    block_size = 1024
-    current_progress = 0
-    previous_percentage = -1
+    partial_path = target_path.with_name(target_path.name + ".part")
 
-    with open(target_path, "wb") as target_file:
-        for chunk in response.iter_content(chunk_size=block_size):
-            if chunk:
-                target_file.write(chunk)
-                current_progress += len(chunk)
+    try:
+        with requests.get(url, stream=True, allow_redirects=True) as response:
+            # Error responses have a body too. Without this check a "404: Entry
+            # not found" page gets written out as if it were the model.
+            response.raise_for_status()
 
-                if total_size > 0:
-                    percentage = math.floor((current_progress / total_size) * 100)
+            total_size = int(response.headers.get("content-length", 0))
+            block_size = 1024
+            current_progress = 0
+            previous_percentage = -1
 
-                    if percentage != previous_percentage:
-                        util.logger.info(
-                            f"Downloading {model_name}: {current_progress}/{total_size} ({percentage}%)"
-                        )
-                        previous_percentage = percentage
+            with open(partial_path, "wb") as target_file:
+                for chunk in response.iter_content(chunk_size=block_size):
+                    if chunk:
+                        target_file.write(chunk)
+                        current_progress += len(chunk)
 
-    if total_size == 0:
-        util.logger.info(
-            f"Downloaded {model_name}: {current_progress} bytes (size unknown during transfer)"
-        )
+                        if total_size > 0:
+                            percentage = math.floor(
+                                (current_progress / total_size) * 100
+                            )
+
+                            if percentage != previous_percentage:
+                                util.logger.info(
+                                    f"Downloading {model_name}: {current_progress}/{total_size} ({percentage}%)"
+                                )
+                                previous_percentage = percentage
+
+            # content-length describes the encoded body, so it only bounds the
+            # bytes we wrote when requests did not decompress on the fly.
+            content_encoding = response.headers.get(
+                "content-encoding", "identity"
+            ).lower()
+            is_decoded = content_encoding not in ("", "identity")
+
+        if total_size > 0 and not is_decoded and current_progress != total_size:
+            raise OSError(
+                f"Incomplete download for {model_name}: got {current_progress} of "
+                f"{total_size} bytes from {url}"
+            )
+
+        if total_size == 0:
+            util.logger.info(
+                f"Downloaded {model_name}: {current_progress} bytes (size unknown during transfer)"
+            )
+
+        os.replace(partial_path, target_path)
+    except Exception:
+        partial_path.unlink(missing_ok=True)
+        raise
 
 
 def download_models(user):
@@ -326,9 +368,21 @@ def download_models(user):
     model_folder = Path(settings.MEDIA_ROOT) / "data_models"
     model_folder.mkdir(parents=True, exist_ok=True)
 
+    failures = []
     for idx, model in enumerate(ML_MODELS):
-        download_model(model)
+        try:
+            download_model(model)
+        except Exception as error:
+            # download_models is chained ahead of scans and setup steps, so a
+            # single unavailable model must not take the rest of the chain -
+            # or the job status - down with it.
+            util.logger.exception(f"Failed to download model {model['name']}")
+            failures.append(f"{model['name']}: {error}")
         lrj.update_progress(current=idx + 1)
+
+    if failures:
+        lrj.fail("Failed to download " + ", ".join(failures))
+        return
 
     lrj.complete()
 

--- a/apps/backend/api/tests/test_ml_models.py
+++ b/apps/backend/api/tests/test_ml_models.py
@@ -1,16 +1,24 @@
+import tarfile
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
+import requests
 from constance.test import override_config
 from django.test import TestCase, override_settings
 
 from api.ml_models import (
     ML_MODELS,
     MlTypes,
+    _download_file,
     _is_model_selected,
     _model_target_exists,
     do_all_models_exist,
+    download_model,
+    download_models,
 )
+from api.models.long_running_job import LongRunningJob
+from api.tests.utils import create_test_user
 
 
 def _ocr_model(tier):
@@ -122,3 +130,152 @@ class OcrModelTargetExistsTest(TestCase):
             model_folder = Path(temp_dir) / "data_models"
             model_folder.mkdir(parents=True)
             self.assertFalse(_model_target_exists(model_folder, model))
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests`` response."""
+
+    def __init__(self, chunks=(), status_code=200, headers=None):
+        self._chunks = list(chunks)
+        self.status_code = status_code
+        self.headers = headers if headers is not None else {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Error", response=self)
+
+    def iter_content(self, chunk_size=1):
+        yield from self._chunks
+
+
+class DownloadFileTest(TestCase):
+    """A download either lands complete, or it lands nothing at all."""
+
+    def test_error_response_body_is_not_written(self):
+        # Hugging Face answers a missing file with a 15 byte "Entry not found"
+        # body, which used to be saved as the model and later blow up as a
+        # corrupt archive far away from the actual cause.
+        body = b"Entry not found"
+        response = _FakeResponse(
+            chunks=[body],
+            status_code=404,
+            headers={"content-length": str(len(body))},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "ocr" / "ppocrv6_small.tar.gz"
+            with patch("api.ml_models.requests.get", return_value=response):
+                with self.assertRaises(requests.HTTPError):
+                    _download_file("https://example.invalid/x", target, "ppocrv6_small")
+
+            self.assertFalse(target.exists())
+            self.assertEqual([], list(target.parent.iterdir()))
+
+    def test_successful_download_is_written(self):
+        payload = b"a" * 2048
+        response = _FakeResponse(
+            chunks=[payload[:1024], payload[1024:]],
+            headers={"content-length": str(len(payload))},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "nested" / "model.onnx"
+            with patch("api.ml_models.requests.get", return_value=response):
+                _download_file("https://example.invalid/x", target, "model")
+
+            self.assertEqual(payload, target.read_bytes())
+            self.assertEqual([target], list(target.parent.iterdir()))
+
+    def test_truncated_download_is_rejected(self):
+        response = _FakeResponse(
+            chunks=[b"half"],
+            headers={"content-length": "2048"},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "model.onnx"
+            with patch("api.ml_models.requests.get", return_value=response):
+                with self.assertRaises(OSError):
+                    _download_file("https://example.invalid/x", target, "model")
+
+            self.assertFalse(target.exists())
+            self.assertEqual([], list(target.parent.iterdir()))
+
+    def test_transparently_decompressed_body_is_not_treated_as_truncated(self):
+        # requests decodes content-encoding on the fly, so the bytes written can
+        # legitimately differ from the advertised content-length.
+        payload = b"decompressed payload, longer than the encoded body"
+        response = _FakeResponse(
+            chunks=[payload],
+            headers={"content-length": "10", "content-encoding": "gzip"},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "model.onnx"
+            with patch("api.ml_models.requests.get", return_value=response):
+                _download_file("https://example.invalid/x", target, "model")
+
+            self.assertEqual(payload, target.read_bytes())
+
+
+@override_config(OCR_MODEL="ppocrv6_small")
+class DownloadModelFailureTest(TestCase):
+    def test_corrupt_archive_is_not_left_behind(self):
+        model = _ocr_model("small")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            media_root = Path(temp_dir) / "protected_media"
+            model_folder = media_root / "data_models"
+            archive = model_folder / (model["target-dir"] + ".tar.gz")
+
+            def fake_download(url, target_path, model_name):
+                target_path = Path(target_path)
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_bytes(b"Entry not found")
+
+            with override_settings(MEDIA_ROOT=str(media_root)):
+                with patch("api.ml_models._download_file", side_effect=fake_download):
+                    with self.assertRaises(tarfile.ReadError):
+                        download_model(model)
+
+            self.assertFalse(archive.exists())
+            self.assertFalse(_model_target_exists(model_folder, model))
+
+
+class DownloadModelsJobTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    def test_one_failing_model_does_not_stop_the_others(self):
+        attempted = []
+
+        def fake_download_model(model):
+            attempted.append(model["name"])
+            if model["name"] == "places365":
+                raise requests.HTTPError("404 Error")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with override_settings(MEDIA_ROOT=str(Path(temp_dir) / "protected_media")):
+                with patch(
+                    "api.ml_models.download_model", side_effect=fake_download_model
+                ):
+                    download_models(self.user)
+
+        self.assertEqual([m["name"] for m in ML_MODELS], attempted)
+
+        job = LongRunningJob.objects.get(job_type=LongRunningJob.JOB_DOWNLOAD_MODELS)
+        self.assertTrue(job.failed)
+        self.assertTrue(job.finished)
+        self.assertIn("places365", job.result["error"])
+        self.assertEqual(len(ML_MODELS), job.progress_current)
+
+    def test_job_completes_when_every_model_downloads(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with override_settings(MEDIA_ROOT=str(Path(temp_dir) / "protected_media")):
+                with patch("api.ml_models.download_model"):
+                    download_models(self.user)
+
+        job = LongRunningJob.objects.get(job_type=LongRunningJob.JOB_DOWNLOAD_MODELS)
+        self.assertFalse(job.failed)
+        self.assertTrue(job.finished)


### PR DESCRIPTION
## The error

Reported from a deployment with `OCR_MODEL = ppocrv6_small`:

```
ml_models.py : _download_file : INFO : Downloading ppocrv6_small: 15/15 (100%)
monitor.py : monitor : ERROR : Failed 'api.ml_models.download_models' - not a gzip file
gzip.BadGzipFile: Not a gzipped file (b'En')
tarfile.ReadError: not a gzip file
```

Those 15 bytes are Hugging Face's `Entry not found` 404 page. `_download_file` never checked the HTTP status, so it wrote the error body to `ppocrv6_small.tar.gz` and the failure only surfaced later in `tarfile.open`, pointing at the archive rather than at the download.

## Why it is worth fixing beyond the confusing traceback

- **The archived models fail late and loudly.** Annoying, but recoverable.
- **The unpacked ones fail silently and permanently.** `resnet18`, `mistral`, `siglip2` and `moondream` have no `unpack-command`, so the 404 body is left sitting *at the final target path*. `_model_target_exists` only checks that the path exists, so from then on the model reports as installed, `do_all_models_exist()` returns `True`, and inference loads a text file. Nothing ever repairs it.
- **One bad model took down the whole chain.** `download_models` is chained ahead of scans and setup (`views.py`, `faces.py`, `serializers/user.py`). The exception aborted every later model *and* every later step in the chain, and since `lrj.complete()` was never reached the job stayed stuck reporting "running".

## Changes

- `raise_for_status()` before a single byte is written.
- Stream to a `.part` sibling, `os.replace` into place only on success — a failed or interrupted download now leaves nothing behind.
- Reject a body shorter than its `content-length`, skipping the check when `content-encoding` shows requests decompressed the stream (there the length does not describe the bytes written).
- Remove the archive even when extraction raises, so a corrupt one is not re-read next run.
- Continue past a failing model, then `lrj.fail()` with the collected reasons instead of leaving the job running forever.

## Tests

`api/tests/test_ml_models.py`, 7 new cases: error body never written, partial file cleaned up, truncated download rejected, transparently decompressed body *not* misread as truncated, successful download written whole, corrupt archive removed, and the job continuing past one failure and reporting it.

Full backend suite: 1853 tests, green (one unrelated pre-existing flake in `test_hamming_distance_performance`, a timing assertion that only trips under machine load and passes in isolation).

## Note — separate from this PR

The three OCR bundles are not actually published: `derneuere/librephotos_models` currently holds only `blip_large.tar.gz`, so `ppocrv6_tiny`, `ppocrv6_small` and `ppocrv6_medium` all 404. This PR makes that failure legible and harmless, but selecting an OCR model still cannot work until the bundles are uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
