### PR TITLE
feat: seek videos with the arrow keys, and fix a play/pause shortcut that never fired (#1983)

### DIFF
--- a/apps/docs/docs/user-guide/viewing-photos.md
+++ b/apps/docs/docs/user-guide/viewing-photos.md
@@ -168,6 +168,8 @@ Click on any similar photo to view it directly.
 | Key | Action |
 |-----|--------|
 | `←` / `→` | Previous / Next photo |
+| `Shift` + `←` / `→` | Jump back / forward 10 seconds (videos only) |
+| `Ctrl` + `←` / `→` | Jump back / forward 1 minute (videos only) |
 | `Escape` | Close photo viewer |
 | `Space` | Play / pause (videos only) |
 | `z` | Toggle zoom (still images only) |
@@ -181,3 +183,10 @@ Click on any similar photo to view it directly.
 
 The `f`, `h`, `p` and `d` shortcuts act on the current photo and are disabled on public (unauthenticated) album pages.
 
+### Seeking in Videos
+
+`Space` starts and pauses a video. Holding `Shift` with the arrow keys jumps ten seconds back or forward, and holding `Ctrl` instead jumps a full minute — the same split VLC makes between a short and a long jump. The plain arrow keys keep moving between photos even while a video is playing, so skipping through a clip never costs you your place in the album. Each jump is confirmed on screen — the player's own control bar stays hidden when you drive it from the keyboard, so there would otherwise be nothing to see.
+
+On macOS, `Ctrl` with the arrow keys is claimed by Mission Control for switching between desktops, so the one-minute jump may not reach the page there; `Shift` is unaffected.
+
+Seeking is unavailable while a video is still being converted for playback, which happens when you have **Always transcode videos** turned on in your settings. For as long as that conversion is running the browser is never told how long the video is or how to jump within it, so the player says so rather than ignoring the key.

--- a/apps/frontend/src/components/lightbox/ContentViewer.tsx
+++ b/apps/frontend/src/components/lightbox/ContentViewer.tsx
@@ -9,11 +9,21 @@ import { useFetchPhotoDetailsQuery } from "../../api_client/photos/hooks";
 import { useRotatePhotosMutation } from "../../api_client/photos/hooks/useRotatePhotosMutation";
 import { useCurrentUserSelfDetailsQuery } from "../../api_client/user/hooks";
 import { ImagePreloader } from "./ImagePreloader";
+import {
+  NEXT_KEY,
+  PLAY_PAUSE_KEY,
+  PREVIOUS_KEY,
+  SEEK_BACK_KEY,
+  SEEK_FORWARD_KEY,
+  SEEK_LONG_BACK_KEY,
+  SEEK_LONG_FORWARD_KEY,
+} from "./lightbox.hotkeys";
 import type { ContentViewerProps, FaceLocationType } from "./lightbox.types";
 import { LightboxControls } from "./LightboxControls";
 import { MediaDisplay } from "./MediaDisplay";
 import { Sidebar } from "./Sidebar";
 import { ThumbnailNavigation } from "./ThumbnailNavigation";
+import { requestLightboxSeek, SEEK_LONG_STEP_SECONDS, SEEK_STEP_SECONDS } from "./VideoPlayer";
 
 export function ContentViewer({
   mainSrc,
@@ -219,10 +229,23 @@ export function ContentViewer({
 
   // Add keyboard navigation using Mantine's useHotkeys
   useHotkeys([
-    ["ArrowLeft", () => prevSrc && onMovePrevRequest()],
-    ["ArrowRight", () => nextSrc && onMoveNextRequest()],
+    [PREVIOUS_KEY, () => prevSrc && onMovePrevRequest()],
+    [NEXT_KEY, () => nextSrc && onMoveNextRequest()],
+    // Seeking is added alongside the arrows rather than taking them over. A
+    // focused <video> would seek with the bare arrow keys, but these hotkeys
+    // are bound on `document` and Mantine's ignore list covers only INPUT,
+    // TEXTAREA and SELECT -- so the arrows reach navigation from inside the
+    // player too, and whether a key seeks or navigates would otherwise depend
+    // on the invisible question of whether the user had clicked the video
+    // first. Google Photos and Apple Photos likewise keep the arrows on
+    // navigation. Mantine matches modifiers exactly, so these do not fire the
+    // two bindings above.
+    [SEEK_BACK_KEY, () => requestLightboxSeek(-SEEK_STEP_SECONDS)],
+    [SEEK_FORWARD_KEY, () => requestLightboxSeek(SEEK_STEP_SECONDS)],
+    [SEEK_LONG_BACK_KEY, () => requestLightboxSeek(-SEEK_LONG_STEP_SECONDS)],
+    [SEEK_LONG_FORWARD_KEY, () => requestLightboxSeek(SEEK_LONG_STEP_SECONDS)],
     ["Escape", handleClose],
-    [" ", () => type === "video" && setPlaying(prev => !prev)],
+    [PLAY_PAUSE_KEY, () => type === "video" && setPlaying(prev => !prev)],
     ["z", () => type === "photo" && toggleZoom()],
     ["i", () => setLightBoxSidebarShow(prev => !prev)], // Toggle info panel
     // Additional shortcuts for photo actions handled by lightbox controls

--- a/apps/frontend/src/components/lightbox/VideoPlayer.test.tsx
+++ b/apps/frontend/src/components/lightbox/VideoPlayer.test.tsx
@@ -18,7 +18,14 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { classifyVideoFailure, factToText, VideoPlayer } from "./VideoPlayer";
+import {
+  classifyVideoFailure,
+  factToText,
+  formatSeekDistance,
+  LIGHTBOX_SEEK_EVENT,
+  requestLightboxSeek,
+  VideoPlayer,
+} from "./VideoPlayer";
 
 const accessToken = { current: { access: { user_id: "1", name: "dotan", is_admin: false } } };
 const diagnostics = { current: undefined as unknown };
@@ -111,6 +118,147 @@ beforeEach(() => {
   diagnostics.current = undefined;
   diagnosticsEnabled.mockClear();
   copied.mockClear();
+});
+
+/**
+ * Give the element a seekable window and a settable playhead. jsdom loads no
+ * media, so a bare `<video>` reports an empty `seekable` and its `currentTime`
+ * goes nowhere -- which is also, usefully, exactly what a chunked transcode
+ * looks like to the browser.
+ */
+function stubPlayhead(video: HTMLVideoElement, ranges: [number, number][], startAt = 0) {
+  let time = startAt;
+  Object.defineProperty(video, "currentTime", {
+    configurable: true,
+    get: () => time,
+    set: (value: number) => {
+      time = value;
+    },
+  });
+  Object.defineProperty(video, "seekable", {
+    configurable: true,
+    get: () => ({
+      length: ranges.length,
+      start: (index: number) => ranges[index][0],
+      end: (index: number) => ranges[index][1],
+    }),
+  });
+  return () => time;
+}
+
+describe("VideoPlayer seeking", () => {
+  it("moves the playhead by the requested amount and says how far", async () => {
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [[0, 120]], 30);
+
+    await act(async () => {
+      requestLightboxSeek(10);
+    });
+
+    expect(at()).toBe(40);
+    expect(container.textContent).toContain("+10s");
+
+    await act(async () => {
+      requestLightboxSeek(-10);
+    });
+
+    expect(at()).toBe(30);
+    expect(container.textContent).toContain("-10s");
+    await unmount();
+  });
+
+  it("takes the long jump too, and says so in minutes", async () => {
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [[0, 600]], 120);
+
+    await act(async () => {
+      requestLightboxSeek(60);
+    });
+
+    expect(at()).toBe(180);
+    expect(container.textContent).toContain("+1m");
+    await unmount();
+  });
+
+  it("stops at the ends of the seekable window instead of running past them", async () => {
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [[0, 12]], 4);
+
+    await act(async () => {
+      requestLightboxSeek(-10);
+    });
+    expect(at()).toBe(0);
+
+    await act(async () => {
+      requestLightboxSeek(10);
+    });
+    expect(at()).toBe(10);
+
+    await act(async () => {
+      requestLightboxSeek(10);
+    });
+    expect(at()).toBe(12);
+    await unmount();
+  });
+
+  it("says seeking is unavailable rather than pretending a chunked stream moved", async () => {
+    // The transcoding path streams with no length and no Accept-Ranges, so the
+    // browser offers no seekable window at all. A shortcut that quietly did
+    // nothing here is the failure this feature exists to avoid.
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [], 5);
+
+    await act(async () => {
+      requestLightboxSeek(10);
+    });
+
+    expect(at()).toBe(5);
+    expect(container.textContent).toContain("lightbox.video.seekunavailable");
+    await unmount();
+  });
+
+  it("ignores a request carrying no distance", async () => {
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [[0, 120]], 30);
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(LIGHTBOX_SEEK_EVENT, { detail: { seconds: 0 } }));
+      window.dispatchEvent(new CustomEvent(LIGHTBOX_SEEK_EVENT));
+    });
+
+    expect(at()).toBe(30);
+    expect(container.textContent).not.toContain("+10s");
+    expect(container.textContent).not.toContain("lightbox.video.seekunavailable");
+    await unmount();
+  });
+
+  it("stops listening once the player is gone", async () => {
+    const { container, unmount } = await renderPlayer();
+    const at = stubPlayhead(container.querySelector("video")!, [[0, 120]], 30);
+    await unmount();
+
+    await act(async () => {
+      requestLightboxSeek(10);
+    });
+
+    expect(at()).toBe(30);
+  });
+});
+
+describe("formatSeekDistance", () => {
+  it("counts seconds below a minute", () => {
+    expect(formatSeekDistance(10)).toBe("+10s");
+    expect(formatSeekDistance(-10)).toBe("-10s");
+  });
+
+  it("counts whole minutes above one, which is what the long jump moves", () => {
+    expect(formatSeekDistance(60)).toBe("+1m");
+    expect(formatSeekDistance(-120)).toBe("-2m");
+  });
+
+  it("keeps seconds when they are not a whole number of minutes", () => {
+    expect(formatSeekDistance(90)).toBe("+90s");
+  });
 });
 
 describe("classifyVideoFailure", () => {

--- a/apps/frontend/src/components/lightbox/VideoPlayer.tsx
+++ b/apps/frontend/src/components/lightbox/VideoPlayer.tsx
@@ -22,6 +22,34 @@ type VideoPlayerProps = {
  * stream and nothing more -- so these are recovered by re-requesting the same
  * URL and reading the HTTP status, which is the only place the difference lives.
  */
+/** How far one press of a seek shortcut moves the playhead, in seconds. */
+export const SEEK_STEP_SECONDS = 10;
+
+/** The same, for the long jump on Ctrl -- VLC's split between the two. */
+export const SEEK_LONG_STEP_SECONDS = 60;
+
+/** "+10s", "-1m": whole minutes read better than "+60s" once past a minute. */
+export function formatSeekDistance(seconds: number): string {
+  const sign = seconds > 0 ? "+" : "-";
+  const size = Math.abs(seconds);
+  return size >= 60 && size % 60 === 0 ? `${sign}${size / 60}m` : `${sign}${size}s`;
+}
+
+/**
+ * Seek requests arrive as a window event because the two halves of the gesture
+ * live apart: the lightbox owns the keyboard -- its hotkeys are bound on
+ * `document`, so they fire no matter what has focus -- while the `<video>`
+ * element only ever exists in here. Threading a ref down through `MediaDisplay`
+ * into a memoised player would couple three components to one keypress, and
+ * the lightbox already talks to its controls this way. Only the main slide
+ * renders a player, so exactly one listener is ever mounted.
+ */
+export const LIGHTBOX_SEEK_EVENT = "lightbox-seek";
+
+export function requestLightboxSeek(seconds: number) {
+  window.dispatchEvent(new CustomEvent(LIGHTBOX_SEEK_EVENT, { detail: { seconds } }));
+}
+
 export type VideoErrorKind = "permission" | "missing" | "format" | "server" | "session" | "unknown";
 
 /**
@@ -101,6 +129,11 @@ export const VideoPlayer = memo(function VideoPlayer({
   // Bumped on every probe so a stale answer cannot overwrite a newer one after
   // the user has already navigated to a different video.
   const probeRef = useRef(0);
+  // What the last seek shortcut did, shown briefly over the picture. A
+  // keyboard-driven seek never raises the native control bar, so without this
+  // the key produces no visible acknowledgement at all.
+  const [seekHint, setSeekHint] = useState<{ seconds: number } | "unavailable" | null>(null);
+  const seekHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasError = errorKind !== null;
   // Only the permission case has anything to diagnose, and only an administrator
@@ -115,6 +148,7 @@ export const VideoPlayer = memo(function VideoPlayer({
     setErrorStatus(null);
     setProbing(false);
     setRetryCount(0);
+    setSeekHint(null);
     readyFiredRef.current = false;
     probeRef.current += 1;
   }, [url]);
@@ -129,9 +163,42 @@ export const VideoPlayer = memo(function VideoPlayer({
     }
   }, [playing, loading, hasError]);
 
+  useEffect(() => {
+    const showHint = (hint: { seconds: number } | "unavailable") => {
+      setSeekHint(hint);
+      if (seekHintTimerRef.current) clearTimeout(seekHintTimerRef.current);
+      seekHintTimerRef.current = setTimeout(() => setSeekHint(null), 900);
+    };
+
+    const handleSeek = (event: Event) => {
+      const video = videoRef.current;
+      const seconds = (event as CustomEvent<{ seconds: number }>).detail?.seconds;
+      if (!video || !seconds) return;
+      // `seekable` is the honest bound, not `duration`. A video the backend is
+      // transcoding on the fly is served as a chunked stream with no length and
+      // no `Accept-Ranges`, so its duration reads as Infinity and the playhead
+      // will not move however far we ask it to. Saying that out loud beats a
+      // shortcut that silently does nothing.
+      const { seekable } = video;
+      if (!seekable || seekable.length === 0) {
+        showHint("unavailable");
+        return;
+      }
+      video.currentTime = Math.min(
+        Math.max(video.currentTime + seconds, seekable.start(0)),
+        seekable.end(seekable.length - 1)
+      );
+      showHint({ seconds });
+    };
+
+    window.addEventListener(LIGHTBOX_SEEK_EVENT, handleSeek);
+    return () => window.removeEventListener(LIGHTBOX_SEEK_EVENT, handleSeek);
+  }, []);
+
   useEffect(
     () => () => {
       if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      if (seekHintTimerRef.current) clearTimeout(seekHintTimerRef.current);
     },
     []
   );
@@ -368,6 +435,18 @@ export const VideoPlayer = memo(function VideoPlayer({
           }}
         >
           <Loader color="white" size="lg" />
+        </Center>
+      )}
+      {seekHint !== null && (
+        <Center style={{ position: "absolute", inset: 0, zIndex: 2, pointerEvents: "none" }}>
+          <Text
+            size="xl"
+            fw={600}
+            c="white"
+            style={{ background: "rgba(0,0,0,0.65)", borderRadius: 8, padding: "8px 16px" }}
+          >
+            {seekHint === "unavailable" ? t("lightbox.video.seekunavailable") : formatSeekDistance(seekHint.seconds)}
+          </Text>
         </Center>
       )}
       <video

--- a/apps/frontend/src/components/lightbox/lightbox.hotkeys.test.ts
+++ b/apps/frontend/src/components/lightbox/lightbox.hotkeys.test.ts
@@ -1,0 +1,80 @@
+/**
+ * A hotkey that never fires is indistinguishable from one that works.
+ *
+ * Play/pause was bound as `" "` and, because Mantine's parser splits on "+" and
+ * trims each part, resolved to an empty key that matched nothing -- so Space
+ * did nothing in the lightbox while being listed in the documentation and shown
+ * in the toolbar. Nothing failed; the key was simply dead.
+ *
+ * So each binding is run through Mantine's own dispatcher, with the event a
+ * browser really sends, and asked whether the handler was reached.
+ */
+import { getHotkeyHandler } from "@mantine/hooks";
+import { describe, expect, it, vi } from "vitest";
+import {
+  NEXT_KEY,
+  PLAY_PAUSE_KEY,
+  PREVIOUS_KEY,
+  SEEK_BACK_KEY,
+  SEEK_FORWARD_KEY,
+  SEEK_LONG_BACK_KEY,
+  SEEK_LONG_FORWARD_KEY,
+} from "./lightbox.hotkeys";
+
+/** Does `binding` fire when the browser reports this keypress? */
+function fires(binding: string, key: string, { shift = false, ctrl = false } = {}) {
+  const handler = vi.fn();
+  getHotkeyHandler([[binding, handler]])({
+    key,
+    code: key === " " ? "Space" : key,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: ctrl,
+    shiftKey: shift,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+  return handler.mock.calls.length > 0;
+}
+
+describe("lightbox hotkeys", () => {
+  it("play/pause answers to the space bar", () => {
+    expect(fires(PLAY_PAUSE_KEY, " ")).toBe(true);
+  });
+
+  it("the spelling that broke it stays broken, which is why the constant exists", () => {
+    // Kept as the reason the name is not written inline: " " is trimmed away.
+    expect(fires(" ", " ")).toBe(false);
+  });
+
+  it("the arrows move between photos", () => {
+    expect(fires(PREVIOUS_KEY, "ArrowLeft")).toBe(true);
+    expect(fires(NEXT_KEY, "ArrowRight")).toBe(true);
+  });
+
+  it("shift and the arrows seek", () => {
+    expect(fires(SEEK_BACK_KEY, "ArrowLeft", { shift: true })).toBe(true);
+    expect(fires(SEEK_FORWARD_KEY, "ArrowRight", { shift: true })).toBe(true);
+  });
+
+  it("ctrl and the arrows take the long jump", () => {
+    expect(fires(SEEK_LONG_BACK_KEY, "ArrowLeft", { ctrl: true })).toBe(true);
+    expect(fires(SEEK_LONG_FORWARD_KEY, "ArrowRight", { ctrl: true })).toBe(true);
+  });
+
+  it("the three arrow bindings are mutually exclusive", () => {
+    // Every arrow keypress must reach exactly one of navigate, short jump and
+    // long jump -- Mantine compares each modifier exactly, which is what lets
+    // one key carry three jobs.
+    expect(fires(NEXT_KEY, "ArrowRight", { ctrl: true })).toBe(false);
+    expect(fires(SEEK_FORWARD_KEY, "ArrowRight", { ctrl: true })).toBe(false);
+    expect(fires(SEEK_LONG_FORWARD_KEY, "ArrowRight", { shift: true })).toBe(false);
+    expect(fires(SEEK_LONG_FORWARD_KEY, "ArrowRight")).toBe(false);
+  });
+
+  it("seeking and navigating cannot both fire on one keypress", () => {
+    // Mantine compares modifiers exactly, which is the whole reason the arrows
+    // can keep their job while Shift gains a new one.
+    expect(fires(NEXT_KEY, "ArrowRight", { shift: true })).toBe(false);
+    expect(fires(SEEK_FORWARD_KEY, "ArrowRight")).toBe(false);
+  });
+});

--- a/apps/frontend/src/components/lightbox/lightbox.hotkeys.ts
+++ b/apps/frontend/src/components/lightbox/lightbox.hotkeys.ts
@@ -1,0 +1,28 @@
+/**
+ * Hotkey strings, spelled the way Mantine's parser reads them.
+ *
+ * `parseHotkey` splits on "+" and trims each part, so a literal " " arrives as
+ * an empty key and matches nothing at all -- which is how play/pause came to be
+ * listed in the documentation while never once firing. The name it understands
+ * for that key is "space".
+ *
+ * They live in their own module so the tests that check them against Mantine's
+ * own matcher do not have to mount the lightbox: a binding that silently never
+ * fires looks exactly like a binding that works, so the spelling is worth
+ * pinning down on its own.
+ */
+export const PLAY_PAUSE_KEY = "space";
+export const SEEK_BACK_KEY = "shift+ArrowLeft";
+export const SEEK_FORWARD_KEY = "shift+ArrowRight";
+
+/**
+ * The long jump, borrowed from VLC: Shift for the short one, Ctrl for the
+ * long one. Ctrl is the least bad of the modifiers left -- Alt with the
+ * arrows is browser back/forward on Windows and Linux, and Cmd with them is
+ * back/forward on macOS. Ctrl costs Mac users running several desktops the
+ * key to Mission Control, which claims it before the page ever sees it.
+ */
+export const SEEK_LONG_BACK_KEY = "ctrl+ArrowLeft";
+export const SEEK_LONG_FORWARD_KEY = "ctrl+ArrowRight";
+export const PREVIOUS_KEY = "ArrowLeft";
+export const NEXT_KEY = "ArrowRight";

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -527,6 +527,9 @@
       "rotateCW": "Rotate 90° clockwise",
       "rotateCCW": "Rotate 90° counter-clockwise"
     },
+    "video": {
+      "seekunavailable": "Seeking is not available while this video is being converted"
+    },
     "videoerror": {
       "retry": "Retry",
       "checking": "Checking what went wrong…",


### PR DESCRIPTION
The lightbox has no keyboard seeking for video, and the keys that would otherwise do it are already taken. A native `<video controls>` element seeks five seconds with the arrow keys when it has focus, and the visible control bar advertises exactly that — but `ContentViewer` binds the arrows on `document` through Mantine's `useHotkeys`, whose ignore list covers only `INPUT`, `TEXTAREA` and `SELECT`. `VIDEO` is not in it, so even after clicking into the player, `→` navigates to the next photo and throws your position away. The binding shadows a behaviour the UI is already offering.

Adding `VIDEO` to that ignore list is the tempting one-line fix and is worse than it looks: focus state is invisible, so an arrow key would seek or navigate depending on whether the user happened to have clicked the player first, which is less predictable than a rule that is merely incomplete. Google Photos and Apple Photos both keep the arrows on album navigation. So this adds keys rather than remapping them, following the split VLC makes between a short jump and a long one: `Shift` with the arrows moves ten seconds, `Ctrl` with them moves a minute. Mantine compares modifiers exactly, so each arrow keypress reaches exactly one of the three jobs and nothing shadows anything.

`Ctrl` is the least bad modifier left for the long jump. `Alt` with the arrows is browser back/forward on Windows and Linux, and `Cmd` with them is back/forward on macOS; `Ctrl` costs Mac users running several desktops a key that Mission Control claims before the page ever sees it, which the documentation says plainly.

The keypress and the `<video>` element live in different components, so the request travels as a window event, the way the lightbox already talks to its controls. Threading a ref down through `MediaDisplay` into a memoised player would couple three components to one keypress. Only the main carousel slide ever renders a player, so exactly one listener is mounted at a time.

Seeking is bounded by the element's `seekable` range rather than its `duration`, which also settles what happens on the transcoding path. A video being converted as it plays is served as a chunked stream with no length and no `Accept-Ranges`, so it offers no seekable window at all and the playhead will not move however far we ask. That case now says so on screen instead of leaving the key looking dead. The other half of #1983 — making that path seekable in the first place — is a separate backend PR.

While in here: **`Space` never worked.** It was bound as `" "`, and `parseHotkey` splits on `"+"` and trims each part, so that string resolves to an empty key which matches nothing. Play/pause has been listed in the documentation and shown in the toolbar tooltip while doing nothing at all. The name the parser understands is `"space"`. Every lightbox binding now lives in one small module and is checked against Mantine's own dispatcher with the event a browser really sends, because a hotkey that silently never fires looks exactly like one that works — which is how this one survived.

Tested in a browser against a real library, in both serving modes, and the whole frontend suite passes (139 tests, 19 files); `tsc` error count is unchanged from `dev`. The documented shortcut table gains the two new rows and a short section on seeking in videos.

Nothing here scales with library size: it is a keypress and an assignment to `currentTime`.

(Analysis and code by Claude, directed and browser-tested by me.)
