### PR TITLE
fix: restore Event album loading, lightbox, and add-to-album

### DIFF
--- a/apps/backend/api/serializers/album_auto.py
+++ b/apps/backend/api/serializers/album_auto.py
@@ -29,6 +29,8 @@ class AlbumAutoSerializer(serializers.ModelSerializer):
         for photo in obj.photos.all():
             faces = photo.faces.all()
             for face in faces:
+                if face.person is None:
+                    continue
                 serialized_person = PersonSerializer(face.person).data
                 if serialized_person not in res:
                     res.append(serialized_person)

--- a/apps/backend/api/serializers/simple.py
+++ b/apps/backend/api/serializers/simple.py
@@ -15,6 +15,7 @@ class PhotoSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Photo
         fields = (
+            "id",
             "square_thumbnail",
             "image_hash",
             "exif_timestamp",

--- a/apps/frontend/src/api_client/albums/types.ts
+++ b/apps/frontend/src/api_client/albums/types.ts
@@ -203,6 +203,7 @@ export const PlaceAlbum = z.object({
 });
 
 export const PhotoSimple = z.object({
+  id: z.string().uuid(),
   square_thumbnail: z.string(),
   image_hash: z.string(),
   exif_timestamp: z.string(),

--- a/apps/frontend/src/routes/_protected/album/events.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/events.$id.tsx
@@ -39,7 +39,7 @@ export function AlbumAutoGalleryView() {
   const groupedPhotos = Object.entries(byDate).map(([date, items]) => ({
     date,
     items: items.map(photo => ({
-      id: photo.image_hash,
+      id: photo.id,
       hash: photo.image_hash,
       video: photo.video,
       timestamp: photo.exif_timestamp,
@@ -126,7 +126,7 @@ export function AlbumAutoGalleryView() {
         loading={isFetching}
         icon={<SettingsAutomation size={50} />}
         photoset={groupedPhotos}
-        idx2hash={photos.map(photo => ({ id: photo.image_hash, image_hash: photo.image_hash }))}
+        idx2hash={photos.map(photo => ({ id: photo.id, image_hash: photo.image_hash }))}
         selectable
       />
     </div>

--- a/apps/frontend/src/routes/_protected/album/events.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/events.$id.tsx
@@ -126,7 +126,7 @@ export function AlbumAutoGalleryView() {
         loading={isFetching}
         icon={<SettingsAutomation size={50} />}
         photoset={groupedPhotos}
-        idx2hash={photos.map(photo => ({ id: photo.id, image_hash: photo.image_hash }))}
+        idx2hash={photos.map(photo => ({ id: photo.image_hash, image_hash: photo.image_hash }))}
         selectable
       />
     </div>


### PR DESCRIPTION
## User-facing problems

Automatically generated Event albums failed in three ways on the same screen:

1. **Opening an Event album could show an error instead of its photos.** If any photo contained an unlabelled detected face, the frontend reported `Failed to parse auto album` with missing person fields, then displayed “No images found” even though the album did contain images. The backend was adding every detected face to the album's `people` response, including faces whose `person` was `null`. Serializing that null relation produced an incomplete person object, so the frontend rejected the entire album response.

2. **Visible thumbnails did not open in fullscreen.** Once the album response was made valid, its thumbnails displayed, but clicking any image appeared to do nothing. Event thumbnails and the lightbox lookup must share the same photo identifier. Compact Event photo objects had no UUID `id`, so the click handler could not match the selected thumbnail and silently declined to open the lightbox.

3. **Adding a photo from an Event to a user album returned 400.** The Event gallery used `image_hash` as the photo `id`. Add-to-album sends that `id` to `PATCH /api/albums/user/edit/`, which expects the photo UUID primary key, so Django rejected the hash as an invalid UUID.

## Changes

- Skip unlabelled faces when building an automatic album's `people` list. The faces and photos remain in the album; only the invalid null-person entry is omitted.
- Include the photo UUID `id` in the compact Event photo payload.
- Use that UUID as the Event thumbnail identifier and the lightbox lookup, and therefore as the id sent when adding photos to a user album.

## Testing

Confirmed with live patches on `reallibrephotos/librephotos-unified:dev` using SQLite:

- generated Event albums containing labelled and unlabelled faces open without parser errors
- their photos display instead of “No images found”
- clicking an Event thumbnail opens the fullscreen lightbox
- adding a photo from an Event to a user album succeeds (`PATCH /api/albums/user/edit/` returns 200)