### PR TITLE
fix: read thumbnail dimensions locally so photos cannot go silently invisible

### DIFF
--- a/apps/backend/api/directory_watcher/scan_jobs.py
+++ b/apps/backend/api/directory_watcher/scan_jobs.py
@@ -235,6 +235,47 @@ def photo_scanner(user, last_scan, full_scan, path, job_id):
         update_scan_counter(job_id)
 
 
+def backfill_missing_aspect_ratios(user):
+    """Recalculate aspect ratios for photos that have a thumbnail but no ratio.
+
+    Every grid view filters on ``thumbnail__aspect_ratio__isnull=False``, so a
+    photo without one is invisible in the UI with no other symptom — the library
+    just looks short. Returns the number of photos still missing an aspect ratio
+    after this pass, and logs a warning when that number is non-zero.
+    """
+    photos_with_missing_aspect_ratio = Photo.objects.filter(
+        Q(owner=user.id)
+        & Q(thumbnail__isnull=False)
+        & Q(thumbnail__thumbnail_big__isnull=False)
+        & Q(thumbnail__aspect_ratio__isnull=True)
+    )
+    if not photos_with_missing_aspect_ratio.exists():
+        return 0
+
+    util.logger.info(
+        f"Found {photos_with_missing_aspect_ratio.count()} photos with missing aspect ratios"
+    )
+    for photo in photos_with_missing_aspect_ratio:
+        try:
+            thumbnail = getattr(photo, "thumbnail", None)
+            if thumbnail and isinstance(thumbnail, Thumbnail):
+                thumbnail._calculate_aspect_ratio()
+        except Exception as e:
+            util.logger.exception(
+                f"Could not calculate aspect ratio for photo {photo.image_hash}: {str(e)}"
+            )
+
+    # ``.all()`` re-queries: iterating above cached the pre-repair rows.
+    still_missing = photos_with_missing_aspect_ratio.all().count()
+    if still_missing:
+        util.logger.warning(
+            f"{still_missing} photos still have no aspect ratio after the repair "
+            "pass; they will not appear in the timeline or album views until it "
+            "can be calculated"
+        )
+    return still_missing
+
+
 def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=None):
     """
     Two-phase scan to avoid race conditions with RAW+JPEG grouping.
@@ -387,25 +428,7 @@ def scan_photos(user, full_scan, job_id, scan_directory="", scan_files=None):
         util.logger.info("Finished updating album things")
 
         # Check for photos with missing aspect ratios but existing thumbnails
-        photos_with_missing_aspect_ratio = Photo.objects.filter(
-            Q(owner=user.id)
-            & Q(thumbnail__isnull=False)
-            & Q(thumbnail__thumbnail_big__isnull=False)
-            & Q(thumbnail__aspect_ratio__isnull=True)
-        )
-        if photos_with_missing_aspect_ratio.exists():
-            util.logger.info(
-                f"Found {photos_with_missing_aspect_ratio.count()} photos with missing aspect ratios"
-            )
-            for photo in photos_with_missing_aspect_ratio:
-                try:
-                    thumbnail = getattr(photo, "thumbnail", None)
-                    if thumbnail and isinstance(thumbnail, Thumbnail):
-                        thumbnail._calculate_aspect_ratio()
-                except Exception as e:
-                    util.logger.exception(
-                        f"Could not calculate aspect ratio for photo {photo.image_hash}: {str(e)}"
-                    )
+        backfill_missing_aspect_ratios(user)
 
         # if the scan type is not the default user scan directory, or if it is specified as only scanning
         # specific files, there is no need to rescan fully for missing photos.

--- a/apps/backend/api/models/thumbnail.py
+++ b/apps/backend/api/models/thumbnail.py
@@ -4,8 +4,6 @@ from django.conf import settings
 from django.db import models
 from PIL import Image
 
-from api.metadata.reader import get_metadata
-from api.metadata.tags import Tags
 from api.models.photo import Photo
 from api.thumbnails import (
     create_animated_thumbnail,
@@ -142,16 +140,19 @@ class Thumbnail(models.Model):
 
     def _calculate_aspect_ratio(self):
         try:
-            # Relies on big thumbnail for correct aspect ratio
-            height, width = get_metadata(
-                self.thumbnail_big.path,
-                tags=[Tags.IMAGE_HEIGHT, Tags.IMAGE_WIDTH],
-                try_sidecar=False,
-            )
+            # Relies on big thumbnail for correct aspect ratio. The thumbnail is
+            # a file we generated ourselves, so read its dimensions directly
+            # instead of asking the exif service: a photo without an aspect
+            # ratio is filtered out of every grid view, and that must not hinge
+            # on a sidecar being reachable.
+            if not self.thumbnail_big:
+                logger.warning(
+                    f"no big thumbnail for photo {self.photo_id}; skipping aspect ratio"
+                )
+                return
+            with Image.open(self.thumbnail_big.path) as img:
+                width, height = img.size
             if not height or not width:
-                # Dimensions unavailable (e.g. the exif sidecar was unreachable).
-                # Skip rather than abort the whole photo pipeline — a missing
-                # aspect ratio is backfilled by a later scan.
                 logger.warning(
                     f"missing dimensions for image {self.thumbnail_big.path}; "
                     "skipping aspect ratio"

--- a/apps/backend/api/tests/test_aspect_ratio_calculation.py
+++ b/apps/backend/api/tests/test_aspect_ratio_calculation.py
@@ -1,0 +1,155 @@
+"""
+Tests for aspect ratio calculation.
+
+A photo whose thumbnail has no ``aspect_ratio`` is filtered out of every grid
+view, so it becomes invisible in the UI with no error and no warning. These
+tests pin down that the ratio is derived from the thumbnail file we generated
+ourselves, rather than from the exif service, so an exif outage during a scan
+cannot make photos disappear.
+"""
+
+import os
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+from PIL import Image
+
+from api.directory_watcher.scan_jobs import backfill_missing_aspect_ratios
+from api.tests.utils import create_test_photo, create_test_user
+
+
+def write_big_thumbnail(photo, width, height):
+    """Write a real image file at the photo's big-thumbnail path."""
+    path = os.path.join(settings.MEDIA_ROOT, photo.thumbnail.thumbnail_big.name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (width, height), color="blue").save(path, format="WEBP")
+    return path
+
+
+class CalculateAspectRatioTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    def tearDown(self):
+        for path in getattr(self, "_written", []):
+            if os.path.exists(path):
+                os.remove(path)
+
+    def _photo_with_thumbnail(self, width, height):
+        photo = create_test_photo(owner=self.user, aspect_ratio=None)
+        path = write_big_thumbnail(photo, width, height)
+        self._written = getattr(self, "_written", []) + [path]
+        return photo
+
+    def test_landscape_ratio_read_from_thumbnail(self):
+        photo = self._photo_with_thumbnail(300, 200)
+
+        photo.thumbnail._calculate_aspect_ratio()
+
+        photo.thumbnail.refresh_from_db()
+        self.assertEqual(photo.thumbnail.aspect_ratio, 1.5)
+
+    def test_portrait_ratio_read_from_thumbnail(self):
+        photo = self._photo_with_thumbnail(200, 400)
+
+        photo.thumbnail._calculate_aspect_ratio()
+
+        photo.thumbnail.refresh_from_db()
+        self.assertEqual(photo.thumbnail.aspect_ratio, 0.5)
+
+    def test_does_not_call_exif_service(self):
+        """The regression: dimensions must not depend on a network service.
+
+        Previously ``get_metadata`` was asked for the dimensions of a thumbnail
+        we had just written ourselves, so a degraded exif service left the
+        aspect ratio NULL and the photo invisible everywhere. Asserted at the
+        HTTP layer so it holds however the reader is imported.
+        """
+        photo = self._photo_with_thumbnail(400, 200)
+
+        with mock.patch("api.metadata.reader.requests.post") as mock_post:
+            photo.thumbnail._calculate_aspect_ratio()
+
+        mock_post.assert_not_called()
+        photo.thumbnail.refresh_from_db()
+        self.assertEqual(photo.thumbnail.aspect_ratio, 2.0)
+
+    def test_missing_thumbnail_file_does_not_raise(self):
+        """A thumbnail path pointing at nothing must not abort the pipeline."""
+        photo = create_test_photo(owner=self.user, aspect_ratio=None)
+
+        photo.thumbnail._calculate_aspect_ratio()
+
+        photo.thumbnail.refresh_from_db()
+        self.assertIsNone(photo.thumbnail.aspect_ratio)
+
+    def test_empty_thumbnail_field_does_not_raise(self):
+        """No thumbnail file at all: warn and return, never raise.
+
+        Accessing ``.path`` on an empty FileField raises ValueError, which the
+        old code did inside its own exception handler while logging.
+        """
+        photo = create_test_photo(owner=self.user, aspect_ratio=None)
+        photo.thumbnail.thumbnail_big = ""
+        photo.thumbnail.save()
+
+        photo.thumbnail._calculate_aspect_ratio()
+
+        photo.thumbnail.refresh_from_db()
+        self.assertIsNone(photo.thumbnail.aspect_ratio)
+
+
+class BackfillMissingAspectRatiosTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self._written = []
+
+    def tearDown(self):
+        for path in self._written:
+            if os.path.exists(path):
+                os.remove(path)
+
+    def test_backfills_photos_with_thumbnails(self):
+        photo = create_test_photo(owner=self.user, aspect_ratio=None)
+        self._written.append(write_big_thumbnail(photo, 600, 300))
+
+        still_missing = backfill_missing_aspect_ratios(self.user)
+
+        self.assertEqual(still_missing, 0)
+        photo.thumbnail.refresh_from_db()
+        self.assertEqual(photo.thumbnail.aspect_ratio, 2.0)
+
+    def test_reports_photos_that_could_not_be_repaired(self):
+        """The count must reflect the state *after* the repair pass.
+
+        Iterating the queryset caches its rows, so a naive re-``count()`` would
+        report the pre-repair number and claim failures that did not happen.
+        """
+        healthy = create_test_photo(owner=self.user, aspect_ratio=None)
+        self._written.append(write_big_thumbnail(healthy, 600, 300))
+        # No thumbnail file on disk: cannot be repaired.
+        broken = create_test_photo(owner=self.user, aspect_ratio=None)
+
+        still_missing = backfill_missing_aspect_ratios(self.user)
+
+        self.assertEqual(still_missing, 1)
+        healthy.thumbnail.refresh_from_db()
+        broken.thumbnail.refresh_from_db()
+        self.assertEqual(healthy.thumbnail.aspect_ratio, 2.0)
+        self.assertIsNone(broken.thumbnail.aspect_ratio)
+
+    def test_no_work_to_do(self):
+        create_test_photo(owner=self.user, aspect_ratio=1.5)
+
+        self.assertEqual(backfill_missing_aspect_ratios(self.user), 0)
+
+    def test_leaves_other_users_photos_alone(self):
+        other_user = create_test_user()
+        other_photo = create_test_photo(owner=other_user, aspect_ratio=None)
+        self._written.append(write_big_thumbnail(other_photo, 600, 300))
+
+        self.assertEqual(backfill_missing_aspect_ratios(self.user), 0)
+
+        other_photo.thumbnail.refresh_from_db()
+        self.assertIsNone(other_photo.thumbnail.aspect_ratio)


