### PR TITLE
fix(backend): scope select_all hide/unhide to request.user's photos

### DIFF
--- a/apps/backend/api/tests/test_hide_photos.py
+++ b/apps/backend/api/tests/test_hide_photos.py
@@ -79,3 +79,97 @@ class FavoritePhotosTest(TestCase):
         logger.assert_called_with(
             "Could not set photo nonexistent_photo to hidden. It does not exist or is not owned by user."
         )
+
+
+class SelectAllHidePhotosOwnerScopeTest(TestCase):
+    """Regression tests for #1980: select_all hide/unhide must only ever
+    modify photos owned by the requesting user, even when the query targets
+    public photos of other users."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user(public_sharing=True)
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_select_all_public_with_username_cannot_hide_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True, "username": self.victim.username},
+            "hidden": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/hide/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertFalse(photo.hidden)
+
+    def test_select_all_public_without_username_cannot_hide_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "hidden": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/hide/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertFalse(photo.hidden)
+
+    def test_select_all_public_cannot_unhide_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=2, owner=self.victim, public=True, hidden=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True, "hidden": True},
+            "hidden": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/hide/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(0, data["count"])
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.hidden)
+
+    def test_select_all_owner_can_still_hide_own_photos(self):
+        own_photos = create_test_photos(number_of_photos=3, owner=self.attacker)
+
+        payload = {
+            "select_all": True,
+            "query": {},
+            "hidden": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/hide/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(3, data["count"])
+        for photo in own_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.hidden)

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -426,6 +426,11 @@ class SetPhotosHidden(APIView):
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 
+            # Security: build_photo_queryset does not scope to the requester
+            # when query.public=true, so restrict the write to the user's own
+            # photos to prevent hiding/unhiding other users' public photos.
+            photos_qs = photos_qs.filter(owner=request.user)
+
             count = photos_qs.update(hidden=val_hidden)
 
             if val_hidden:


### PR DESCRIPTION
## Vulnerability

Incomplete fix for CVE-2026-57943 in `/api/photosedit/hide/` (issue #1980).

The `select_all` branch of `SetPhotosHidden.post()` built its write target with `build_photo_queryset(request.user, query_params)` and then called `photos_qs.update(hidden=val_hidden)` directly. `build_photo_queryset` deliberately skips the `owner=request.user` filter when `query.public=true` (it is shared with legitimate public read paths and instead selects `public=True` rows, optionally narrowed by `username`).

As a result, **any authenticated user could hide or unhide other users' public photos**:

```http
POST /api/photosedit/hide/
{"select_all": true, "query": {"public": true, "username": "<victim>"}, "hidden": true}
```

The `username` key is optional (omitting it hits every user's public photos), and sending `"hidden": false` with `"query": {"public": true, "hidden": true}` performs the unhide direction.

## Root cause

The bulk-update queryset was never re-scoped to the requester before the write, unlike the per-hash branch which already filters `owner=request.user`.

## Fix

In the `select_all` branch only, bind the write target to the requester before the update:

```python
photos_qs = photos_qs.filter(owner=request.user)
```

`build_photo_queryset` itself is untouched since public read paths rely on its current behavior. Other bulk endpoints are handled in separate PRs.

## Regression tests

New `SelectAllHidePhotosOwnerScopeTest` in `api/tests/test_hide_photos.py`:

- attacker + `query.public=true` + `username=<victim>` + `hidden=true` → victim photos untouched, count 0
- attacker + `query.public=true` (no username) + `hidden=true` → same
- unhide direction (victim photo `public=True, hidden=True`, attacker sends `hidden=false`) → stays hidden
- owner sanity: a user can still bulk-hide their own photos via `select_all`

All three attack tests fail against the unfixed code (counts 3/3/2 victim photos modified) and pass with the fix; `api.tests.test_hide_photos` and `api.tests.test_public_photos` are green (12 tests).

Fixes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)