### PR TITLE
fix(backend): serve UUID-addressed thumbnails in direct mode and thumbnails_big

### DIFF
--- a/apps/backend/api/tests/test_media_uuid_thumbnails.py
+++ b/apps/backend/api/tests/test_media_uuid_thumbnails.py
@@ -1,0 +1,212 @@
+"""Thumbnails must be served whether the URL carries an image_hash or a UUID.
+
+``Thumbnail._generate_thumbnail`` always writes ``<image_hash>.<ext>``, but the
+frontend addresses a photo by its primary key in several places
+(``AlbumCoverPickerModal`` builds its tile from ``photo.id``, and the lightbox
+``ImagePreloader`` / ``StackLightbox`` request ``thumbnails_big`` and
+``square_thumbnails`` by id).  So the request filename and the stored filename
+are two different strings, and anything that derives the on-disk name from the
+request -- the ``X-Accel-Redirect`` in proxy mode, the ``os.path.join`` lookup
+in ``SERVE_FRONTEND`` mode -- points at a file that was never written.
+
+These tests pin the contract from both ends: the same photo must be served
+identically under both spellings of its address, in both serving modes, and a
+photo whose ``Thumbnail`` row is missing must degrade rather than 500.
+"""
+
+import os
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
+
+from api.models.thumbnail import Thumbnail
+from api.tests.utils import create_test_photo, create_test_user
+
+THUMBNAIL_FIELDS = {
+    "square_thumbnails": "square_thumbnail",
+    "square_thumbnails_small": "square_thumbnail_small",
+    "thumbnails_big": "thumbnail_big",
+}
+
+# thumbnails_big is a static webp even for videos; the square variants follow
+# the source medium.
+EXPECTED_IMAGE = {
+    "square_thumbnails": (".webp", "image/webp"),
+    "square_thumbnails_small": (".webp", "image/webp"),
+    "thumbnails_big": (".webp", "image/webp"),
+}
+EXPECTED_VIDEO = {
+    "square_thumbnails": (".mp4", "video/mp4"),
+    "square_thumbnails_small": (".mp4", "video/mp4"),
+    "thumbnails_big": (".webp", "image/webp"),
+}
+
+
+def create_legacy_jpg_photo(user):
+    """A Thumbnail row as it looks on an install that predates webp.
+
+    Both surviving variants are ``.jpg`` and ``square_thumbnail_small`` was
+    never populated -- the shape the pre-#1970 view already coped with by
+    serving the big jpg for any thumbnail request.
+    """
+    photo = create_test_photo(owner=user, video=False)
+    thumbnail = photo.thumbnail
+    thumbnail.thumbnail_big.name = f"thumbnails_big/{photo.image_hash}.jpg"
+    thumbnail.square_thumbnail.name = f"square_thumbnails/{photo.image_hash}.jpg"
+    thumbnail.square_thumbnail_small.name = ""
+    thumbnail.save()
+    return photo
+
+
+class MediaUuidThumbnailBase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        # The media endpoint authenticates off the "jwt" cookie that
+        # CustomTokenObtainPairView sets, not off the DRF Authorization header.
+        self.client.cookies["jwt"] = str(AccessToken.for_user(self.user))
+        self.image = create_test_photo(owner=self.user, video=False)
+        self.video = create_test_photo(owner=self.user, video=True)
+
+    def _get(self, path, fname):
+        return self.client.get(f"/media/{path}/{fname}")
+
+    def _addresses(self, photo):
+        """Both spellings of the same photo's media address."""
+        return (("image_hash", photo.image_hash), ("uuid", str(photo.pk)))
+
+
+class ProxyThumbnailAddressingTest(MediaUuidThumbnailBase):
+    """Proxy mode: the nginx internal URI must name the stored file."""
+
+    def test_redirect_and_type_are_identical_for_hash_and_uuid(self):
+        for photo, expected in (
+            (self.image, EXPECTED_IMAGE),
+            (self.video, EXPECTED_VIDEO),
+        ):
+            for path, (ext, content_type) in expected.items():
+                for kind, fname in self._addresses(photo):
+                    with self.subTest(video=photo.video, path=path, addressed_by=kind):
+                        response = self._get(path, fname)
+                        self.assertEqual(200, response.status_code)
+                        self.assertEqual(
+                            f"/protected_media/{path}/{photo.image_hash}{ext}",
+                            response.headers.get("X-Accel-Redirect"),
+                        )
+                        self.assertEqual(
+                            content_type, response.headers.get("Content-Type")
+                        )
+
+    def test_photo_without_thumbnail_row_does_not_error(self):
+        """#1970 dropped the hasattr() guard, turning an empty 200 into a 500."""
+        Thumbnail.objects.filter(photo=self.image).delete()
+        Thumbnail.objects.filter(photo=self.video).delete()
+
+        for photo in (self.image, self.video):
+            for path in THUMBNAIL_FIELDS:
+                for kind, fname in self._addresses(photo):
+                    with self.subTest(video=photo.video, path=path, addressed_by=kind):
+                        response = self._get(path, fname)
+                        self.assertLess(
+                            response.status_code,
+                            500,
+                            "a missing Thumbnail row must not raise "
+                            "RelatedObjectDoesNotExist",
+                        )
+
+    def test_unknown_uuid_is_a_404(self):
+        response = self._get(
+            "square_thumbnails", "00000000-0000-4000-8000-000000000000"
+        )
+        self.assertEqual(404, response.status_code)
+
+    def test_legacy_jpg_big_thumbnail_is_announced_as_jpeg(self):
+        """The redirect names a .jpg, so the type must not claim webp."""
+        photo = create_legacy_jpg_photo(self.user)
+
+        for kind, fname in self._addresses(photo):
+            with self.subTest(addressed_by=kind):
+                response = self._get("thumbnails_big", fname)
+                self.assertEqual(200, response.status_code)
+                self.assertEqual(
+                    f"/protected_media/thumbnails_big/{photo.image_hash}.jpg",
+                    response.headers.get("X-Accel-Redirect"),
+                )
+                self.assertEqual("image/jpeg", response.headers.get("Content-Type"))
+
+
+@override_settings(SERVE_FRONTEND=True)
+class DirectThumbnailAddressingTest(MediaUuidThumbnailBase):
+    """SERVE_FRONTEND mode: the file has to be found on disk, not guessed."""
+
+    def setUp(self):
+        super().setUp()
+        self.written = []
+        for photo in (self.image, self.video):
+            for field in THUMBNAIL_FIELDS.values():
+                self._write(getattr(photo.thumbnail, field).name)
+
+    def tearDown(self):
+        for file_path in self.written:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+        super().tearDown()
+
+    def _write(self, name):
+        file_path = os.path.join(settings.MEDIA_ROOT, name)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "wb") as handle:
+            handle.write(b"thumbnail-bytes")
+        self.written.append(file_path)
+
+    def test_stored_file_is_served_for_hash_and_uuid(self):
+        for photo, expected in (
+            (self.image, EXPECTED_IMAGE),
+            (self.video, EXPECTED_VIDEO),
+        ):
+            for path, (_ext, content_type) in expected.items():
+                for kind, fname in self._addresses(photo):
+                    with self.subTest(video=photo.video, path=path, addressed_by=kind):
+                        response = self._get(path, fname)
+                        try:
+                            self.assertEqual(
+                                200,
+                                response.status_code,
+                                "the thumbnail exists on disk under its "
+                                "image_hash name and must be found",
+                            )
+                            self.assertEqual(
+                                content_type, response.headers.get("Content-Type")
+                            )
+                        finally:
+                            response.close()
+
+    def test_legacy_jpg_row_falls_back_to_the_big_jpg(self):
+        """A legacy row with no small variant must not start 404ing.
+
+        Resolving from the model first means an unpopulated field now yields
+        no candidate at all, so the big-jpg fallback has to stay reachable
+        after the request-derived lookup fails.
+        """
+        photo = create_legacy_jpg_photo(self.user)
+        self._write(f"thumbnails_big/{photo.image_hash}.jpg")
+
+        for path in THUMBNAIL_FIELDS:
+            for kind, fname in self._addresses(photo):
+                with self.subTest(path=path, addressed_by=kind):
+                    response = self._get(path, fname)
+                    try:
+                        self.assertEqual(200, response.status_code)
+                        self.assertEqual(
+                            "image/jpg", response.headers.get("Content-Type")
+                        )
+                    finally:
+                        response.close()
+
+    def test_unknown_uuid_is_a_404(self):
+        response = self._get(
+            "square_thumbnails", "00000000-0000-4000-8000-000000000000"
+        )
+        self.assertEqual(404, response.status_code)

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -643,30 +643,64 @@ class UnifiedMediaAccessView(APIView):
             content_type="video/mp4",
         )
 