### PR DESCRIPTION
Every grid view filters on `thumbnail__aspect_ratio__isnull=False` — the timeline (`api/views/albums.py:447` and `:580`), the photo list (`api/views/photos.py:76`), and the shared filter in `api/views/photo_filters.py:39`. A photo whose aspect ratio is NULL is therefore invisible everywhere in the UI, with no error, no warning, and nothing in the job result to say so. The library just looks short, and there is no way for a user to tell "healthy but empty" from "broken".

The aspect ratio was derived by asking the exif service for the dimensions of the big thumbnail — a file we had just generated ourselves a few lines earlier. When that service was degraded while a scan ran, `get_metadata` returned `[None, None]`, `_calculate_aspect_ratio` logged a warning and returned without setting the field, and the affected photos silently disappeared. What makes it sticky rather than transient is that the existing repair pass in `scan_photos` calls the same service, so rescanning while exif was still unhealthy silently no-oped and the library stayed broken. That is exactly what I hit on my own install: photos missing, rescan, no change, no clue why.

I should say that the skip-and-continue behaviour is my own doing — it came from #1873, which made `get_metadata` degrade to None instead of aborting. That was the right call, since one flaky exif call must not kill a 155k-photo scan, but the downstream consequence was never surfaced.

Rather than making the failure louder, this removes the network dependency from the path entirely: the dimensions now come from the thumbnail via PIL, which is already a dependency and is already used on this exact file elsewhere (`api/models/photo.py:425`). Asking a sidecar over HTTP about a local file we generated ourselves was never buying anything. Note that `get_metadata` returned `[height, width]` while `Image.size` is `(width, height)`; the ratio is still `round(width / height, 2)`.

