### PR TITLE
fix: serve media for album-shared photos instead of 500

### DIFF
--- a/apps/backend/api/tests/test_media_access_sharing.py
+++ b/apps/backend/api/tests/test_media_access_sharing.py
@@ -1,0 +1,151 @@
+"""Regression tests for UnifiedMediaAccessView authorization.
+
+Two defects are covered here:
+
+1. The album-share branch queried a field that does not exist. `AlbumUser`
+   lost its `public` flag when sharing moved to the `AlbumUserShare` relation,
+   but two call sites still did `.only("shared_to", "public")`. Django raises
+   `FieldDoesNotExist` while *building* the query, so every album-level share
+   returned HTTP 500 instead of the media, and unauthorized requests returned
+   500 instead of 404.
+
+2. When several Photo rows share one `image_hash`, the view resolved the
+   ambiguity with `.first()` — an arbitrary row that may belong to a different
+   user — so an owner could be denied their own photo.
+"""
+
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.models import AlbumUser
+from api.models.album_user_share import AlbumUserShare
+from api.tests.utils import create_test_photo, create_test_user
+
+
+def _client_for(user):
+    """The view reads the raw `jwt` cookie, so force_authenticate is not enough."""
+    client = APIClient()
+    if user is not None:
+        client.cookies["jwt"] = str(RefreshToken.for_user(user).access_token)
+    return client
+
+
+class AlbumShareMediaAccessTest(TestCase):
+    """An album shared with another user must serve media, not 500."""
+
+    def setUp(self):
+        self.owner = create_test_user()
+        self.recipient = create_test_user()
+        self.stranger = create_test_user()
+        self.photo = create_test_photo(owner=self.owner)
+        self.album = AlbumUser.objects.create(title="Holiday", owner=self.owner)
+        self.album.photos.add(self.photo)
+        self.album.shared_to.add(self.recipient)
+
+    def test_recipient_can_fetch_thumbnail(self):
+        resp = _client_for(self.recipient).get(
+            f"/media/thumbnails_big/{self.photo.image_hash}"
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_recipient_can_fetch_original(self):
+        resp = _client_for(self.recipient).get(f"/media/photos/{self.photo.image_hash}")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_owner_can_still_fetch_thumbnail(self):
+        resp = _client_for(self.owner).get(
+            f"/media/thumbnails_big/{self.photo.image_hash}"
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_stranger_gets_404_not_500(self):
+        for path in ("thumbnails_big", "photos"):
+            with self.subTest(path=path):
+                resp = _client_for(self.stranger).get(
+                    f"/media/{path}/{self.photo.image_hash}"
+                )
+                self.assertEqual(resp.status_code, 404)
+
+    def test_anonymous_is_forbidden(self):
+        resp = _client_for(None).get(f"/media/thumbnails_big/{self.photo.image_hash}")
+        self.assertEqual(resp.status_code, 403)
+
+
+class PublicAlbumShareMediaAccessTest(TestCase):
+    """A link-shared album grants anonymous access only while the share is live."""
+
+    def setUp(self):
+        self.owner = create_test_user()
+        self.stranger = create_test_user()
+        self.photo = create_test_photo(owner=self.owner)
+        self.album = AlbumUser.objects.create(title="Public", owner=self.owner)
+        self.album.photos.add(self.photo)
+        self.share = AlbumUserShare.objects.create(album=self.album, enabled=True)
+
+    def test_active_share_is_public(self):
+        resp = _client_for(None).get(f"/media/thumbnails_big/{self.photo.image_hash}")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_disabled_share_is_not_public(self):
+        self.share.enabled = False
+        self.share.save()
+        resp = _client_for(None).get(f"/media/thumbnails_big/{self.photo.image_hash}")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_expired_share_denied_to_other_user(self):
+        self.share.expires_at = timezone.now() - datetime.timedelta(days=1)
+        self.share.save()
+        resp = _client_for(self.stranger).get(
+            f"/media/thumbnails_big/{self.photo.image_hash}"
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+class DuplicateImageHashResolutionTest(TestCase):
+    """A hash shared by two Photo rows must resolve in the requester's favour.
+
+    Two users who scan the same file end up with two Photo rows carrying an
+    identical `image_hash`, because `File.create()` returns the row that
+    already exists for that path and the second Photo inherits the first
+    scanner's hash.
+    """
+
+    def setUp(self):
+        self.alice = create_test_user()
+        self.bob = create_test_user()
+        self.stranger = create_test_user()
+        self.alice_photo = create_test_photo(owner=self.alice)
+        self.bob_photo = create_test_photo(owner=self.bob)
+        # Capture the distinct originals before collapsing the hashes.
+        self.alice_path = self.alice_photo.main_file.path
+        self.bob_path = self.bob_photo.main_file.path
+        self.shared_hash = self.alice_photo.image_hash
+        self.bob_photo.image_hash = self.shared_hash
+        self.bob_photo.save()
+
+    def _redirect_for(self, user):
+        resp = _client_for(user).get(f"/media/photos/{self.shared_hash}")
+        self.assertEqual(resp.status_code, 200)
+        return resp["X-Accel-Redirect"]
+
+    def test_each_owner_gets_their_own_row(self):
+        self.assertIn(self.alice_path.split("/")[-1], self._redirect_for(self.alice))
+        self.assertIn(self.bob_path.split("/")[-1], self._redirect_for(self.bob))
+
+    def test_owner_of_second_row_is_not_denied(self):
+        # Before the fix `.first()` could hand back Alice's row, leaving Bob
+        # unable to fetch a photo he owns.
+        resp = _client_for(self.bob).get(f"/media/thumbnails_big/{self.shared_hash}")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_stranger_still_denied(self):
+        for path in ("thumbnails_big", "photos"):
+            with self.subTest(path=path):
+                resp = _client_for(self.stranger).get(
+                    f"/media/{path}/{self.shared_hash}"
+                )
+                self.assertEqual(resp.status_code, 404)

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -773,6 +773,61 @@ class UnifiedMediaAccessView(APIView):
             Q(share__expires_at__isnull=True) | Q(share__expires_at__gte=timezone.now())
         )
 
+    def _resolve_requester(self, jwt):
+        """Return ``(user, token_valid)`` for the value of the ``jwt`` cookie.
+
+        ``user`` is None both when there is no usable token and when the token
+        names a user that no longer exists, so callers must not assume a valid
+        token yields a user.
+        """
+        if jwt is None:
+            return None, False
+        try:
+            token = AccessToken(jwt)
+        except TokenError:
+            return None, False
+        user = (
+            User.objects.filter(id=token["user_id"])
+            .only("id", "transcode_videos")
+            .first()
+        )
+        return user, True
+
+    def _pick_visible_photo(self, photos, user):
+        """Choose which row a shared ``image_hash`` resolves to.
+
+        ``Photo.image_hash`` is meant to be unique per user, but two users who
+        scan the same file end up sharing one: ``File.create()`` returns the
+        existing row for a path already on disk, so the second user's Photo
+        inherits the first scanner's hash. Falling back to an arbitrary row
+        then denies an owner access to their own photo, so prefer a row the
+        requester can actually see.
+        """
+        candidates = list(photos)
+        if not candidates:
+            return None
+        if user is not None:
+            for p in candidates:
+                if p.owner_id == user.id:
+                    return p
+            for p in candidates:
+                if p.shared_to.filter(id=user.id).exists():
+                    return p
+        for p in candidates:
+            if p.albumuser_set.filter(self._public_album_active_q()).exists():
+                return p
+        return candidates[0]
+
+    def _may_access(self, photo, user):
+        """Whether `user` may fetch `photo`: owner, direct share, or via album."""
+        if user is None:
+            return False
+        if photo.owner_id == user.id or photo.shared_to.filter(id=user.id).exists():
+            return True
+        return photo.albumuser_set.filter(
+            self._public_album_active_q() | Q(shared_to=user)
+        ).exists()
+
     def get(self, request, path, fname, album_id=None, format=None):
         use_proxy = self._should_use_proxy()
 
@@ -913,6 +968,10 @@ class UnifiedMediaAccessView(APIView):
 
         # Non-photos (thumbnails, faces, etc.)
         if path.lower() != "photos":
+            # Resolved up front so that a hash shared by several Photo rows can
+            # be resolved in the requester's favour.
+            user, token_valid = self._resolve_requester(request.COOKIES.get("jwt"))
+
             # Try UUID lookup first (for new-style requests after migration 0099),
             # then fall back to image_hash lookup (for legacy/backward compatibility)
             is_uuid_format = len(image_hash) == 36 and image_hash.count("-") == 4
@@ -924,38 +983,21 @@ class UnifiedMediaAccessView(APIView):
             except Photo.DoesNotExist:
                 return HttpResponse(status=404)
             except Photo.MultipleObjectsReturned:
-                # Multiple photos with same hash - find one that matches permissions
-                photos = Photo.objects.filter(image_hash=image_hash)
-                photo = None
-                # First try to find one in a public album
-                for p in photos:
-                    if p.albumuser_set.filter(self._public_album_active_q()).exists():
-                        photo = p
-                        break
-                # If none found, we'll check user permissions below
+                photo = self._pick_visible_photo(
+                    Photo.objects.filter(image_hash=image_hash), user
+                )
                 if photo is None:
-                    photo = photos.first()
+                    return HttpResponse(status=404)
 
             if photo.albumuser_set.filter(self._public_album_active_q()).exists():
                 if use_proxy:
                     return self._generate_response_proxy(photo, path, fname, False)
                 return self._generate_response_direct(photo, path, fname, False)
 
-            jwt = request.COOKIES.get("jwt")
-            if jwt is not None:
-                try:
-                    token = AccessToken(jwt)
-                except TokenError:
-                    return HttpResponseForbidden()
-            else:
+            if not token_valid:
                 return HttpResponseForbidden()
 
-            user = (
-                User.objects.filter(id=token["user_id"])
-                .only("id", "transcode_videos")
-                .first()
-            )
-            if photo.owner == user or user in photo.shared_to.all():
+            if self._may_access(photo, user):
                 if use_proxy:
                     return self._generate_response_proxy(
                         photo, path, fname, user.transcode_videos
@@ -963,64 +1005,37 @@ class UnifiedMediaAccessView(APIView):
                 return self._generate_response_direct(
                     photo, path, fname, user.transcode_videos
                 )
-            else:
-                for album in photo.albumuser_set.only("shared_to", "public"):
-                    if getattr(album, "public", False) or user in album.shared_to.all():
-                        if use_proxy:
-                            return self._generate_response_proxy(
-                                photo, path, fname, user.transcode_videos
-                            )
-                        return self._generate_response_direct(
-                            photo, path, fname, user.transcode_videos
-                        )
             return HttpResponse(status=404)
 
         # Original photos (path == photos)
+        user, token_valid = self._resolve_requester(request.COOKIES.get("jwt"))
+
         try:
             photo = Photo.objects.get(image_hash=image_hash)
         except Photo.DoesNotExist:
             return HttpResponse(status=404)
         except Photo.MultipleObjectsReturned:
-            # Multiple photos with same hash - find one that matches permissions
-            photos = Photo.objects.filter(image_hash=image_hash)
-            photo = None
-            # First try to find one in a public album
-            for p in photos:
-                if p.albumuser_set.filter(self._public_album_active_q()).exists():
-                    photo = p
-                    break
-            # If none found, we'll check user permissions below
+            photo = self._pick_visible_photo(
+                Photo.objects.filter(image_hash=image_hash), user
+            )
             if photo is None:
-                photo = photos.first()
+                return HttpResponse(status=404)
 
         if photo.albumuser_set.filter(self._public_album_active_q()).exists():
             return self._generate_response_original(photo, use_proxy, False)
 
-        jwt = request.COOKIES.get("jwt")
-        if jwt is not None:
-            try:
-                token = AccessToken(jwt)
-            except TokenError:
-                return HttpResponseForbidden()
-        else:
+        if not token_valid:
             return HttpResponseForbidden()
 
-        user = (
-            User.objects.filter(id=token["user_id"])
-            .only("id", "transcode_videos")
-            .first()
-        )
         transcode_videos = user is not None and user.transcode_videos
-        if photo.owner == user or user in photo.shared_to.all():
+        if user is not None and (
+            photo.owner_id == user.id or photo.shared_to.filter(id=user.id).exists()
+        ):
             return self._generate_response_original(
                 photo, use_proxy, transcode_videos, inline=True
             )
-        else:
-            for album in photo.albumuser_set.only("shared_to", "public"):
-                if getattr(album, "public", False) or user in album.shared_to.all():
-                    return self._generate_response_original(
-                        photo, use_proxy, transcode_videos
-                    )
+        if self._may_access(photo, user):
+            return self._generate_response_original(photo, use_proxy, transcode_videos)
         return HttpResponse(status=404)
 
 


### PR DESCRIPTION
Sharing an album with another user currently breaks every image and video in it. The recipient can open the album, but each thumbnail and each original comes back as HTTP 500.

The cause is a field that no longer exists. `AlbumUser` lost its `public` flag when sharing moved to the `AlbumUserShare` relation with `enabled`/`expires_at`, but `UnifiedMediaAccessView` still ran `photo.albumuser_set.only("shared_to", "public")`. Django raises `FieldDoesNotExist` while *building* that query, so the defensive `getattr(album, "public", False)` on the very next line never gets a chance to run:

```
Internal Server Error: /media/thumbnails_big/<hash>
  File "api/views/views.py", line 967, in get
    for album in photo.albumuser_set.only("shared_to", "public"):
django.core.exceptions.FieldDoesNotExist: AlbumUser has no field named 'public'
```

That loop is the "is this photo in an album shared *with me*?" branch, reached whenever the requester is neither the owner nor in `photo.shared_to` — in other words, it is the entire album-sharing path. The same stale query appears twice, once in the thumbnail branch and once in the originals branch, which is why video playback and "download original" fail as well, not just thumbnails. A side effect is that genuinely unauthorized requests also return 500 rather than the intended 404, which confirms to a caller that the hash exists.

Both sites now go through the `_public_album_active_q()` helper that the four other call sites in this file already use, folded into a single `_may_access()` helper so the two branches cannot drift apart again.

While reproducing this I hit a second problem in the same view and fixed it here too, because it produces the same user-visible symptom. When several `Photo` rows share an `image_hash`, `Photo.objects.get()` raises `MultipleObjectsReturned` and the fallback was `photos.first()` — an arbitrary row from an unordered queryset, which may belong to a different user. When it picked the other user's row, the legitimate owner failed the owner check, fell through to the album branch, and was denied access to their own photo. `_pick_visible_photo()` now prefers a row the requester owns, then one shared directly with them, then one in an active public album, before falling back as before. That ordering is worth having regardless of how the duplicates arise, since `.first()` on an unordered queryset is not deterministic between calls.

Those duplicate hashes are themselves a separate upstream bug that I have not fixed here — `File.path` is unique, so a file already scanned by one user hands the next user the first scanner's `File` row and its salted hash, and the second user's `Photo` inherits it. That deserves its own discussion because a real fix touches how `File` is keyed and needs a data migration, so I opened #1957 for it rather than bundling it in. This PR only makes the media view behave correctly when duplicates exist.

Behaviour that is deliberately preserved: a missing or invalid `jwt` cookie still returns 403 and still does so only after the anonymous public-album check, so link-shared albums keep working for logged-out visitors; and the originals branch keeps its distinction between owner access (`inline=True`) and album-share access.

For performance this is neutral-to-positive at both ends of the scale. The old code fetched every `AlbumUser` row a photo belongs to and looped over them in Python, testing `user in album.shared_to.all()` per album, which issued a query per album. The replacement is a single `EXISTS` query, so a photo in one album costs about the same and a photo in many albums costs strictly less. `_pick_visible_photo` only runs on the `MultipleObjectsReturned` path, which does not execute at all on a library without duplicate hashes.

Tested with 11 new tests in `api/tests/test_media_access_sharing.py` covering an album-share recipient fetching both a thumbnail and an original, the owner still being served, a stranger getting 404 rather than 500, anonymous access getting 403, active/disabled/expired link shares, and each owner of a colliding hash being served their own row. These go through the real URL with a `jwt` cookie, since the view reads `request.COOKIES` directly and `force_authenticate` alone never reaches the code under test. Both fixes were mutation-tested: restoring the `public` lookup turns 6 of them into `FieldDoesNotExist` errors, and restoring the `.first()` fallback turns 2 into `404 != 200`. The full backend suite goes from 1862 to 1873 tests with a failure set identical to the pre-change baseline, and `ruff check` plus `ruff format --check` are clean.

I also verified it end to end against a real library where 655 hashes are shared between two users: before the change roughly half of that user's thumbnail requests returned 500, and afterwards all 655 return 200, with the other user still served correctly on the same hashes.

One thing left alone on purpose: `MediaAccessView` in this same file has three more references to the removed `public` field, but it is dead code — it is defined and never routed, since `urls.py` only wires `UnifiedMediaAccessView`. Deleting it felt like a separate cleanup rather than part of a bug fix, but I am happy to fold that in if you would prefer.