+    def _thumbnail_field_for(self, photo, path):
+        """Return the ``FieldFile`` holding the thumbnail ``path`` asks for.
+
+        The request filename cannot be turned into an on-disk name by string
+        manipulation: ``Thumbnail._generate_thumbnail`` always stores files as
+        ``<image_hash>.<ext>``, while the frontend also addresses photos by
+        their UUID (``AlbumCoverPickerModal``, the lightbox preloader), so a
+        UUID request would otherwise be pointed at a file that does not exist.
+        The model is the only reliable source of the stored name.
+
+        Returns ``None`` when the photo has no ``Thumbnail`` row or the
+        relevant field was never populated -- callers then fall back to the
+        legacy request-derived name instead of raising.
+        """
+        thumbnail = photo.thumbnail if hasattr(photo, "thumbnail") else None
+        if thumbnail is None:
+            return None
+        if "thumbnails_big" in path:
+            field = thumbnail.thumbnail_big
+        elif "square_thumbnails_small" in path:
+            field = thumbnail.square_thumbnail_small
+        else:
+            field = thumbnail.square_thumbnail
+        # An empty FileField raises ValueError on .path/.name access downstream.
+        return field if field else None
+
     def _generate_response_proxy(self, photo, path, fname, transcode_videos):
         if "thumbnail" in path:
             response = HttpResponse()
