### PR TITLE
fix(backend): scope select_all makepublic to request.user's photos

### DIFF
--- a/apps/backend/api/tests/test_public_photos.py
+++ b/apps/backend/api/tests/test_public_photos.py
@@ -83,3 +83,82 @@ class PublicPhotosTest(TestCase):
         logger_ext.assert_called_with(
             "Could not set photo nonexistent_photo to public. It does not exist or is not owned by user."
         )
+
+
+class SelectAllPublicPhotosSecurityTest(TestCase):
+    """Regression tests for issue #1981 (incomplete fix for CVE-2026-57943).
+
+    The select_all branch of POST /api/photosedit/makepublic/ built its
+    queryset via build_photo_queryset, which does NOT scope to
+    owner=request.user when query.public=true. That allowed any
+    authenticated user to bulk-set OTHER users' public photos to private.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user()
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_select_all_cannot_unpublish_other_users_photos_with_username(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True, "username": self.victim.username},
+            "val_public": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/makepublic/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.public)
+
+    def test_select_all_cannot_unpublish_other_users_photos_without_username(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "val_public": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/makepublic/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.public)
+
+    def test_select_all_owner_can_still_unpublish_own_photos(self):
+        own_photos = create_test_photos(
+            number_of_photos=2, owner=self.attacker, public=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "val_public": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/makepublic/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(2, data["count"])
+        for photo in own_photos:
+            photo.refresh_from_db()
+            self.assertFalse(photo.public)

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -750,6 +750,13 @@ class SetPhotosPublic(APIView):
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 
+            # Scope the write to the requester's own photos. build_photo_queryset
+            # intentionally does not filter by owner when query.public=true (it is
+            # shared with public read paths), so without this an authenticated user
+            # could bulk-set OTHER users' public photos to private (issue #1981,
+            # incomplete fix for CVE-2026-57943).
+            photos_qs = photos_qs.filter(owner=request.user)
+
             count = photos_qs.update(public=val_public)
 
             if val_public:


### PR DESCRIPTION
## Vulnerability

Incomplete fix for CVE-2026-57943 (issue #1981): the `select_all` branch of `POST /api/photosedit/makepublic/` builds its write target with `build_photo_queryset(request.user, query_params)` and then calls `.update(public=val_public)` directly. `build_photo_queryset` deliberately does **not** apply `owner=request.user` when `query.public=true` — it selects `public=True` rows across all users (optionally narrowed by `username`), because it is shared with the public *read* paths.

Any authenticated user could therefore bulk-set **other users'** public photos to private:

```json
POST /api/photosedit/makepublic/
{"select_all": true, "query": {"public": true, "username": "victim"}, "val_public": false}
```

(The `username` filter is optional — omitting it flips every public photo on the instance.) The exposure is public→private only: the selector matches already-public rows, so this branch cannot expose private photos.

## Root cause

The select_all branch reused a read-path queryset builder as a write target without re-applying ownership scoping.

## Fix

Bind the update queryset to the requester before the bulk write in `SetPhotosPublic.post()`:

```python
photos_qs = photos_qs.filter(owner=request.user)
```

`build_photo_queryset` itself is intentionally untouched, since legitimate public read paths depend on its current behavior. Sibling endpoints (favorites/hide/setdeleted/etc.) are handled in separate PRs.

## Regression tests

New `SelectAllPublicPhotosSecurityTest` in `api/tests/test_public_photos.py`:

- attacker with `query.public=true` **and** `username=<victim>` → victim photos remain public, count 0
- attacker with `query.public=true` without `username` → same
- sanity: the owner can still set their own public photos private via select_all

Both attack tests fail against the unfixed code (`AssertionError: 0 != 3` — 3 victim photos flipped) and pass with the fix; full `api.tests.test_public_photos` file passes (7/7).

Fixes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)