### PR TITLE
fix(backend): complete XMP face import

### DIFF
--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -443,7 +443,9 @@ class Photo(models.Model):
                 top, right, bottom, left, person_name = face_location
                 if person_name:
                     person = api.models.person.get_or_create_person(
-                        name=person_name, owner=self.owner
+                        name=person_name,
+                        owner=self.owner,
+                        kind=api.models.person.Person.KIND_USER,
                     )
                     person.save()
                 else:
@@ -492,9 +494,6 @@ class Photo(models.Model):
                     person=person,
                     cluster=unknown_cluster,
                 )
-                if person_name:
-                    person._calculate_face_count()
-                    person._set_default_cover_photo()
                 face_io = BytesIO()
                 if face_image.mode in ("RGBA", "P"):
                     face_image = face_image.convert("RGB")
@@ -502,6 +501,9 @@ class Photo(models.Model):
                 face.image.save(image_path, ContentFile(face_io.getvalue()))
                 face_io.close()
                 face.save()
+                if person_name:
+                    person._calculate_face_count()
+                    person._set_default_cover_photo()
                 existing_face_locations.append((top, right, bottom, left))
             logger.info(f"image {self.image_hash}: {len(face_locations)} face(s) saved")
         except IntegrityError:


### PR DESCRIPTION
## Usability problem

#1969 fixed the backend overlap path so that, when an XMP face region overlaps a face LibrePhotos has already detected, the XMP person association is stored instead of being discarded.

That fix was incomplete from the user's perspective: the XMP importer still created the named person with the default `UNKNOWN` kind. LibrePhotos' frontend People views only visualize user-labelled (`USER`) people, so the association could exist in the backend while the named person remained absent from People albums.

There was also an ordering issue for newly created XMP faces: LibrePhotos recalculated the person's count and cover before saving the face. A person with one XMP-labelled face therefore appeared with a count of zero and no usable album cover; people with multiple imported faces had a count one lower than the real total.

## Change

This follow-up keeps the fix intentionally small and confined to `photo.py`:

- create named XMP people as `KIND_USER`, making the stored labels visible in the frontend
- recalculate the person's face count and default cover only after the new face has been saved

The conservative overlap behavior from #1969 remains unchanged: an XMP label is applied only when the overlapping existing face does not already have an explicit person.

## Testing

Confirmed on the latest `-dev` build using `reallibrephotos/librephotos-unified:dev` with SQLite, a fresh library, and a full face rescan:

- XMP-labelled people appear in People albums
- their albums contain the expected photos
- a person with a single imported face has the correct count and cover
- imported people are stored as `USER`