+            thumb = self._thumbnail_field_for(photo, path)
 
-            # thumbnails_big is always .webp (static image), even for videos
+            # thumbnails_big is a static image even for videos: .webp today,
+            # .jpg on installs that predate the webp switch.
             if "thumbnails_big" in path:
-                response["Content-Type"] = "image/webp"
+                name = os.path.basename(thumb.name) if thumb else fname + ".webp"
+                response["Content-Type"] = (
+                    "image/jpeg" if "jpg" in os.path.splitext(name)[1] else "image/webp"
+                )
+                response["X-Accel-Redirect"] = self._protected_media_url(path, name)
+                return response
+
+            if thumb is None:
+                # No Thumbnail row (or an unpopulated field): keep serving the
+                # legacy request-derived name rather than 500ing on the
+                # missing relation.
+                ext = ".mp4" if photo.video else ".webp"
+                response["Content-Type"] = "video/mp4" if photo.video else "image/webp"
                 response["X-Accel-Redirect"] = self._protected_media_url(
-                    path, fname + ".webp"
+                    path, fname + ext
                 )
                 return response
 
-            thumb = (
-                photo.thumbnail.square_thumbnail_small
-                if "square_thumbnails_small" in path
-                else photo.thumbnail.square_thumbnail
-            )
-            ext = os.path.splitext(thumb.path)[1]
-            actual_name = os.path.basename(thumb.path)
+            ext = os.path.splitext(thumb.name)[1]
+            actual_name = os.path.basename(thumb.name)
             if "jpg" in ext:
                 response["Content-Type"] = "image/jpg"
