### PR TITLE
fix(backend): scope remaining select_all bulk writes (favorite/share/delete) to the request user

### DIFF
--- a/apps/backend/api/tests/test_select_all_owner_scope.py
+++ b/apps/backend/api/tests/test_select_all_owner_scope.py
@@ -1,0 +1,179 @@
+"""Regression tests: select_all bulk operations must never write to other
+users' photos.
+
+build_photo_queryset(user, {"public": True}) intentionally drops the owner
+filter so public browsing works, which means every select_all branch that
+feeds it into a write must re-scope to owner=request.user itself. These
+tests pin that property for the favorite, share, and delete endpoints
+(the hide/makepublic/setdeleted counterparts are covered by their own
+fixes, see #1980/#1981/#1982).
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.models import Photo
+from api.tests.utils import create_test_photos, create_test_user
+
+
+class FavoriteSelectAllOwnerScopeTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user()
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_public_query_cannot_favorite_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True, rating=0
+        )
+        own_photos = create_test_photos(
+            number_of_photos=2, owner=self.attacker, public=True, rating=0
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "favorite": True,
+        }
+        response = self.client.post(
+            "/api/photosedit/favorite/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        # Only the attacker's own photos may be touched
+        self.assertEqual(data["count"], 2)
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertEqual(photo.rating, 0)
+        for photo in own_photos:
+            photo.refresh_from_db()
+            self.assertGreaterEqual(photo.rating, self.attacker.favorite_min_rating)
+
+    def test_public_query_cannot_unfavorite_other_users_photos(self):
+        victim_rating = self.victim.favorite_min_rating
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True, rating=victim_rating
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "favorite": False,
+        }
+        response = self.client.post(
+            "/api/photosedit/favorite/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(data["count"], 0)
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertEqual(photo.rating, victim_rating)
+
+
+class ShareSelectAllOwnerScopeTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user()
+        self.target = create_test_user()
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_public_query_cannot_share_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True
+        )
+        create_test_photos(number_of_photos=2, owner=self.attacker, public=True)
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "val_shared": True,
+            "target_user_id": self.target.id,
+        }
+        response = self.client.post(
+            "/api/photosedit/share/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(data["count"], 2)
+
+        through_model = Photo.shared_to.through
+        victim_shared = through_model.objects.filter(
+            user_id=self.target.id,
+            photo_id__in=[photo.id for photo in victim_photos],
+        ).count()
+        self.assertEqual(victim_shared, 0)
+
+    def test_public_query_cannot_unshare_other_users_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=2, owner=self.victim, public=True
+        )
+        through_model = Photo.shared_to.through
+        through_model.objects.bulk_create(
+            [
+                through_model(user_id=self.target.id, photo_id=photo.id)
+                for photo in victim_photos
+            ]
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+            "val_shared": False,
+            "target_user_id": self.target.id,
+        }
+        response = self.client.post(
+            "/api/photosedit/share/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(data["count"], 0)
+
+        still_shared = through_model.objects.filter(
+            user_id=self.target.id,
+            photo_id__in=[photo.id for photo in victim_photos],
+        ).count()
+        self.assertEqual(still_shared, 2)
+
+
+class DeleteSelectAllOwnerScopeTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.attacker = create_test_user()
+        self.victim = create_test_user()
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_public_query_cannot_delete_other_users_trashed_photos(self):
+        victim_photos = create_test_photos(
+            number_of_photos=3, owner=self.victim, public=True, in_trashcan=True
+        )
+        own_photos = create_test_photos(
+            number_of_photos=2, owner=self.attacker, public=True, in_trashcan=True
+        )
+
+        payload = {
+            "select_all": True,
+            "query": {"public": True},
+        }
+        response = self.client.delete(
+            "/api/photosedit/delete/", format="json", data=payload
+        )
+        data = response.json()
+
+        self.assertTrue(data["status"])
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(data["failed_count"], 0)
+
+        for photo in victim_photos:
+            photo.refresh_from_db()
+            self.assertFalse(photo.removed)
+            self.assertTrue(photo.in_trashcan)
+        for photo in own_photos:
+            photo.refresh_from_db()
+            self.assertTrue(photo.removed)

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -318,7 +318,11 @@ class SetPhotosFavorite(APIView):
             query_params = data.get("query", {})
             excluded_hashes = data.get("excluded_hashes", [])
 
-            photos_qs = build_photo_queryset(request.user, query_params)
+            # build_photo_queryset drops the owner filter for public queries,
+            # so re-scope to the requesting user before writing (see #1980).
+            photos_qs = build_photo_queryset(request.user, query_params).filter(
+                owner=request.user
+            )
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 
@@ -672,7 +676,12 @@ class SetPhotosShared(APIView):
             query_params = data.get("query", {})
             excluded_hashes = data.get("excluded_hashes", [])
 
-            photos_qs = build_photo_queryset(request.user, query_params)
+            # build_photo_queryset drops the owner filter for public queries.
+            # The write below re-filters by owner, but scope here too so the
+            # security property doesn't hinge on a distant check.
+            photos_qs = build_photo_queryset(request.user, query_params).filter(
+                owner=request.user
+            )
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 
@@ -893,7 +902,12 @@ class DeletePhotos(APIView):
             # Override query to filter for trashcan photos only
             query_params["in_trashcan"] = True
 
-            photos_qs = build_photo_queryset(request.user, query_params)
+            # build_photo_queryset drops the owner filter for public queries.
+            # The loop below re-checks ownership, but scope here too so other
+            # users' photos are never even loaded.
+            photos_qs = build_photo_queryset(request.user, query_params).filter(
+                owner=request.user
+            )
             if excluded_hashes:
                 photos_qs = photos_qs.exclude(image_hash__in=excluded_hashes)
 


### PR DESCRIPTION
## What

#1980/#1981/#1982 reported that the `select_all` branches of hide/makepublic/setdeleted call `build_photo_queryset(request.user, query)` and bulk-write without binding `owner=request.user`. `build_photo_queryset` intentionally drops the owner filter when the query has `public: true` (that's how public browsing works), so those branches could write to **other users' public photos**.

The same pattern exists in three more `select_all` branches in `api/views/photos.py` that the issues scoped out. This PR audits and fixes all three:

| Endpoint | select_all branch | Exploitable on dev? |
|---|---|---|
| `POST /api/photosedit/favorite/` (`SetPhotosFavorite`) | `photos_qs.filter(rating…).update(rating…)` with no owner check anywhere | **Yes** — any authenticated user could rewrite the rating (favorite/unfavorite) of every other user's public photos |
| `POST /api/photosedit/share/` (`SetPhotosShared`) | collects hashes unscoped, but the write re-queries with `owner=request.user` | No — hardened anyway |
| `DELETE /api/photosedit/delete/` (`DeletePhotos`) | iterates the unscoped queryset, but checks `photo.owner == request.user` before `manual_delete()` | No — the per-photo guard holds, so no cross-user permanent delete. Hardened anyway |

## Fix

Each `select_all` branch now scopes the queryset with `.filter(owner=request.user)` immediately after `build_photo_queryset(...)`, same shape as the fixes for #1980/#1981/#1982. For share and delete this makes the security property local to the branch instead of hinging on a downstream check (and for delete, stops loading every other user's public trashed photo into memory just to skip it).

## Tests

New `api/tests/test_select_all_owner_scope.py` with cross-user regression tests for all three endpoints (attacker sends `select_all: true, query: {public: true}` against a victim's public photos):

- `FavoriteSelectAllOwnerScopeTest` — **fails without the fix** (`count` included the victim's 3 photos and their ratings were rewritten), passes with it
- `ShareSelectAllOwnerScopeTest` / `DeleteSelectAllOwnerScopeTest` — pin the already-safe behavior so a future refactor of the downstream guards can't silently reintroduce the hole

Full backend suite green on Windows/py3.11 (`test_sqlite` settings).

Related: #1980 #1981 #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
