### PR TITLE
fix(backend): accept UUID person cover photos

### DIFF
--- a/apps/backend/api/serializers/person.py
+++ b/apps/backend/api/serializers/person.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Q
 from rest_framework import serializers
 
@@ -94,10 +95,25 @@ class PersonSerializer(serializers.ModelSerializer):
             instance.save()
             return instance
         if "cover_photo" in validated_data.keys():
-            image_hash = validated_data.pop("cover_photo")
-            photo = Photo.objects.filter(image_hash=image_hash).first()
+            photo_ref = validated_data.pop("cover_photo")
+
+            # Backward compatibility:
+            # older frontend paths send image_hash, newer paths send Photo UUID.
+            photo = Photo.objects.filter(image_hash=photo_ref).first()
+
+            if photo is None:
+                try:
+                    photo = Photo.objects.filter(pk=photo_ref).first()
+                except (ValueError, TypeError, DjangoValidationError):
+                    photo = None
+
+            if photo is None:
+                raise serializers.ValidationError(
+                    {"cover_photo": f"Photo not found: {photo_ref}"}
+                )
+
             instance.cover_photo = photo
-            instance.cover_face = photo.faces.filter(person__name=instance.name).first()
+            instance.cover_face = photo.faces.filter(person=instance).first()
             instance.save()
             return instance
         return instance


### PR DESCRIPTION
## User-visible issue

After the frontend supplies the correct person ID, it identifies the selected cover photo using the photo's UUID. The backend currently accepts only the older image-hash format, so the update ends in a server error and the person's cover still does not change. This is the backend half of restoring the complete cover-selection workflow.

## Problem

The current frontend identifies a selected person-cover photo with `Photo.id`, which is a UUID. `PersonSerializer.update()` only looked up `cover_photo` as an `image_hash`.

For UUID input that lookup returned `None`, and the next access to `photo.faces` caused a server error instead of updating the cover. Malformed UUID input could also raise Django's field-conversion `ValidationError`. The cover-face lookup additionally matched a person by name, which can select the wrong row when names are duplicated.

## Change

- Preserve backward compatibility by trying the existing `image_hash` lookup first.
- Fall back to a primary-key lookup so current Photo UUID values are accepted.
- Catch Django's UUID conversion error and return a clear serializer validation error when neither reference resolves, instead of producing a server error.
- Match the cover face to the exact `Person` instance rather than only its name.

## Validation

The minimal compatibility patch was confirmed in a live LibrePhotos Docker 1.0.3 installation. The changed backend file also passes Ruff 0.15.22 formatting/lint checks and Python compilation.

**Diff:** 1 file, 19 additions, 3 deletions.