### PR TITLE
fix: keep person albums in sync when untagging faces

### DIFF
--- a/apps/backend/api/views/faces.py
+++ b/apps/backend/api/views/faces.py
@@ -304,8 +304,11 @@ class SetFacePersonLabel(APIView):
         updated = []
         not_updated = []
         relabeled_faces = []
+        affected_person_ids = set()
         for face in faces.values():
             if face.photo.owner == request.user:
+                if face.person_id is not None:
+                    affected_person_ids.add(face.person_id)
                 face.person = person
                 if not person:
                     face.cluster_person = cluster_person
@@ -318,8 +321,10 @@ class SetFacePersonLabel(APIView):
             relabeled_faces, ["person", "cluster_person", "classification_person"]
         )
         if person:
-            person._calculate_face_count()
-            person._set_default_cover_photo()
+            affected_person_ids.add(person.id)
+        for affected_person in Person.objects.filter(id__in=affected_person_ids):
+            affected_person._calculate_face_count()
+            affected_person._set_default_cover_photo()
 
         # Every photo we relabeled needs its captions rebuilt, not just the one
         # the loop happened to end on.

--- a/apps/frontend/src/api_client/faces/types.ts
+++ b/apps/frontend/src/api_client/faces/types.ts
@@ -48,7 +48,7 @@ export const PersonFace = z.object({
   photo_image_hash: z.string().nullable().optional(),
   person_label_probability: z.number(),
   isTemp: z.boolean().optional(),
-  person: z.number().optional(),
+  person: z.number().nullable().optional(),
   person_name: z.string().optional(),
   timestamp: z.string().optional().nullable(),
 });


### PR DESCRIPTION
## Usability problem

Moving a labelled face back to **Unknown - Other** succeeds in the backend, but the frontend reports a failure:

> Failed to parse set faces label response  
> Expected number, received null at results.0.person; Expected number, received null at updated.0.person.

The API correctly returns `person: null` because an untagged face has no assigned person. The frontend schema accepted only a numeric person ID or an omitted field, so it rejected this valid response. As a result, users saw an error even though the face had been removed successfully, and the mutation's normal query refresh did not run.

A second issue left the People-album count unchanged after removal. The backend recalculated only the destination person's count. When moving a face to Unknown the destination is `None`, while the previous labelled person was never recalculated. The album therefore lost the photo but continued showing the old count in the People list.

## Change

- allow `person` to be `null` in the frontend face-response schema
- remember the previous person for every face being relabelled
- after the bulk update, recalculate every affected previous person as well as the destination person

This also keeps counts correct when a batch of faces is moved between different named people, while retaining the existing ownership check.

## Testing

Confirmed on the latest `-dev` build using `reallibrephotos/librephotos-unified:dev` with SQLite:

- moving a face to **Unknown - Other** completes without the false frontend parse error
- the photo is removed from the person's album
- the People-list count decreases immediately
- adding and removing faces continues to work across all tested person albums

Additional validation:

- frontend production build completed successfully
- existing backend face-labelling regression tests passed on SQLite
- Python compilation and diff checks passed