-                response["X-Accel-Redirect"] = getattr(
-                    photo.thumbnail, "thumbnail_big", photo.thumbnail.square_thumbnail
-                ).path
+                big = self._thumbnail_field_for(photo, "thumbnails_big")
+                response["X-Accel-Redirect"] = (big or thumb).path
             if "webp" in ext:
                 response["Content-Type"] = "image/webp"
                 response["X-Accel-Redirect"] = self._protected_media_url(
@@ -704,6 +738,23 @@ class UnifiedMediaAccessView(APIView):
 
     def _generate_response_direct(self, photo, path, fname, transcode_videos):
         if "thumbnail" in path:
+            # Resolve from the model first: `fname` is the Photo UUID for
+            # UUID-addressed requests, and no thumbnail is ever stored under
+            # that name, so the request-derived lookup below can only ever
+            # 404 for them.
+            thumb = self._thumbnail_field_for(photo, path)
+            if thumb is not None:
+                ext = os.path.splitext(thumb.name)[1]
+                if "jpg" in ext:
+                    # Legacy jpg thumbnails: only the big variant is usable.
+                    big = self._thumbnail_field_for(photo, "thumbnails_big")
+                    return self._serve_file_direct((big or thumb).path, "image/jpg")
+                if os.path.exists(thumb.path):
+                    return self._serve_file_direct(
+                        thumb.path,
+                        "video/mp4" if "mp4" in ext else "image/webp",
+                    )
+
             file_path = os.path.join(settings.MEDIA_ROOT, path, fname)
             if not os.path.exists(file_path):
                 if not fname.endswith(".webp"):
@@ -714,12 +765,12 @@ class UnifiedMediaAccessView(APIView):
                     mp4 = os.path.join(settings.MEDIA_ROOT, path, fname + ".mp4")
                     if os.path.exists(mp4):
                         return self._serve_file_direct(mp4, "video/mp4")
-            if hasattr(photo, "thumbnail"):
-                ext = os.path.splitext(photo.thumbnail.square_thumbnail.path)[1]
-                if "jpg" in ext:
-                    return self._serve_file_direct(
-                        photo.thumbnail.thumbnail_big.path, "image/jpg"
-                    )
+            # Legacy jpg installs may never have populated the small/square
+            # variants; fall back to the big jpg for any of them, as before.
+            square = self._thumbnail_field_for(photo, "square_thumbnails")
+            if square is not None and "jpg" in os.path.splitext(square.name)[1]:
+                big = self._thumbnail_field_for(photo, "thumbnails_big")
+                return self._serve_file_direct((big or square).path, "image/jpg")
             return self._serve_file_direct(file_path)
 
         if "faces" in path:


### PR DESCRIPTION
Follow-up to #1970, which made `square_thumbnails` / `square_thumbnails_small` requests addressed by Photo **UUID** redirect to the *stored* `<image_hash>.<ext>` filename in proxy mode. Review of #1970 found three gaps; this closes them.

## Problem
Thumbnail files are always stored as `<image_hash>.webp|.mp4` (`Thumbnail._generate_thumbnail`), while the frontend also addresses photos by UUID (`AlbumCoverPickerModal` → `Tile`, the lightbox `ImagePreloader`, `StackLightbox`). After #1970:

1. **Direct-serve mode (`SERVE_FRONTEND=True`)** still resolved the file from the request `fname` (the UUID) → 404 for every UUID-addressed thumbnail.
2. **`thumbnails_big/<uuid>`** in proxy mode still redirected to `/protected_media/thumbnails_big/<uuid>.webp`, which does not exist.
3. #1970 dropped the `hasattr(photo, "thumbnail")` guard, so a Photo without a `Thumbnail` row raised `RelatedObjectDoesNotExist` → HTTP 500 (and `.path` on an empty `FileField` raised `ValueError`).

## Change (`api/views/views.py`, `UnifiedMediaAccessView`)
- New `_thumbnail_field_for(photo, path)` returns the `FieldFile` for `thumbnails_big` / `square_thumbnails_small` / `square_thumbnail` (checked in that order — `square_thumbnails_small` contains `square_thumbnails` as a substring), or `None` when there is no `Thumbnail` row or the field is empty. Both response branches share it.
- **Proxy:** `thumbnails_big` redirects to the stored basename (falls back to `fname + ".webp"` without a thumbnail row); Content-Type is `image/jpeg` for legacy `.jpg` big thumbnails instead of a hard-coded `image/webp`. Missing thumbnail row → legacy `fname + ext` redirect chosen by `photo.video` instead of a 500. Uses `.name` rather than `.path` for ext/basename so empty fields can’t raise.
- **Direct:** model-first resolution — serve `<field>.path` with `video/mp4` for `.mp4`, `image/webp` otherwise; legacy `.jpg` rows keep serving the big jpg for any thumbnail request (parity with dev, including when `square_thumbnail_small` was never populated). Falls through to the original request-derived lookup when the model has no thumbnail, so hash-addressed requests behave exactly as before.
- `faces`, `photos`, `zip`, `avatars`, `embedded_media`, transcoding and the public-album branch are unchanged.

## Tests
New `api/tests/test_media_uuid_thumbnails.py` (7 tests, style of `test_repro_issue_384.py`): proxy redirect + Content-Type parity for image and video × all three paths × hash/UUID addressing; direct mode with real files under `MEDIA_ROOT`; missing `Thumbnail` row → non-500; unknown UUID → 404; legacy `.jpg` row in both modes. Verified to fail against `dev` (8 errors + 8 failures) and pass here. Existing `test_repro_issue_384`, `test_media_access_sharing`, `test_repro_issue_124` pass; full backend suite: only the two pre-existing Windows-path failures in `test_embedded_media`. Ruff check/format clean.

Independently verified by a second agent with additional probes (public-album access by UUID in both modes, legacy jpg rows, empty thumbnail fields, `.only()` on the public-album queryset, path-traversal surface): no new filesystem reach from request input; non-thumbnail branches byte-identical to `dev`.

## Notes
- The legacy jpg branch in proxy mode still emits an absolute filesystem path as `X-Accel-Redirect` — pre-existing on `dev`, left as-is (worth its own follow-up).
- Legacy jpg is announced as `image/jpeg` in proxy `thumbnails_big` and `image/jpg` (dev’s spelling) in the direct fallback; both render, normalising is a separate cosmetic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
