### PR TITLE
fix(backend): use stored thumbnail filenames for UUID requests

### DIFF
--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -655,12 +655,13 @@ class UnifiedMediaAccessView(APIView):
                 )
                 return response
 
-            # For square_thumbnails, use the actual extension from the model
-            ext = (
-                os.path.splitext(getattr(photo.thumbnail, "square_thumbnail").path)[1]
-                if hasattr(photo, "thumbnail")
-                else ""
+            thumb = (
+                photo.thumbnail.square_thumbnail_small
+                if "square_thumbnails_small" in path
+                else photo.thumbnail.square_thumbnail
             )
+            ext = os.path.splitext(thumb.path)[1]
+            actual_name = os.path.basename(thumb.path)
             if "jpg" in ext:
                 response["Content-Type"] = "image/jpg"
                 response["X-Accel-Redirect"] = getattr(
@@ -669,12 +670,12 @@ class UnifiedMediaAccessView(APIView):
             if "webp" in ext:
                 response["Content-Type"] = "image/webp"
                 response["X-Accel-Redirect"] = self._protected_media_url(
-                    path, fname + ".webp"
+                    path, actual_name
                 )
             if "mp4" in ext:
                 response["Content-Type"] = "video/mp4"
                 response["X-Accel-Redirect"] = self._protected_media_url(
-                    path, fname + ".mp4"
+                    path, actual_name
                 )
             return response
 


### PR DESCRIPTION
## User-visible issue

When users open a person album and choose a new cover photo, the picker needs to show square previews of the available photos. UUID-addressed thumbnail requests currently return 404, so the picker displays broken or missing images. Users cannot reliably identify the photo they want to select, making the cover-photo workflow confusing or unusable.

## Problem

The person-cover picker requests square thumbnails through UUID-addressed media URLs. The view correctly resolves the UUID to a `Photo`, but then reconstructs the protected-media filename as `<UUID>.webp` or `<UUID>.mp4`.

Thumbnail files are stored under their generated storage names rather than the photo UUID, so nginx receives a redirect to a filename that does not exist and returns 404. The small-square route must also derive its response information from the small thumbnail field rather than the regular square thumbnail.

## Change

- Select `square_thumbnail_small` for `square_thumbnails_small` requests and `square_thumbnail` otherwise.
- Derive both the extension and basename from that selected thumbnail field.
- Use the actual stored filename for WebP and MP4 `X-Accel-Redirect` responses instead of constructing a filename from the request UUID.

This is limited to the existing square-thumbnail proxy path; legacy routing and other media behavior remain unchanged.

## Validation

The minimal patch was confirmed in a live LibrePhotos Docker 1.0.3 installation, including person-cover picker thumbnails. The changed backend file also passes Ruff 0.15.22 formatting/lint checks and Python compilation.

**Diff:** 1 file, 8 additions, 7 deletions.