### PR TITLE
fix(backend): scope select_all trash/restore to request.user's photos

### DIFF
--- a/apps/backend/api/tests/test_bulk_operations.py
+++ b/apps/backend/api/tests/test_bulk_operations.py
@@ -351,6 +351,115 @@ class BulkSetPhotosDeletedTest(TestCase):
             self.assertFalse(photo.in_trashcan)
 
 
+class BulkSetPhotosDeletedOwnerScopeTest(TestCase):
+    """Regression tests for issue #1982 (incomplete fix for CVE-2026-57943).
+
+    An authenticated attacker must not be able to trash or restore another
+    user's photos through the public-photos query in select_all mode of
+    POST /api/photosedit/setdeleted/.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user()
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_select_all_public_query_with_username_cannot_trash_others_photos(self):
+        """query.public + username=<victim> must not move victim photos to trash."""
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True, in_trashcan=False
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True, "username": self.victim.username},
+            "deleted": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/setdeleted/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertEqual(data["count"], 0)
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertFalse(
+                photo.in_trashcan,
+                "Attacker was able to trash another user's public photo",
+            )
+
+    def test_select_all_public_query_without_username_cannot_trash_others_photos(self):
+        """query.public without username must not move other users' photos to trash."""
+        victim_photos = create_test_photos(
+            number_of_photos=2, owner=self.victim, public=True, in_trashcan=False
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "deleted": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/setdeleted/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertEqual(data["count"], 0)
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertFalse(
+                photo.in_trashcan,
+                "Attacker was able to trash another user's public photo",
+            )
+
+    def test_select_all_public_query_cannot_restore_others_trashed_photos(self):
+        """query.public + in_trashcan must not restore other users' trashed photos."""
+        victim_photos = create_test_photos(
+            number_of_photos=2, owner=self.victim, public=True, in_trashcan=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True, "in_trashcan": True},
+            "deleted": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/setdeleted/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertEqual(data["count"], 0)
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertTrue(
+                photo.in_trashcan,
+                "Attacker was able to restore another user's trashed photo",
+            )
+
+    def test_select_all_owner_can_still_trash_own_photos(self):
+        """Sanity: the owner can still trash their own photos via select_all."""
+        own_photos = create_test_photos(
+            number_of_photos=3, owner=self.attacker, in_trashcan=False
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {},
+            "deleted": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/setdeleted/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(data["count"], 3)
+        for photo in own_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.in_trashcan)
+
+
 class BulkSharePhotosTest(TestCase):
     """Tests for bulk SetPhotosShared with select_all mode."""
 

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -191,6 +191,10 @@ class SetPhotosDeleted(APIView):
             excluded_hashes = data.get("excluded_hashes", [])
 
             photos_qs = build_photo_queryset(request.user, query_params)
+            # Security: build_photo_queryset does not scope to the requester
+            # when query.public is set, so bind the write target to the
+            # requesting user's own photos (CVE-2026-57943, issue #1982).
+            photos_qs = photos_qs.filter(owner=request.user)
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 


### PR DESCRIPTION
## Vulnerability

Incomplete fix for CVE-2026-57943: the `select_all` branch of `POST /api/photosedit/setdeleted/` lets any authenticated user trash or restore **other users' public photos**.

Attacker request shapes:

```json
{"select_all": true, "query": {"public": true, "username": "<victim>"}, "deleted": true}
{"select_all": true, "query": {"public": true}, "deleted": true}
{"select_all": true, "query": {"public": true, "in_trashcan": true}, "deleted": false}
```

## Root cause

`SetPhotosDeleted.post()` builds its write target with `build_photo_queryset(request.user, query_params)` and then calls `photos_qs.update(in_trashcan=...)`. `build_photo_queryset` deliberately skips the `owner=request.user` filter when `query.public` is set (that behavior is correct for the public read paths that share it), so the bulk `update()` ran against rows owned by other users whenever the attacker passed `public: true`.

## Fix

Bind the write target to the requester before the update, in `api/views/photos.py`:

```python
photos_qs = photos_qs.filter(owner=request.user)
```

`build_photo_queryset` itself is untouched since it is shared with legitimate public read paths. Only the setdeleted endpoint is changed here — the other bulk endpoints are handled separately.

## Regression tests

New `BulkSetPhotosDeletedOwnerScopeTest` in `api/tests/test_bulk_operations.py`:

- attacker + `query.public` with `username=<victim>`, `deleted=true` → victim photos stay out of trash, count 0
- attacker + `query.public` without `username`, `deleted=true` → same
- attacker + `query.public` + `query.in_trashcan`, `deleted=false` → victim's trashed photos stay trashed, count 0
- owner sanity: the owner can still trash their own photos via `select_all`

All three attacker tests fail on `dev` (counts 3/2/2 victim photos modified) and pass with the fix; full `test_bulk_operations`, `test_trash_api`, and `test_delete_photos` files pass (37 tests, OK).

Fixes #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)