To confirm this is not a behaviour change for healthy setups, I compared both methods across all 665 generated big thumbnails of a real library: zero PIL failures, zero dimension disagreements with exiftool, and zero differences against the 1320 aspect ratios already stored in the database for them. On a live install I then blanked 20 photos' aspect ratios to reproduce the bug, confirmed they dropped out of the grid filter (665 → 645), and ran the repair pass: all 20 came back with exactly their original values.

Two smaller things ride along. `_calculate_aspect_ratio` now checks for an empty `thumbnail_big` before touching `.path`; previously that case raised `ValueError` from inside the exception handler that was logging it, because the log message itself interpolated `.path`. And the repair block is extracted out of `scan_photos` into `backfill_missing_aspect_ratios`, which makes it testable, and which now counts how many photos are still without an aspect ratio afterwards and logs a warning naming the consequence, so photos that genuinely cannot be repaired (a missing thumbnail file, say) become a visible number instead of silence. That recount deliberately re-queries: iterating the queryset caches its rows, so a naive second `.count()` would report the pre-repair number and claim failures that never happened.

Nine tests cover this. Four of them fail against the current `dev` — the two ratio calculations and the no-network assertion fail because in a test environment there is no exif service on port 8010, which is the bug in miniature, and the empty-thumbnail case errors on the `ValueError` described above.

For scale, this is neutral-to-positive in both directions. Per photo it replaces an HTTP round trip (plus up to three retries with backoff on a degraded service) with a local header read, so it is strictly faster and removes 1–2 requests per photo from the sidecar during a scan; on a small library the difference is a few milliseconds either way, and on a large one it removes a per-photo network dependency from the scan path. No new queries: the extracted helper runs the same single filtered query as before, plus one `COUNT` for the report.
