### PR TITLE
fix(backend): reconcile named XMP faces

### DIFF
--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -457,6 +457,29 @@ class Photo(models.Model):
                 if _overlaps_existing_face(
                     existing_face_locations, top, right, bottom, left
                 ):
+                    if person is not None:
+                        for existing_face in api.models.face.Face.objects.filter(
+                            photo=self
+                        ):
+                            existing_location = (
+                                existing_face.location_top,
+                                existing_face.location_right,
+                                existing_face.location_bottom,
+                                existing_face.location_left,
+                            )
+                            if _overlaps_existing_face(
+                                [existing_location], top, right, bottom, left
+                            ):
+                                if existing_face.person_id is None:
+                                    existing_face.person = person
+                                    existing_face.save(update_fields=["person"])
+                                    person._calculate_face_count()
+                                    person._set_default_cover_photo()
+                                    logger.warning(
+                                        f"XMP face reconciliation: assigned {person_name} "
+                                        f"to existing face {existing_face.id}"
+                                    )
+                                break
                     continue
 
                 face = api.models.face.Face(


### PR DESCRIPTION
## User-visible issue

Users importing photos with existing XMP face tags—whether the metadata is embedded in the photo file or stored in an XMP sidecar—expect LibrePhotos to retain the people names they have already assigned. If LibrePhotos has already detected an overlapping face but that face is still unlabeled, the XMP name is currently discarded. Users must then manually relabel a face whose identity is already present in their metadata.

## Problem

LibrePhotos skips an imported XMP face region as soon as it overlaps a face already stored for that photo. This commonly happens when face detection runs before XMP metadata is processed: the geometric duplicate is correctly avoided, but an unlabeled existing face never receives the explicit XMP identity.

## Change

- When a named XMP region overlaps an existing unlabeled face, assign the XMP person to that face instead of immediately skipping all processing.
- Preserve any existing explicit LibrePhotos person assignment; XMP metadata does not overwrite it.
- Refresh the assigned person's face count and default cover.
- Keep the existing duplicate-prevention behavior: no second face row is created.

Person creation semantics, explicitly assigned faces, unnamed regions, and non-overlapping imports are unchanged.

## Validation

The minimal overlap-reconciliation patch was confirmed in a live LibrePhotos Docker 1.0.3 installation. The changed backend file also passes Ruff 0.15.22 formatting/lint checks and Python compilation.

**Diff:** 1 file, 23 additions.