### PR TITLE
fix(frontend): pass person album ID to photo list

### DIFF
--- a/apps/frontend/src/routes/_protected/album/persons.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/persons.$id.tsx
@@ -72,6 +72,7 @@ export function AlbumPersonGallery(): JSX.Element {
       updateGroups={getAlbums}
       selectable
       mediaType={mediaType}
+      albumID={id}
       photosetQuery={{ person: id ? +id : undefined, ...mediaTypeToBulkQuery(mediaType) }}
     />
   );


### PR DESCRIPTION
## User-visible issue

From a person album, users can select a photo and set it as that person's cover. Before this fix, the action targets `/api/persons/undefined/` instead of the person being viewed. The request fails and the visible cover remains unchanged, so the user cannot complete an otherwise normal cover-selection action.

## Problem

Choosing a new cover photo from a person album eventually calls the person update endpoint through `PhotoListView`. The person album route did not pass its route ID as `albumID`, so that component built the request as:

`/api/persons/undefined/`

The cover selection therefore failed before the backend could update the person.

## Change

Pass the existing person route parameter to `PhotoListView`:

`albumID={id}`

This is deliberately a one-line route wiring fix; no component or API behavior is otherwise changed.

## Validation

The failure and corresponding frontend fix were confirmed against LibrePhotos Docker 1.0.3. The changed route passes the project's ESLint and Prettier checks.

**Diff:** 1 file, 1 addition.