### PR TITLE
feat: sha256-pinned model downloads served from our own mirror

### DIFF
--- a/apps/backend/api/ml_models.py
+++ b/apps/backend/api/ml_models.py
@@ -1,3 +1,4 @@
+import hashlib
 import math
 import os
 import tarfile
@@ -23,6 +24,14 @@ class MlTypes:
     OCR = "ocr"
 
 
+class ModelChecksumError(Exception):
+    """A downloaded file's sha256 did not match the pinned value.
+
+    Treated exactly like any other failed download: the partial file is
+    cleaned up by ``_download_file`` and nothing ever reaches the model dir.
+    """
+
+
 ML_MODELS = [
     {
         "id": 1,
@@ -31,6 +40,7 @@ ML_MODELS = [
         "type": MlTypes.CAPTIONING,
         "unpack-command": "tar -zxC",
         "target-dir": "im2txt",
+        "sha256": "980670c0365c0e32b5fecfc0907bfee4742bcd6a40e0d6ac5692c69bbd49ccc4",
     },
     {
         "id": 2,
@@ -39,6 +49,7 @@ ML_MODELS = [
         "type": MlTypes.CLIP,
         "unpack-command": "tar -zxC",
         "target-dir": "clip-embeddings",
+        "sha256": "3d2f66350b75127024603dfaff55d4b981461363072d9697aa88d472440ecb4e",
     },
     {
         "id": 3,
@@ -47,6 +58,7 @@ ML_MODELS = [
         "type": MlTypes.CATEGORIES,
         "unpack-command": "tar -zxC",
         "target-dir": "places365",
+        "sha256": "27792ffcd1f6a4de7abebdea046dda0916f9cd12eba7bed7b5f51f120f91f0d8",
     },
     {
         "id": 4,
@@ -55,14 +67,20 @@ ML_MODELS = [
         "type": MlTypes.CATEGORIES,
         "unpack-command": None,
         "target-dir": "resnet18-5c106cde.pth",
+        "sha256": "5c106cde386e87d4033832f2996f5493238eda96ccf559d1d62760c4de0613f8",
     },
     {
+        # InsightFace buffalo_* and antelopev2 bundles are licensed for
+        # NON-COMMERCIAL RESEARCH USE ONLY, so they deliberately stay on their
+        # upstream github.com/deepinsight release URLs and are NOT mirrored to
+        # the LibrePhotos Hugging Face mirror.
         "id": 5,
         "name": "buffalo_sc",
         "url": "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip",
         "type": MlTypes.FACE_RECOGNITION,
         "unpack-command": "zip",
         "target-dir": "face_recognition/models/buffalo_sc",
+        "sha256": "57d31b56b6ffa911c8a73cfc1707c73cab76efe7f13b675a05223bf42de47c72",
     },
     {
         "id": 7,
@@ -71,6 +89,7 @@ ML_MODELS = [
         "type": MlTypes.FACE_RECOGNITION,
         "unpack-command": "zip",
         "target-dir": "face_recognition/models/buffalo_s",
+        "sha256": "d85a87f503f691807cd8bb97128bdf7a0660326cd9cd02657127fa978bab8b5e",
     },
     {
         "id": 6,
@@ -79,6 +98,7 @@ ML_MODELS = [
         "type": MlTypes.CAPTIONING,
         "unpack-command": "tar -zxC",
         "target-dir": "blip",
+        "sha256": "7c730d83bfdf4def7e9cca070e88b89192e61b8b1e7b64179b182e03922179f8",
     },
     {
         "id": 10,
@@ -87,30 +107,35 @@ ML_MODELS = [
         "type": MlTypes.FACE_RECOGNITION,
         "unpack-command": "zip",
         "target-dir": "face_recognition/models/buffalo_m",
+        "sha256": "d98264bd8f2dc75cbc2ddce2a14e636e02bb857b3051c234b737bf3b614edca9",
     },
     {
         "id": 8,
         "name": "mistral-7b-instruct-v0.2.Q5_K_M",
-        "url": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q5_K_M.gguf?download=true",
+        "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/mistral/mistral-7b-instruct-v0.2.Q5_K_M.gguf?download=true",
         "type": MlTypes.LLM,
         "unpack-command": None,
         "target-dir": "mistral-7b-instruct-v0.2.Q5_K_M.gguf",
+        "sha256": "b85cdd596ddd76f3194047b9108a73c74d77ba04bef49255a50fc0cfbda83d32",
     },
     {
         "id": 11,
         "name": "siglip2",
-        "url": "https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/vision_model.onnx",
+        "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/siglip2/vision_model.onnx",
         "type": MlTypes.TAGGING,
         "unpack-command": None,
         "target-dir": "siglip2/vision_model.onnx",
+        "sha256": "49ae4958b1098ca995e929d646f7be05a69c65e6344beae07d58c6598ffc5210",
         "additional_files": [
             {
-                "url": "https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/onnx/text_model.onnx",
+                "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/siglip2/text_model.onnx",
                 "target": "siglip2/text_model.onnx",
+                "sha256": "d28c21c7f12c38b0ec43aacb7ce2228fba6bd6b20641802ef2b29809ece46af8",
             },
             {
-                "url": "https://huggingface.co/onnx-community/siglip2-base-patch16-384-ONNX/resolve/main/tokenizer.model",
+                "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/siglip2/tokenizer.model",
                 "target": "siglip2/tokenizer.model",
+                "sha256": "61a7b147390c64585d6c3543dd6fc636906c9af3865a5548f27f31aee1d4c8e2",
             },
         ],
     },
@@ -121,6 +146,7 @@ ML_MODELS = [
         "type": MlTypes.FACE_RECOGNITION,
         "unpack-command": "zip",
         "target-dir": "face_recognition/models/buffalo_l",
+        "sha256": "80ffe37d8a5940d59a7384c201a2a38d4741f2f3c51eef46ebb28218a7b0ca2f",
     },
     {
         "id": 13,
@@ -129,6 +155,7 @@ ML_MODELS = [
         "type": MlTypes.FACE_RECOGNITION,
         "unpack-command": "zip",
         "target-dir": "face_recognition/models/antelopev2",
+        "sha256": "8e182f14fc6e80b3bfa375b33eb6cff7ee05d8ef7633e738d1c89021dcf0c5c5",
     },
     {
         "id": 14,
@@ -137,6 +164,7 @@ ML_MODELS = [
         "type": MlTypes.OCR,
         "unpack-command": "tar -zxC",
         "target-dir": "ocr/ppocrv6_tiny",
+        "sha256": "7e534d86a0cb6335c769993f6fd9a29f752b6ed98e93f60808649870baa5440b",
     },
     {
         "id": 15,
@@ -145,6 +173,7 @@ ML_MODELS = [
         "type": MlTypes.OCR,
         "unpack-command": "tar -zxC",
         "target-dir": "ocr/ppocrv6_small",
+        "sha256": "241769eb7750b4a43141a509bee8ac6893517c8b41ec3b5e5c45bdd4fde47c21",
     },
     {
         "id": 16,
@@ -153,19 +182,22 @@ ML_MODELS = [
         "type": MlTypes.OCR,
         "unpack-command": "tar -zxC",
         "target-dir": "ocr/ppocrv6_medium",
+        "sha256": "21232b79847cd56d5cae801d3364f95e508b40bb0ce159f31687e63c63959a0b",
     },
     {
         # Moondream 2 GGUF model for llama-cpp-python multimodal support
         "id": 9,
         "name": "moondream",
-        "url": "https://huggingface.co/moondream/moondream-2b-2025-04-14-4bit/resolve/main/moondream2-text-model-f16.gguf?download=true",
+        "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/moondream/moondream2-text-model-f16.gguf?download=true",
         "type": MlTypes.MOONDREAM,
         "unpack-command": None,
         "target-dir": "moondream2-text-model-f16.gguf",
+        "sha256": "4e17e9107fb8781629b3c8ce177de57ffeae90fe14adcf7b99f0eef025889696",
         "additional_files": [
             {
-                "url": "https://huggingface.co/moondream/moondream-2b-2025-04-14-4bit/resolve/main/moondream2-mmproj-f16.gguf?download=true",
+                "url": "https://huggingface.co/derneuere/librephotos_models/resolve/main/moondream/moondream2-mmproj-f16.gguf?download=true",
                 "target": "moondream2-mmproj-f16.gguf",
+                "sha256": "4cc1cb3660d87ff56432ebeb7884ad35d67c48c7b9f6b2856f305e39c38eed8f",
             }
         ],
     },
@@ -271,7 +303,7 @@ def download_model(model):
     util.logger.info(f"Downloading model {model['name']}")
     target_path = _get_download_target(model_folder, model)
 
-    _download_file(model["url"], target_path, model["name"])
+    _download_file(model["url"], target_path, model["name"], model.get("sha256"))
 
     if model["unpack-command"]:
         try:
@@ -289,10 +321,11 @@ def download_model(model):
                     additional_file["url"],
                     additional_target,
                     f"{model['name']} ({additional_file['target']})",
+                    additional_file.get("sha256"),
                 )
 
 
-def _download_file(url, target_path, model_name):
+def _download_file(url, target_path, model_name, expected_sha256=None):
     """Download a single file with progress tracking.
 
     The download is streamed to a temporary sibling and only moved into place
@@ -300,10 +333,20 @@ def _download_file(url, target_path, model_name):
     ever reaches ``target_path``, so a failed transfer cannot leave behind a
     corrupt archive or - worse, for models that are stored unpacked - a file
     that later checks happily accept as an installed model.
+
+    When ``expected_sha256`` is given, the digest is computed over the streamed
+    bytes and compared before the file is moved into place (so archives are
+    verified before they are unpacked and plain files before they land at their
+    final path). A mismatch is treated exactly like any other failed download:
+    the partial file is removed and nothing reaches ``target_path``. Entries
+    without a pin skip verification so a future hashless entry cannot crash the
+    download.
     """
     target_path = Path(target_path)
     target_path.parent.mkdir(parents=True, exist_ok=True)
     partial_path = target_path.with_name(target_path.name + ".part")
+
+    hasher = hashlib.sha256() if expected_sha256 else None
 
     try:
         with requests.get(url, stream=True, allow_redirects=True) as response:
@@ -320,6 +363,8 @@ def _download_file(url, target_path, model_name):
                 for chunk in response.iter_content(chunk_size=block_size):
                     if chunk:
                         target_file.write(chunk)
+                        if hasher is not None:
+                            hasher.update(chunk)
                         current_progress += len(chunk)
 
                         if total_size > 0:
@@ -345,6 +390,23 @@ def _download_file(url, target_path, model_name):
                 f"Incomplete download for {model_name}: got {current_progress} of "
                 f"{total_size} bytes from {url}"
             )
+
+        if hasher is not None:
+            actual_sha256 = hasher.hexdigest()
+            expected = expected_sha256.lower()
+            if actual_sha256 != expected:
+                # Named file plus both digests so the operator can tell a
+                # corrupted download from a stale pin at a glance.
+                util.logger.error(
+                    f"Checksum mismatch for {model_name} from {url}: "
+                    f"expected sha256 {expected}, got {actual_sha256}"
+                )
+                raise ModelChecksumError(
+                    f"Checksum mismatch for {model_name} from {url}: "
+                    f"expected sha256 {expected}, got {actual_sha256}"
+                )
+        else:
+            util.logger.debug(f"No sha256 pin for {model_name}; skipping verification")
 
         if total_size == 0:
             util.logger.info(

--- a/apps/backend/api/tests/test_ml_models.py
+++ b/apps/backend/api/tests/test_ml_models.py
@@ -1,3 +1,5 @@
+import hashlib
+import re
 import tarfile
 import tempfile
 from pathlib import Path
@@ -9,6 +11,7 @@ from django.test import TestCase, override_settings
 
 from api.ml_models import (
     ML_MODELS,
+    ModelChecksumError,
     MlTypes,
     _download_file,
     _is_model_selected,
@@ -229,7 +232,7 @@ class DownloadModelFailureTest(TestCase):
             model_folder = media_root / "data_models"
             archive = model_folder / (model["target-dir"] + ".tar.gz")
 
-            def fake_download(url, target_path, model_name):
+            def fake_download(url, target_path, model_name, expected_sha256=None):
                 target_path = Path(target_path)
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 target_path.write_bytes(b"Entry not found")
@@ -279,3 +282,150 @@ class DownloadModelsJobTest(TestCase):
         job = LongRunningJob.objects.get(job_type=LongRunningJob.JOB_DOWNLOAD_MODELS)
         self.assertFalse(job.failed)
         self.assertTrue(job.finished)
+
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{40,}$")
+
+
+class ModelChecksumPinTest(TestCase):
+    """Every model artifact must carry a plausible sha256 pin.
+
+    The guard is what keeps a future entry from being added unpinned and thus
+    silently skipping verification.
+    """
+
+    def _assert_pinned(self, sha256, where):
+        self.assertIsInstance(sha256, str, f"{where} sha256 must be a string")
+        self.assertTrue(sha256, f"{where} sha256 must not be empty")
+        self.assertRegex(
+            sha256,
+            _SHA256_RE,
+            f"{where} sha256 must be 40+ hex characters",
+        )
+
+    def test_every_entry_and_additional_file_is_pinned(self):
+        for model in ML_MODELS:
+            self._assert_pinned(model.get("sha256"), model["name"])
+            for additional_file in model.get("additional_files", []):
+                self._assert_pinned(
+                    additional_file.get("sha256"),
+                    f"{model['name']} -> {additional_file['target']}",
+                )
+
+
+class ModelSourceUrlTest(TestCase):
+    """The licensing / mirroring decisions are encoded as regression tests."""
+
+    def _model(self, name):
+        for model in ML_MODELS:
+            if model["name"] == name:
+                return model
+        raise AssertionError(f"model {name} not found in ML_MODELS")
+
+    def test_insightface_models_stay_on_upstream_github(self):
+        # buffalo_* and antelopev2 are NON-COMMERCIAL-RESEARCH licensed, so they
+        # must never be moved onto the LibrePhotos mirror. This test fails loudly
+        # if someone re-points them.
+        for name in ("buffalo_sc", "buffalo_s", "buffalo_m", "buffalo_l", "antelopev2"):
+            self.assertIn(
+                "github.com/deepinsight/insightface",
+                self._model(name)["url"],
+                f"{name} must stay on its upstream InsightFace release URL",
+            )
+
+    def test_mirrored_models_point_at_librephotos_mirror(self):
+        mirror = "huggingface.co/derneuere/librephotos_models"
+
+        siglip2 = self._model("siglip2")
+        moondream = self._model("moondream")
+
+        expected_mirrored = [
+            self._model("mistral-7b-instruct-v0.2.Q5_K_M")["url"],
+            siglip2["url"],
+            siglip2["additional_files"][0]["url"],
+            siglip2["additional_files"][1]["url"],
+            moondream["url"],
+            moondream["additional_files"][0]["url"],
+        ]
+
+        for url in expected_mirrored:
+            self.assertIn(mirror, url, f"{url} must be served from the mirror")
+
+
+class DownloadFileChecksumTest(TestCase):
+    """sha256 verification is wired into the post-#1950 download flow."""
+
+    def test_matching_checksum_is_accepted(self):
+        payload = b"a" * 2048
+        digest = hashlib.sha256(payload).hexdigest()
+        response = _FakeResponse(
+            chunks=[payload[:1024], payload[1024:]],
+            headers={"content-length": str(len(payload))},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "nested" / "model.onnx"
+            with patch("api.ml_models.requests.get", return_value=response):
+                _download_file("https://example.invalid/x", target, "model", digest)
+
+            self.assertEqual(payload, target.read_bytes())
+            self.assertEqual([target], list(target.parent.iterdir()))
+
+    def test_mismatching_checksum_is_rejected_and_nothing_lands(self):
+        payload = b"a" * 2048
+        wrong_digest = hashlib.sha256(b"different").hexdigest()
+        response = _FakeResponse(
+            chunks=[payload],
+            headers={"content-length": str(len(payload))},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "nested" / "model.onnx"
+            with patch("api.ml_models.requests.get", return_value=response):
+                with self.assertRaises(ModelChecksumError):
+                    _download_file(
+                        "https://example.invalid/x", target, "model", wrong_digest
+                    )
+
+            # Neither the final file nor the partial ".part" sibling survives.
+            self.assertFalse(target.exists())
+            self.assertEqual([], list(target.parent.iterdir()))
+
+    def test_no_pin_skips_verification(self):
+        # A future hashless entry must not crash the download path.
+        payload = b"unpinned payload"
+        response = _FakeResponse(
+            chunks=[payload],
+            headers={"content-length": str(len(payload))},
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "model.bin"
+            with patch("api.ml_models.requests.get", return_value=response):
+                _download_file("https://example.invalid/x", target, "model", None)
+
+            self.assertEqual(payload, target.read_bytes())
+
+
+@override_config(OCR_MODEL="ppocrv6_small")
+class DownloadModelChecksumTest(TestCase):
+    def test_bad_checksum_leaves_no_archive_or_target(self):
+        model = _ocr_model("small")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            media_root = Path(temp_dir) / "protected_media"
+            model_folder = media_root / "data_models"
+            archive = model_folder / (model["target-dir"] + ".tar.gz")
+
+            # A well-formed response whose bytes do not match the pinned hash:
+            # the archive must be rejected before any unpack is attempted.
+            body = b"not the real bundle"
+            response = _FakeResponse(
+                chunks=[body],
+                headers={"content-length": str(len(body))},
+            )
+
+            with override_settings(MEDIA_ROOT=str(media_root)):
+                with patch("api.ml_models.requests.get", return_value=response):
+                    with self.assertRaises(ModelChecksumError):
+                        download_model(model)
+
+            self.assertFalse(archive.exists())
+            self.assertFalse((model_folder / (archive.name + ".part")).exists())
+            self.assertFalse(_model_target_exists(model_folder, model))


### PR DESCRIPTION
Follow-up to #1943/#1950. Two changes, implemented and independently adversarially verified:

## 1. Third-party models now come from our mirror

Mistral-7B-Instruct-v0.2 (GGUF), SigLIP2 ONNX (3 files), and Moondream (2 files) now download from [`derneuere/librephotos_models`](https://huggingface.co/derneuere/librephotos_models) instead of third-party accounts. Motivation: the Mistral GGUF lived on TheBloke's dormant account, and the siglip2/moondream URLs were `main`-pinned in repos we don't control — any of them could vanish or change bytes under us. The mirror's README credits every original creator (Salesforce, PaddlePaddle, Mistral AI, TheBloke, Google DeepMind, onnx-community, Moondream/M87 Labs) with licenses and upstream links.

**Deliberately not mirrored:** the InsightFace packs (`buffalo_*`, `antelopev2`) are licensed for non-commercial research use only, so they stay on InsightFace's own releases (a code comment and a regression test record this); the pytorch-CDN resnet18 and our existing librephotos-docker artifacts also stay put.

## 2. Every model download is now sha256-verified

All 15 `ML_MODELS` entries plus all 3 `additional_files` carry a `sha256` pin, checked while streaming in `_download_file` — after the #1950 truncation check, before anything reaches the model directory (archives verify before unpack). A mismatch raises `ModelChecksumError`, reuses #1950's cleanup (no partial file, no target dir), and lands in the job's failure accounting like any failed download. Unpinned future entries degrade gracefully to a debug log.

## Verification

- 22 `test_ml_models` tests pass; ruff clean.
- An independent verifier recomputed all 18 digests against the real artifacts (18/18 match), confirmed via anonymous HEAD requests that all six mirror URLs are live with HF LFS object IDs equal to the pins (proving the remote bytes, not just local copies), and drove the real `download_models` chain with a corrupted mock download: job failed cleanly, zero files left on disk.
- Byte-for-byte mirror fidelity: each mirrored file hashes identically to its upstream source at mirror time (2026-07-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)