### PR TITLE
feat: make a transcoded video seekable, and serve byte ranges without the proxy (Closes #1983)

### DIFF
--- a/apps/backend/api/http_range.py
+++ b/apps/backend/api/http_range.py
@@ -1,0 +1,111 @@
+"""Byte-range support for files this backend serves itself.
+
+Installs that run behind the bundled nginx never reach this code for media
+bytes: the backend authorizes and hands off with ``X-Accel-Redirect``, and
+nginx answers ranges on its own. Installs that serve the frontend from Django
+have no such helper, and until now every file they served arrived whole, from
+the beginning, with no ``Accept-Ranges`` at all -- which is the same as saying
+that no video in one of those installs could be sought.
+"""
+
+import os
+import re
+
+from django.http import FileResponse, HttpResponse, StreamingHttpResponse
+
+#: Returned by :func:`parse_byte_range` when the range names bytes the file
+#: does not have, which HTTP answers with 416 rather than the whole file.
+UNSATISFIABLE = "unsatisfiable"
+
+CHUNK_SIZE = 64 * 1024
+
+_RANGE = re.compile(r"^bytes=(\d*)-(\d*)$")
+
+
+def parse_byte_range(header, size):
+    """Resolve a ``Range`` header against a file of ``size`` bytes.
+
+    Returns an inclusive ``(start, end)`` pair, :data:`UNSATISFIABLE`, or None
+    for "send the whole thing" -- which covers an absent header, a syntax this
+    does not understand, and multi-range requests. Answering those with the
+    complete file is always allowed and is what browsers expect; they only ever
+    ask for one range when seeking.
+    """
+    if not header or size <= 0:
+        return None
+    match = _RANGE.match(header.strip())
+    if not match:
+        return None
+    first, last = match.group(1), match.group(2)
+
+    if not first:
+        if not last:
+            return None
+        # "bytes=-500": the final 500 bytes, which is how a player finds the
+        # index of an mp4 that was not written for streaming.
+        length = min(int(last), size)
+        if length == 0:
+            return UNSATISFIABLE
+        return size - length, size - 1
+
+    start = int(first)
+    if start >= size:
+        return UNSATISFIABLE
+    end = min(int(last), size - 1) if last else size - 1
+    if end < start:
+        return UNSATISFIABLE
+    return start, end
+
+
+def _read_range(handle, start, length):
+    remaining = length
+    try:
+        handle.seek(start)
+        while remaining > 0:
+            chunk = handle.read(min(CHUNK_SIZE, remaining))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+            yield chunk
+    finally:
+        handle.close()
+
+
+def ranged_response(handle, size, range_header, content_type=None):
+    """Serve an open file, honouring a single byte range if one was asked for.
+
+    Takes the open handle rather than a path so that the caller keeps the one
+    place where a missing or unreadable file is diagnosed, and so the file
+    cannot change underneath between the two.
+    """
+    parsed = parse_byte_range(range_header, size)
+
+    if parsed is UNSATISFIABLE:
+        handle.close()
+        response = HttpResponse(status=416)
+        response["Content-Range"] = f"bytes */{size}"
+        response["Accept-Ranges"] = "bytes"
+        return response
+
+    if parsed is None:
+        response = FileResponse(handle)
+        if content_type:
+            response["Content-Type"] = content_type
+        response["Accept-Ranges"] = "bytes"
+        return response
+
+    start, end = parsed
+    length = end - start + 1
+    response = StreamingHttpResponse(
+        _read_range(handle, start, length),
+        status=206,
+        content_type=content_type or "application/octet-stream",
+    )
+    response["Content-Range"] = f"bytes {start}-{end}/{size}"
+    response["Content-Length"] = length
+    response["Accept-Ranges"] = "bytes"
+    return response
+
+
+def file_size(handle):
+    return os.fstat(handle.fileno()).st_size

--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 from django.db.utils import IntegrityError
 
 import api.models
-from api import date_time_extractor, face_extractor, util
+from api import date_time_extractor, face_extractor, transcode_cache, util
 from api.geocode import GEOCODE_VERSION
 from api.geocode.geocode import reverse_geocode
 from api.metadata.reader import get_metadata
@@ -591,6 +591,11 @@ class Photo(models.Model):
         self.files.set([])
         self.main_file = None
         self.removed = True
+
+        # A cached transcode outlives the photo otherwise: it is named after the
+        # image hash, which no longer belongs to anything, so nothing would ever
+        # serve it and nothing would ever reclaim it until the cache filled up.
+        transcode_cache.discard(self.image_hash)
 
         # Clear all stack references from this photo (ManyToMany)
         self.stacks.clear()

--- a/apps/backend/api/tests/test_http_range.py
+++ b/apps/backend/api/tests/test_http_range.py
@@ -1,0 +1,142 @@
+"""Byte ranges for files the backend serves itself.
+
+An install running behind the bundled proxy never gets here for media bytes --
+nginx answers ranges itself once the backend hands off with X-Accel-Redirect.
+An install serving media from Django had no such help: every response arrived
+whole, from the first byte, without so much as an ``Accept-Ranges`` header, so
+no video in one of those installs could be sought at all.
+"""
+
+import os
+import tempfile
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.http_range import UNSATISFIABLE, parse_byte_range, ranged_response
+from api.tests.utils import create_test_file, create_test_photo, create_test_user
+
+CONTENT = bytes(range(256)) * 8  # 2048 bytes, every one of them distinguishable
+
+
+class ParseByteRangeTest(TestCase):
+    def test_no_header_means_the_whole_file(self):
+        self.assertIsNone(parse_byte_range(None, 100))
+        self.assertIsNone(parse_byte_range("", 100))
+
+    def test_a_closed_range(self):
+        self.assertEqual(parse_byte_range("bytes=10-19", 100), (10, 19))
+
+    def test_an_open_range_runs_to_the_end(self):
+        self.assertEqual(parse_byte_range("bytes=90-", 100), (90, 99))
+
+    def test_a_suffix_range_counts_back_from_the_end(self):
+        # How a player finds the index of an mp4 that was not laid out for
+        # streaming: ask for the last few kilobytes.
+        self.assertEqual(parse_byte_range("bytes=-10", 100), (90, 99))
+
+    def test_a_suffix_longer_than_the_file_is_the_whole_file(self):
+        self.assertEqual(parse_byte_range("bytes=-500", 100), (0, 99))
+
+    def test_an_end_past_the_file_is_clamped(self):
+        self.assertEqual(parse_byte_range("bytes=50-999", 100), (50, 99))
+
+    def test_a_start_past_the_file_cannot_be_satisfied(self):
+        self.assertIs(parse_byte_range("bytes=100-", 100), UNSATISFIABLE)
+        self.assertIs(parse_byte_range("bytes=150-160", 100), UNSATISFIABLE)
+
+    def test_a_backwards_range_cannot_be_satisfied(self):
+        self.assertIs(parse_byte_range("bytes=50-10", 100), UNSATISFIABLE)
+
+    def test_syntax_we_do_not_speak_falls_back_to_the_whole_file(self):
+        # Answering with the complete file is always allowed, and is a great
+        # deal friendlier than a 416 at something merely unfamiliar.
+        self.assertIsNone(parse_byte_range("items=0-10", 100))
+        self.assertIsNone(parse_byte_range("bytes=abc", 100))
+        self.assertIsNone(parse_byte_range("bytes=0-10, 20-30", 100))
+        self.assertIsNone(parse_byte_range("bytes=-", 100))
+
+    def test_an_empty_file_has_no_ranges(self):
+        self.assertIsNone(parse_byte_range("bytes=0-10", 0))
+
+
+class RangedResponseTest(TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.path = os.path.join(self.directory.name, "clip.mp4")
+        with open(self.path, "wb") as handle:
+            handle.write(CONTENT)
+
+    def _serve(self, header):
+        handle = open(self.path, "rb")
+        return ranged_response(handle, len(CONTENT), header, "video/mp4")
+
+    def test_a_whole_file_still_advertises_ranges(self):
+        response = self._serve(None)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Accept-Ranges"], "bytes")
+        self.assertEqual(response["Content-Type"], "video/mp4")
+        response.close()
+
+    def test_a_range_is_answered_with_exactly_those_bytes(self):
+        response = self._serve("bytes=100-199")
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response["Content-Range"], f"bytes 100-199/{len(CONTENT)}")
+        self.assertEqual(response["Content-Length"], "100")
+        self.assertEqual(b"".join(response.streaming_content), CONTENT[100:200])
+
+    def test_an_open_range_runs_to_the_last_byte(self):
+        response = self._serve("bytes=2040-")
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(b"".join(response.streaming_content), CONTENT[2040:])
+
+    def test_a_range_larger_than_one_chunk_arrives_intact(self):
+        # The reader hands out 64 KiB at a time; a range has to survive being
+        # cut into pieces without gaining or losing a byte.
+        big = os.path.join(self.directory.name, "big.mp4")
+        payload = CONTENT * 100  # 200 KiB
+        with open(big, "wb") as handle:
+            handle.write(payload)
+        response = ranged_response(open(big, "rb"), len(payload), "bytes=1-199999")
+        self.assertEqual(b"".join(response.streaming_content), payload[1:200000])
+
+    def test_an_impossible_range_is_refused_rather_than_answered(self):
+        response = self._serve("bytes=9999-")
+        self.assertEqual(response.status_code, 416)
+        self.assertEqual(response["Content-Range"], f"bytes */{len(CONTENT)}")
+
+
+@override_settings(SERVE_FRONTEND=True)
+class ServeFileDirectRangeTest(TestCase):
+    """The same thing, reached the way a browser reaches it."""
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.user = create_test_user()
+        path = os.path.join(self.directory.name, "clip.mp4")
+        file = create_test_file(path, self.user, CONTENT)
+        self.photo = create_test_photo(owner=self.user, video=True)
+        # create_test_photo supplies a main_file of its own, so the real one has
+        # to be put in place afterwards.
+        self.photo.main_file = file
+        self.photo.save()
+        self.photo.files.add(file)
+        self.client = APIClient()
+        self.client.cookies["jwt"] = str(RefreshToken.for_user(self.user).access_token)
+
+    def test_seeking_a_video_gets_the_part_that_was_asked_for(self):
+        response = self.client.get(
+            f"/media/photos/{self.photo.image_hash}", HTTP_RANGE="bytes=64-127"
+        )
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response["Content-Range"], f"bytes 64-127/{len(CONTENT)}")
+        self.assertEqual(b"".join(response.streaming_content), CONTENT[64:128])
+
+    def test_a_plain_request_says_that_seeking_is_possible(self):
+        response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Accept-Ranges"], "bytes")
+        response.close()

--- a/apps/backend/api/tests/test_transcode_cache.py
+++ b/apps/backend/api/tests/test_transcode_cache.py
@@ -1,0 +1,415 @@
+"""The disk cache that makes a converted video seekable.
+
+"Always transcode videos" pipes a file the browser cannot decode through
+ffmpeg and streams the result as it is produced. That stream has no known
+length, so it carries no Content-Length and no Accept-Ranges, and a Range
+request against it can only be answered from the beginning -- which is to say
+that for anyone with the setting on, no video could be sought at all.
+
+The conversion is therefore also written to a file once, in the background, and
+later plays are served from that. These tests cover the two things that makes
+that safe: nothing is ever served before it is complete, and the cache stays
+inside both of the ceilings it is given.
+"""
+
+import os
+import shlex
+import tempfile
+from unittest import mock
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api import transcode_cache
+from api.views import views
+from api.tests.utils import create_test_file, create_test_photo, create_test_user
+
+GB = transcode_cache.BYTES_PER_GB
+
+
+def _write(path, content=b"x"):
+    with open(path, "wb") as handle:
+        handle.write(content)
+    return path
+
+
+class CacheDirectoryTestCase(TestCase):
+    """A cache in a temporary directory, roomy unless a test says otherwise."""
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = os.path.join(self.directory.name, "transcoded")
+        os.makedirs(self.root)
+        settings = override_settings(
+            TRANSCODE_CACHE_ROOT=self.root,
+            TRANSCODE_CACHE_MAX_GB=1,
+            TRANSCODE_CACHE_MIN_FREE_GB=0,
+            TRANSCODE_CACHE_MAX_CONCURRENT=1,
+        )
+        settings.enable()
+        self.addCleanup(settings.disable)
+
+
+class EnablementTest(CacheDirectoryTestCase):
+    def test_a_size_of_zero_switches_caching_off(self):
+        with override_settings(TRANSCODE_CACHE_MAX_GB=0):
+            self.assertFalse(transcode_cache.is_enabled())
+
+    def test_it_is_on_when_it_has_somewhere_to_write_and_room_to_write(self):
+        self.assertTrue(transcode_cache.is_enabled())
+
+
+class LookupTest(CacheDirectoryTestCase):
+    def setUp(self):
+        super().setUp()
+        self.photo = create_test_photo(owner=create_test_user(), video=True)
+
+    def test_nothing_cached_yet(self):
+        self.assertIsNone(transcode_cache.cached_path(self.photo))
+
+    def test_a_finished_file_is_found(self):
+        path = _write(transcode_cache.final_path(self.photo.image_hash))
+        self.assertEqual(transcode_cache.cached_path(self.photo), path)
+
+    def test_a_conversion_still_running_is_not_served(self):
+        # The part-file is the work in progress. Serving it would hand out a
+        # video that plays half way and stops.
+        _write(transcode_cache.final_path(self.photo.image_hash) + ".part")
+        self.assertIsNone(transcode_cache.cached_path(self.photo))
+
+    def test_serving_marks_the_file_as_recently_used(self):
+        # mtime is the only ordering the eviction has: access times cannot be
+        # relied on, since plenty of volumes are mounted noatime or relatime.
+        path = _write(transcode_cache.final_path(self.photo.image_hash))
+        os.utime(path, (1000, 1000))
+        transcode_cache.cached_path(self.photo)
+        self.assertGreater(os.stat(path).st_mtime, 1000)
+
+    def test_a_disabled_cache_never_reports_a_hit(self):
+        _write(transcode_cache.final_path(self.photo.image_hash))
+        with override_settings(TRANSCODE_CACHE_MAX_GB=0):
+            self.assertIsNone(transcode_cache.cached_path(self.photo))
+
+
+class EstimateTest(CacheDirectoryTestCase):
+    def test_the_estimate_follows_the_recorded_duration(self):
+        owner = create_test_user()
+        short = create_test_photo(owner=owner, video=True, video_length="60")
+        long = create_test_photo(owner=owner, video=True, video_length="600")
+        self.assertAlmostEqual(
+            transcode_cache.estimated_size(long),
+            transcode_cache.estimated_size(short) * 10,
+            delta=10,
+        )
+
+    def test_a_video_of_unknown_length_is_still_worth_starting(self):
+        photo = create_test_photo(owner=create_test_user(), video=True)
+        photo.video_length = None
+        self.assertGreater(transcode_cache.estimated_size(photo), 0)
+
+
+class CommandTest(CacheDirectoryTestCase):
+    def test_the_height_is_a_ceiling_rather_than_a_target(self):
+        # "scale=-2:720" enlarges anything shorter, which is most phone footage
+        # and exactly the material that needs converting.
+        command = transcode_cache.build_command("/in.mkv", "/out.part")
+        self.assertIn("scale=-2:'min(720,ih)'", command)
+
+    def test_the_cached_copy_is_encoded_more_carefully_than_the_live_one(self):
+        # Nothing is waiting on this conversion, and ultrafast costs roughly
+        # double the bytes for the same picture.
+        command = transcode_cache.build_command("/in.mkv", "/out.part")
+        self.assertIn("veryfast", command)
+        self.assertNotIn("ultrafast", command)
+
+    def test_the_result_is_laid_out_for_playing_over_http(self):
+        command = transcode_cache.build_command("/in.mkv", "/out.part")
+        self.assertIn("+faststart", command)
+
+    def test_it_stands_back_from_whatever_else_the_server_is_doing(self):
+        # Nobody is waiting for this conversion, so it must not take the machine
+        # away from playback, thumbnails or a scan.
+        command = transcode_cache.build_command("/in.mkv", "/out.part")
+        self.assertIn("nice", command[0])
+        self.assertEqual(command[1:3], ["-n", "10"])
+
+    def test_the_encoder_is_capped_at_half_the_cores(self):
+        # ffmpeg takes every core by default. The flag has to sit after the
+        # input, or it limits decoding rather than encoding.
+        command = transcode_cache.build_command("/in.mkv", "/out.part")
+        threads = command.index("-threads")
+        self.assertGreater(threads, command.index("/in.mkv"))
+        self.assertEqual(command[threads + 1], str(max(1, (os.cpu_count() or 2) // 2)))
+
+
+class MakeRoomTest(CacheDirectoryTestCase):
+    def test_the_least_recently_served_go_first(self):
+        old = _write(os.path.join(self.root, "old.mp4"), b"a" * 1000)
+        recent = _write(os.path.join(self.root, "recent.mp4"), b"b" * 1000)
+        os.utime(old, (1000, 1000))
+        os.utime(recent, (2000, 2000))
+
+        # Two 1000-byte entries in a 2500-byte cache: making room for another
+        # 1000 costs exactly one of them, and it should be the older.
+        with override_settings(TRANSCODE_CACHE_MAX_GB=2500 / GB):
+            self.assertTrue(transcode_cache.make_room(self.root, 1000))
+
+        self.assertFalse(os.path.exists(old))
+        self.assertTrue(os.path.exists(recent))
+
+    def test_a_conversion_in_progress_is_never_evicted(self):
+        part = _write(os.path.join(self.root, "busy.mp4.part"), b"a" * 1000)
+        with override_settings(TRANSCODE_CACHE_MAX_GB=500 / GB):
+            transcode_cache.make_room(self.root, 400)
+        self.assertTrue(os.path.exists(part))
+
+    def test_it_gives_up_rather_than_emptying_the_cache_for_nothing(self):
+        _write(os.path.join(self.root, "kept.mp4"), b"a" * 100)
+        with override_settings(TRANSCODE_CACHE_MAX_GB=1000 / GB):
+            self.assertFalse(transcode_cache.make_room(self.root, 5000))
+
+    def test_the_free_space_floor_is_respected_even_with_room_in_the_budget(self):
+        # The volume holds the thumbnails and, in the default layout, the
+        # database. Filling it is a worse outcome than converting again.
+        with override_settings(TRANSCODE_CACHE_MIN_FREE_GB=1):
+            with mock.patch.object(
+                transcode_cache, "free_bytes", return_value=GB + 1000
+            ):
+                self.assertFalse(transcode_cache.make_room(self.root, 5000))
+                self.assertTrue(transcode_cache.make_room(self.root, 500))
+
+
+class StalePartTest(CacheDirectoryTestCase):
+    def test_an_abandoned_conversion_stops_blocking_its_video(self):
+        # The part-file is how the claim is held across worker processes, so a
+        # worker killed mid-conversion would otherwise make that one video
+        # uncacheable forever.
+        stale = _write(os.path.join(self.root, "stale.mp4.part"))
+        fresh = _write(os.path.join(self.root, "fresh.mp4.part"))
+        os.utime(stale, (1000, 1000))
+
+        transcode_cache._drop_stale_parts(self.root)
+
+        self.assertFalse(os.path.exists(stale))
+        self.assertTrue(os.path.exists(fresh))
+
+
+class RunTranscodeTest(CacheDirectoryTestCase):
+    def setUp(self):
+        super().setUp()
+        self.final = os.path.join(self.root, "clip.mp4")
+        self.part = self.final + ".part"
+
+    def _command(self, script):
+        return ["sh", "-c", script.format(part=shlex.quote(self.part))]
+
+    def test_a_finished_conversion_is_published_under_its_real_name(self):
+        self.assertTrue(
+            transcode_cache.run_transcode(
+                self._command("printf video > {part}"), self.part, self.final
+            )
+        )
+        self.assertFalse(os.path.exists(self.part))
+        with open(self.final, "rb") as handle:
+            self.assertEqual(handle.read(), b"video")
+
+    def test_a_failed_conversion_leaves_nothing_behind(self):
+        # Publishing on failure is the one thing that must never happen: a
+        # truncated file would play part way through and stop, for good.
+        self.assertFalse(
+            transcode_cache.run_transcode(
+                self._command("printf half > {part}; exit 3"), self.part, self.final
+            )
+        )
+        self.assertFalse(os.path.exists(self.final))
+        self.assertFalse(os.path.exists(self.part))
+
+    def test_an_empty_result_is_not_published(self):
+        self.assertFalse(
+            transcode_cache.run_transcode(self._command("true"), self.part, self.final)
+        )
+        self.assertFalse(os.path.exists(self.final))
+
+    def test_a_command_that_cannot_even_start_is_survived(self):
+        _write(self.part)
+        self.assertFalse(
+            transcode_cache.run_transcode(
+                ["/nonexistent/ffmpeg"], self.part, self.final
+            )
+        )
+        self.assertFalse(os.path.exists(self.part))
+
+
+class EnsureCachedTest(CacheDirectoryTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user, video=True, video_length="10")
+        source = _write(os.path.join(self.directory.name, "source.mkv"), b"source")
+        self.photo.main_file = create_test_file(source, self.user, b"source")
+        self.photo.save()
+        self.started = []
+
+    def _start(self, command, part, final, root):
+        self.started.append((command, part, final))
+
+    def test_it_claims_the_work_and_starts_a_conversion(self):
+        self.assertTrue(transcode_cache.ensure_cached(self.photo, start=self._start))
+        self.assertEqual(len(self.started), 1)
+        self.assertTrue(os.path.exists(self.started[0][1]))
+
+    def test_a_second_request_does_not_start_a_second_conversion(self):
+        # The part-file is created with O_EXCL, which is the only claim that
+        # holds across the several worker processes the backend runs.
+        transcode_cache.ensure_cached(self.photo, start=self._start)
+        self.assertFalse(transcode_cache.ensure_cached(self.photo, start=self._start))
+        self.assertEqual(len(self.started), 1)
+
+    def test_an_already_cached_video_is_left_alone(self):
+        _write(transcode_cache.final_path(self.photo.image_hash))
+        self.assertFalse(transcode_cache.ensure_cached(self.photo, start=self._start))
+
+    def test_only_so_many_conversions_run_at_once(self):
+        _write(os.path.join(self.root, "someone-else.mp4.part"))
+        self.assertFalse(transcode_cache.ensure_cached(self.photo, start=self._start))
+
+    def test_a_full_disk_declines_the_work_instead_of_failing(self):
+        with override_settings(TRANSCODE_CACHE_MIN_FREE_GB=1):
+            with mock.patch.object(transcode_cache, "free_bytes", return_value=1000):
+                self.assertFalse(
+                    transcode_cache.ensure_cached(self.photo, start=self._start)
+                )
+        # And no claim is left behind to block a later, roomier attempt.
+        self.assertEqual(os.listdir(self.root), [])
+
+    def test_caching_switched_off_does_nothing_at_all(self):
+        with override_settings(TRANSCODE_CACHE_MAX_GB=0):
+            self.assertFalse(
+                transcode_cache.ensure_cached(self.photo, start=self._start)
+            )
+        self.assertEqual(self.started, [])
+
+    def test_a_photo_with_no_file_is_not_attempted(self):
+        self.photo.main_file = None
+        self.assertFalse(transcode_cache.ensure_cached(self.photo, start=self._start))
+
+
+class DiscardTest(CacheDirectoryTestCase):
+    def test_deleting_a_photo_takes_its_cached_copy_with_it(self):
+        user = create_test_user()
+        photo = create_test_photo(owner=user, video=True)
+        final = _write(transcode_cache.final_path(photo.image_hash))
+        part = _write(final + ".part")
+
+        photo.manual_delete()
+
+        self.assertFalse(os.path.exists(final))
+        self.assertFalse(os.path.exists(part))
+
+
+@override_settings(SERVE_FRONTEND=True)
+class ServingACachedTranscodeTest(CacheDirectoryTestCase):
+    """What the media endpoint does once a seekable copy exists."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = create_test_user()
+        self.user.transcode_videos = True
+        self.user.save()
+        self.photo = create_test_photo(owner=self.user, video=True)
+        source = _write(os.path.join(self.directory.name, "source.mkv"), b"source")
+        self.photo.main_file = create_test_file(source, self.user, b"source")
+        self.photo.save()
+        self.client = APIClient()
+        self.client.cookies["jwt"] = str(RefreshToken.for_user(self.user).access_token)
+
+    def test_the_file_is_served_instead_of_a_conversion_being_started(self):
+        _write(transcode_cache.final_path(self.photo.image_hash), b"cached mp4")
+
+        with mock.patch.object(views, "VideoTranscoder") as transcoder:
+            response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+
+        transcoder.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Accept-Ranges"], "bytes")
+        response.close()
+
+    def test_the_cached_copy_can_be_sought(self):
+        # The whole point: a live conversion has no length and no ranges, so
+        # until there is a file there is no seeking.
+        _write(transcode_cache.final_path(self.photo.image_hash), b"0123456789")
+
+        with mock.patch.object(views, "VideoTranscoder"):
+            response = self.client.get(
+                f"/media/photos/{self.photo.image_hash}", HTTP_RANGE="bytes=4-6"
+            )
+
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response["Content-Range"], "bytes 4-6/10")
+        self.assertEqual(b"".join(response.streaming_content), b"456")
+
+    @override_settings(SERVE_FRONTEND=False)
+    def test_behind_the_proxy_the_web_server_is_handed_the_file(self):
+        # nginx answers ranges by itself, so the redirect is all that is needed
+        # for seeking to work there.
+        with override_settings(MEDIA_ROOT=self.directory.name):
+            _write(transcode_cache.final_path(self.photo.image_hash), b"cached mp4")
+
+            with mock.patch.object(views, "VideoTranscoder") as transcoder:
+                response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+
+        transcoder.assert_not_called()
+        self.assertEqual(
+            response["X-Accel-Redirect"],
+            f"/protected_media/transcoded/{self.photo.image_hash}.mp4",
+        )
+        self.assertEqual(response["Content-Type"], "video/mp4")
+
+    def test_the_first_play_still_streams_live(self):
+        with (
+            mock.patch.object(views, "VideoTranscoder"),
+            mock.patch.object(views.transcode_cache, "ensure_cached"),
+            mock.patch.object(views, "gen", return_value=iter([b"live"])),
+        ):
+            response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response["Content-Type"], "video/mp4")
+            # Both answer to the same URL, and this is the poorer of the two: a
+            # browser that kept it would go on serving an unseekable video
+            # after a seekable one exists.
+            self.assertEqual(response["Cache-Control"], "no-store")
+            self.assertEqual(b"".join(response.streaming_content), b"live")
+
+    def test_the_copy_is_written_after_the_live_stream_and_not_beside_it(self):
+        # The live conversion has to keep ahead of playback. A second ffmpeg
+        # started next to it takes a share of the machine away from the one
+        # thing somebody is waiting for -- on two cores, half of it, which is
+        # enough to make a video that used to start at once look stuck.
+        with (
+            mock.patch.object(views, "VideoTranscoder"),
+            mock.patch.object(views.transcode_cache, "ensure_cached") as ensure_cached,
+            mock.patch.object(views, "gen", return_value=iter([b"x"])),
+        ):
+            response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+
+            ensure_cached.assert_not_called()
+            b"".join(response.streaming_content)
+            ensure_cached.assert_called_once()
+
+    def test_a_viewer_who_leaves_early_still_gets_a_copy_written(self):
+        # Closing the response closes the generator, so the copy is asked for
+        # whether the video ran to the end or the tab was shut after a second.
+        with (
+            mock.patch.object(views, "VideoTranscoder"),
+            mock.patch.object(views.transcode_cache, "ensure_cached") as ensure_cached,
+            mock.patch.object(views, "gen", return_value=iter([b"a", b"b", b"c"])),
+        ):
+            response = self.client.get(f"/media/photos/{self.photo.image_hash}")
+
+            next(response.streaming_content)
+            ensure_cached.assert_not_called()
+            response.close()
+            ensure_cached.assert_called_once()

--- a/apps/backend/api/transcode_cache.py
+++ b/apps/backend/api/transcode_cache.py
@@ -1,0 +1,390 @@
+"""A disk cache of transcoded videos, so a converted video can be sought.
+
+Some videos a library holds are in containers or codecs the browser cannot
+decode, and the per-user "Always transcode videos" setting exists to get those
+users something playable: the file is piped through ffmpeg and streamed out as
+mp4 while it is being converted.
+
+A live conversion cannot be sought, and nothing about the player can change
+that. Its length is not known until it ends, so the response carries no
+``Content-Length`` and no ``Accept-Ranges``; a ``Range`` request against it can
+only be answered with the whole stream from the beginning. For anyone with that
+setting on, every video therefore plays start to finish with no duration, no
+scrub bar and no way to skip -- a limitation with no notice attached to it.
+
+So the conversion is also written to a real file, once, in the background. The
+next play of that video is served from the file: an ordinary mp4 with a length
+and byte ranges, which the browser seeks natively. The first play still streams
+live, so nothing gets slower.
+
+Two ceilings keep the cache from being a liability. It never grows past
+``TRANSCODE_CACHE_MAX_GB``, and it never eats into the last
+``TRANSCODE_CACHE_MIN_FREE_GB`` of the filesystem -- the same volume usually
+holds the thumbnails and the database, and a full disk is a far worse outcome
+than a video that has to be converted again. When either ceiling is reached the
+least recently served entries are dropped, and when dropping them is not enough
+the video simply is not cached: playback falls back to streaming it live, which
+is what happens today anyway.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import threading
+import time
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+BYTES_PER_GB = 1024**3
+
+# What a minute of output costs, measured across real phone footage at the
+# preset below: roughly 15 MB. Used only to judge in advance whether a video can
+# possibly fit, never to report a size that matters.
+ESTIMATED_BYTES_PER_SECOND = 15 * BYTES_PER_GB / 1024 / 60
+
+# A part-file abandoned by a killed worker would otherwise keep its video from
+# ever being cached again, since its presence is what marks the work as taken.
+STALE_PART_SECONDS = 6 * 60 * 60
+
+# How often a conversion in progress re-checks that it is still welcome on the
+# disk. Sizes are estimates and something else may be filling the volume.
+SPACE_CHECK_SECONDS = 15
+
+PART_SUFFIX = ".part"
+
+
+def _root():
+    return getattr(settings, "TRANSCODE_CACHE_ROOT", "") or ""
+
+
+def _max_bytes():
+    return float(getattr(settings, "TRANSCODE_CACHE_MAX_GB", 0)) * BYTES_PER_GB
+
+
+def _min_free_bytes():
+    return float(getattr(settings, "TRANSCODE_CACHE_MIN_FREE_GB", 0)) * BYTES_PER_GB
+
+
+def _max_concurrent():
+    return max(1, int(getattr(settings, "TRANSCODE_CACHE_MAX_CONCURRENT", 1)))
+
+
+def is_enabled():
+    """Caching is off when it has nowhere to write or no room to write in."""
+    return bool(_root()) and _max_bytes() > 0
+
+
+def final_path(image_hash):
+    root = _root()
+    if not root or not image_hash:
+        return None
+    return os.path.join(root, f"{image_hash}.mp4")
+
+
+def media_name(image_hash):
+    """The name the finished file is served under, relative to the media root."""
+    return f"{image_hash}.mp4"
+
+
+def cached_path(photo):
+    """The finished transcode of ``photo``, or None. Marks it as just used.
+
+    ``mtime`` is the cache's idea of "last served", which is why it is stamped
+    on read: access times are unreliable (``relatime``, ``noatime``) and this
+    is the only ordering the eviction has to go on.
+    """
+    if not is_enabled():
+        return None
+    path = final_path(getattr(photo, "image_hash", None))
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        os.utime(path, None)
+    except OSError:
+        pass
+    return path
+
+
+def discard(image_hash):
+    """Forget a video: called when the photo it belongs to is deleted."""
+    path = final_path(image_hash)
+    for candidate in [path, (path + PART_SUFFIX) if path else None]:
+        if candidate and os.path.exists(candidate):
+            try:
+                os.remove(candidate)
+            except OSError:
+                logger.warning("could not remove cached transcode %s", candidate)
+
+
+def estimated_size(photo):
+    """How large the conversion is likely to be, from the stored duration.
+
+    Videos with no duration recorded are assumed to be worth a guess of one
+    minute rather than skipped: the running check on free space is what
+    actually protects the disk, and this only decides whether to begin.
+    """
+    length = getattr(photo, "video_length", None)
+    try:
+        seconds = float(length)
+    except (TypeError, ValueError):
+        seconds = 0.0
+    if seconds <= 0:
+        seconds = 60.0
+    return int(seconds * ESTIMATED_BYTES_PER_SECOND)
+
+
+def _entries(root):
+    """Finished cache files as (path, mtime, size), oldest use first."""
+    entries = []
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return entries
+    for name in names:
+        if name.endswith(PART_SUFFIX):
+            continue
+        path = os.path.join(root, name)
+        try:
+            stat = os.stat(path)
+        except OSError:
+            continue
+        if os.path.isfile(path):
+            entries.append((path, stat.st_mtime, stat.st_size))
+    entries.sort(key=lambda entry: entry[1])
+    return entries
+
+
+def _in_flight(root):
+    try:
+        return len([n for n in os.listdir(root) if n.endswith(PART_SUFFIX)])
+    except OSError:
+        return 0
+
+
+def _drop_stale_parts(root, now=None):
+    """Remove part-files whose writer is long gone.
+
+    ffmpeg touches its output continuously, so a part-file that has not grown
+    in hours belongs to a process that no longer exists -- a recycled worker, a
+    restarted container -- and holding its claim forever would make that one
+    video permanently uncacheable.
+    """
+    now = time.time() if now is None else now
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return
+    for name in names:
+        if not name.endswith(PART_SUFFIX):
+            continue
+        path = os.path.join(root, name)
+        try:
+            if now - os.stat(path).st_mtime > STALE_PART_SECONDS:
+                os.remove(path)
+                logger.info("removed abandoned transcode %s", path)
+        except OSError:
+            continue
+
+
+def free_bytes(root):
+    try:
+        return shutil.disk_usage(root).free
+    except OSError:
+        return 0
+
+
+def make_room(root, wanted):
+    """Free up ``wanted`` bytes of headroom, evicting least recently served.
+
+    Returns False when the room cannot be had, which is not an error: the
+    caller then leaves the video uncached and it streams live as before.
+    """
+    entries = _entries(root)
+    used = sum(entry[2] for entry in entries)
+    budget = _max_bytes()
+    reserve = _min_free_bytes()
+
+    for path, _, size in entries:
+        over_budget = used + wanted > budget
+        under_reserve = free_bytes(root) - wanted < reserve
+        if not over_budget and not under_reserve:
+            return True
+        try:
+            os.remove(path)
+        except OSError:
+            continue
+        used -= size
+        logger.info("evicted cached transcode %s", path)
+
+    return used + wanted <= budget and free_bytes(root) - wanted >= reserve
+
+
+def _background_threads():
+    """Leave at least half the machine to whoever is using it.
+
+    ffmpeg helps itself to every core by default, which is the right answer for
+    the conversion someone is waiting on and the wrong one for this. Half, and
+    never fewer than one.
+    """
+    return max(1, (os.cpu_count() or 2) // 2)
+
+
+def build_command(source, destination):
+    """The conversion that produces a seekable file.
+
+    Three deliberate differences from the live stream, all of them because
+    nobody is waiting for this one. It is niced and given half the cores, so
+    playback, thumbnails and the scan all outrank it. The preset is slower,
+    since ``ultrafast`` costs roughly double the bytes for the same picture --
+    about 30 MB a minute against 15. And the height is a ceiling rather than a
+    target: the live command scales everything to 720 lines, which quietly
+    *upscales* the phone clips that most often need converting, spending disk
+    and CPU to add nothing.
+    """
+    nice = shutil.which("nice")
+    niceness = int(getattr(settings, "TRANSCODE_CACHE_NICE", 10))
+    # Without the binary the conversion still runs, just without the courtesy.
+    prefix = [nice, "-n", str(niceness)] if nice and niceness else []
+    return prefix + [
+        "ffmpeg",
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        source,
+        # After the input, so it limits the encoder -- which is what costs the
+        # CPU. Before it, ffmpeg would read it as a decoder setting.
+        "-threads",
+        str(_background_threads()),
+        "-vcodec",
+        "libx264",
+        "-preset",
+        getattr(settings, "TRANSCODE_CACHE_PRESET", "veryfast"),
+        "-filter:v",
+        "scale=-2:'min(720,ih)'",
+        "-movflags",
+        "+faststart",
+        "-f",
+        "mp4",
+        destination,
+    ]
+
+
+def run_transcode(command, part, final, root=None):
+    """Convert into ``part`` and publish it as ``final`` if it worked out.
+
+    The rename is the commit: nothing serves a file until ffmpeg has exited
+    cleanly, so a conversion cut short by a restart or a filling disk leaves
+    only a part-file behind, never a truncated video that plays half way and
+    stops.
+    """
+    root = root or os.path.dirname(part)
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError:
+        logger.warning("could not start a transcode for %s", final, exc_info=True)
+        _remove(part)
+        return False
+
+    ran_out_of_room = False
+    while True:
+        try:
+            process.wait(timeout=SPACE_CHECK_SECONDS)
+            break
+        except subprocess.TimeoutExpired:
+            if free_bytes(root) < _min_free_bytes():
+                ran_out_of_room = True
+                process.kill()
+                process.wait()
+                break
+
+    if ran_out_of_room:
+        logger.info("abandoned caching %s: the disk is close to full", final)
+        _remove(part)
+        return False
+    if process.returncode != 0:
+        logger.warning("transcode of %s failed (%s)", final, process.returncode)
+        _remove(part)
+        return False
+    try:
+        if os.path.getsize(part) == 0:
+            _remove(part)
+            return False
+        os.replace(part, final)
+    except OSError:
+        logger.warning("could not publish cached transcode %s", final, exc_info=True)
+        _remove(part)
+        return False
+    logger.info("cached a seekable copy of %s", final)
+    return True
+
+
+def _remove(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _start_background(command, part, final, root):
+    thread = threading.Thread(
+        target=run_transcode,
+        args=(command, part, final, root),
+        name="transcode-cache",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def ensure_cached(photo, start=None):
+    """Begin caching ``photo`` if it is not cached and there is room for it.
+
+    Returns whether a conversion was started. Every reason not to start one is
+    ordinary: it is already there, someone else is already doing it, too many
+    are running, or the disk says no.
+    """
+    if not is_enabled():
+        return False
+    source = photo.main_file.path if photo.main_file else None
+    final = final_path(getattr(photo, "image_hash", None))
+    if not source or not final or os.path.isfile(final):
+        return False
+
+    root = _root()
+    try:
+        os.makedirs(root, exist_ok=True)
+    except OSError:
+        logger.warning("cannot create the transcode cache at %s", root)
+        return False
+
+    _drop_stale_parts(root)
+    if _in_flight(root) >= _max_concurrent():
+        return False
+    if not make_room(root, estimated_size(photo)):
+        logger.info("no room to cache a transcode of %s", final)
+        return False
+
+    part = final + PART_SUFFIX
+    try:
+        # O_EXCL is the claim, and it is the only one that holds across the
+        # several worker processes the backend runs: whoever creates the
+        # part-file owns the conversion, and everyone else moves on.
+        os.close(os.open(part, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
+    except FileExistsError:
+        return False
+    except OSError:
+        logger.warning("cannot write to the transcode cache at %s", root)
+        return False
+
+    (start or _start_background)(build_command(source, part), part, final, root)
+    return True

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from api.mail import email_is_configured
 from django.db.models import Q, Sum
 from django.http import (
-    FileResponse,
     HttpResponse,
     HttpResponseForbidden,
     StreamingHttpResponse,
@@ -34,10 +33,12 @@ from api.all_tasks import create_download_job, delete_zip_file
 from api.api_util import get_search_term_examples
 from api.autoalbum import delete_missing_photos
 from api.directory_watcher import scan_photos
+from api.http_range import file_size, ranged_response
 from api.ml_models import do_all_models_exist, download_models
 from api.models import AlbumUser, LongRunningJob, Photo, User
 from api.schemas.site_settings import site_settings_schema
 from api.serializers.album_user import AlbumUserEditSerializer, AlbumUserListSerializer
+from api import transcode_cache
 from api.util import logger
 from api.views.pagination import StandardResultsSetPagination
 
@@ -578,7 +579,11 @@ class VideoTranscoder:
             "-movflags",
             "frag_keyframe+empty_moov",
             "-filter:v",
-            ("scale=-2:" + str(720)),
+            # A ceiling, not a target: plain "scale=-2:720" enlarges anything
+            # shorter than 720 lines, and the phone clips that most often need
+            # converting are exactly that. Upscaling costs bandwidth and CPU to
+            # add nothing a viewer can see.
+            "scale=-2:'min(720,ih)'",
             "-f",
             "mp4",
             "-",
@@ -629,16 +634,24 @@ class UnifiedMediaAccessView(APIView):
         if not os.path.exists(file_path):
             return HttpResponse(status=404)
         try:
-            response = FileResponse(open(file_path, "rb"))
-            if content_type:
-                response["Content-Type"] = content_type
-            else:
+            handle = open(file_path, "rb")
+            if not content_type:
                 try:
                     mime = magic.Magic(mime=True)
-                    response["Content-Type"] = mime.from_file(file_path)
+                    content_type = mime.from_file(file_path)
                 except Exception:
-                    response["Content-Type"] = "application/octet-stream"
-            return response
+                    content_type = "application/octet-stream"
+            # Ranges matter here and nowhere else in this class: behind the
+            # bundled proxy the bytes never come from Django, but an install
+            # serving media itself has to answer a seek on its own, and a video
+            # served without ranges cannot be sought at all.
+            request = getattr(self, "request", None)
+            return ranged_response(
+                handle,
+                file_size(handle),
+                request.headers.get("Range") if request is not None else None,
+                content_type,
+            )
         except FileNotFoundError:
             return HttpResponse(status=404)
         except PermissionError:
@@ -652,17 +665,66 @@ class UnifiedMediaAccessView(APIView):
         except Exception:
             return HttpResponse(status=500)
 
-    def _transcoded_video_response(self, photo):
-        """Pipe the original through ffmpeg and hand out a plain mp4 stream.
+    def _transcoded_video_response(self, photo, use_proxy):
+        """Hand out a playable mp4 for a video the browser cannot decode.
 
         Browsers cannot decode every container/codec we store, so the per-user
         "Always transcode videos" setting exists to get them something they can
         actually play.
+
+        A conversion happening live cannot be sought -- its length is unknown
+        until it ends, so there is no ``Content-Length``, no ``Accept-Ranges``
+        and nothing a ``Range`` request can be answered with. The first play
+        still streams like that, because it starts immediately; in the
+        background the same conversion is written to a file, and every later
+        play is served from that instead, as an ordinary seekable mp4. See
+        :mod:`api.transcode_cache` for what keeps it from filling the disk.
         """
-        return StreamingHttpResponse(
-            gen(VideoTranscoder(photo.main_file.path)),
+        cached = transcode_cache.cached_path(photo)
+        if cached:
+            served_by_proxy = use_proxy and cached.startswith(
+                os.path.join(settings.MEDIA_ROOT, "")
+            )
+            if served_by_proxy:
+                response = HttpResponse()
+                response["Content-Type"] = "video/mp4"
+                response["X-Accel-Redirect"] = self._protected_media_url(
+                    os.path.dirname(os.path.relpath(cached, settings.MEDIA_ROOT)),
+                    os.path.basename(cached),
+                )
+                return response
+            return self._serve_file_direct(cached, "video/mp4")
+
+        response = StreamingHttpResponse(
+            self._cache_after_streaming(
+                gen(VideoTranscoder(photo.main_file.path)), photo
+            ),
             content_type="video/mp4",
         )
+        # The live stream and the cached file answer to the same URL, and this
+        # one is the poorer of the two: a browser that kept it would keep
+        # serving an unseekable video after a seekable one exists.
+        response["Cache-Control"] = "no-store"
+        return response
+
+    @staticmethod
+    def _cache_after_streaming(stream, photo):
+        """Stream the live conversion, and only then start writing the copy.
+
+        Not alongside it. The live conversion has to keep ahead of playback, and
+        a second ffmpeg started next to it takes a share of the machine away
+        from the one thing somebody is actually waiting for -- on a two-core
+        server, half of it, which is enough to turn a video that used to start
+        at once into one that looks stuck.
+
+        Waiting costs nothing, because the copy is for the *next* play. The
+        generator is closed either way, whether the video ran to the end or the
+        viewer left after five seconds, so the copy still gets written.
+        """
+        try:
+            yield from stream
+        finally:
+            transcode_cache.ensure_cached(photo)
 
     def _thumbnail_field_for(self, photo, path):
         """Return the ``FieldFile`` holding the thumbnail ``path`` asks for.
@@ -742,7 +804,7 @@ class UnifiedMediaAccessView(APIView):
 
         if photo.video:
             if transcode_videos:
-                return self._transcoded_video_response(photo)
+                return self._transcoded_video_response(photo, use_proxy=True)
             mime = magic.Magic(mime=True)
             filename = mime.from_file(photo.main_file.path)
             response = HttpResponse()
@@ -800,7 +862,7 @@ class UnifiedMediaAccessView(APIView):
 
         if photo.video:
             if transcode_videos:
-                return self._transcoded_video_response(photo)
+                return self._transcoded_video_response(photo, use_proxy=False)
             return self._serve_file_direct(photo.main_file.path)
 
         file_path = os.path.join(settings.MEDIA_ROOT, path, fname)
@@ -815,7 +877,7 @@ class UnifiedMediaAccessView(APIView):
         transcode videos", exactly like the thumbnail/video paths do.
         """
         if photo.video and transcode_videos:
-            return self._transcoded_video_response(photo)
+            return self._transcoded_video_response(photo, use_proxy=use_proxy)
         try:
             mime = magic.Magic(mime=True)
             content_type = mime.from_file(photo.main_file.path)

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -31,6 +31,27 @@ IM2TXT_ROOT = os.path.join(MEDIA_ROOT, "data_models", "im2txt")
 BLIP_ROOT = os.path.join(MEDIA_ROOT, "data_models", "blip")
 PLACES365_ROOT = os.path.join(MEDIA_ROOT, "data_models", "places365", "model")
 CLIP_ROOT = os.path.join(MEDIA_ROOT, "data_models", "clip-embeddings")
+
+# Videos in a container or codec the browser cannot decode are converted on the
+# fly for users who turn on "Always transcode videos". A live conversion has no
+# known length, so it cannot be sought at all; the same conversion is therefore
+# written to a file in the background and later plays are served from that,
+# seekable. See api/transcode_cache.py.
+#
+# The cache is bounded twice over: it never grows past TRANSCODE_CACHE_MAX_GB,
+# and it never eats into the last TRANSCODE_CACHE_MIN_FREE_GB of the volume,
+# which is shared with the thumbnails and (in the default layout) the database.
+# Set the size to 0 to switch caching off and keep only the live streaming.
+TRANSCODE_CACHE_ROOT = os.path.join(MEDIA_ROOT, "transcoded")
+TRANSCODE_CACHE_MAX_GB = float(os.environ.get("TRANSCODE_CACHE_MAX_GB", "10"))
+TRANSCODE_CACHE_MIN_FREE_GB = float(os.environ.get("TRANSCODE_CACHE_MIN_FREE_GB", "2"))
+TRANSCODE_CACHE_MAX_CONCURRENT = int(
+    os.environ.get("TRANSCODE_CACHE_MAX_CONCURRENT", "1")
+)
+# How far the background conversion stands back from everything else. It is
+# niced and given half the cores, because playback, thumbnails and the scan all
+# matter more than a copy nobody is waiting for.
+TRANSCODE_CACHE_NICE = int(os.environ.get("TRANSCODE_CACHE_NICE", "10"))
 LOGS_ROOT = BASE_LOGS
 # Create the directory before anything in this module writes to it. secret.key
 # lives in there too and is written some 40 lines further down, so an install

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -173,6 +173,23 @@ services:
 `FEATURE_PROCESS_EMBEDDED_MEDIA` is checked only at the moment a file is first imported. Turning it on for a library that has already been scanned extracts nothing for the photos already there — not even with **Rescan All Photos** — so only files added afterwards are affected.
 :::
 
+### Cached video conversions
+
+A user who turns on **Always transcode videos** (Settings → Experimental) has videos in containers or codecs their browser cannot decode converted as they play. A conversion happening live has no known length, so it carries no `Content-Length` and no `Accept-Ranges`, and it cannot be sought at all — no duration, no scrub bar, no skipping. The same conversion is therefore written to a file once, and every later play of that video is served from the file instead, as an ordinary seekable mp4. The first play still streams live and starts exactly as quickly as it does today: the copy is written **after** that stream ends, never alongside it, because the live conversion has to keep ahead of playback and would lose a share of the machine to a second ffmpeg. The copy is also niced and limited to half the cores, so playback, thumbnails and a running scan all outrank it.
+
+The cache costs somewhere between 10 and 20 MB per minute of video — how much movement there is in the footage decides where in that range it lands — and only for the videos somebody actually opens with that setting on. If nobody turns it on, nothing is ever written.
+
+| Variable | `.env` key | Default | What it does |
+| --- | --- | --- | --- |
+| `TRANSCODE_CACHE_MAX_GB` | `transcodeCacheMaxGb` | `10` | How large the cache may grow, in GB. Roughly an hour of video per GB. Set it to `0` to switch caching off entirely and keep only the live streaming. |
+| `TRANSCODE_CACHE_MIN_FREE_GB` | `transcodeCacheMinFreeGb` | `2` | How much free space to leave alone on the volume, in GB. The cache never writes into this, and a conversion already running is abandoned if the free space drops into it. |
+| `TRANSCODE_CACHE_MAX_CONCURRENT` | `transcodeCacheMaxConcurrent` | `1` | How many conversions may be written at once. Each is an ffmpeg process, so raising this trades CPU for having more videos become seekable sooner. |
+| `TRANSCODE_CACHE_NICE` | `transcodeCacheNice` | `10` | How far the background conversion stands back from everything else, as a `nice` value. `0` turns the courtesy off. |
+
+When either ceiling is reached, the least recently played entries are deleted until the new one fits; if even that is not enough, the video simply is not cached and plays live as before. Nothing is ever served before its conversion has finished, so an interrupted one leaves no half-playable file behind.
+
+The files live under `protected_media/transcoded/`, named by image hash, and are deleted along with the photo. Deleting the directory by hand is safe at any time — it costs only the CPU to convert those videos again.
+
 ### Logging
 
 The backend writes its log files into the directory named by `BASE_LOGS`. `ownphotos.log` is the one to look at first; it is also downloadable from the Admin Area (see [Internal files](../user-guide/internal-files.md) and [Library](../user-guide/library.md)).

--- a/apps/docs/docs/user-guide/settings/index.md
+++ b/apps/docs/docs/user-guide/settings/index.md
@@ -55,6 +55,10 @@ For each rule you can toggle it on or off, delete it, or drag it to reorder the 
 
 Always transcode videos will transcode all videos on demand to h264 to improve compatibility. This is not yet well optimized.
 
+The first time you play a video with this on, it is converted as it plays. A conversion happening live has no known length, so that first play has no duration and cannot be sought — the scrub bar and the seek shortcuts do nothing, and the player says so. Once you are done watching, that same conversion is written to a file in the background — afterwards rather than at the same time, so it never slows down the video you are watching — and every later play of that video is served from it: an ordinary video with a duration, a working scrub bar and working seek keys.
+
+Converted copies are kept under `protected_media/transcoded/` and cost somewhere between 10 and 20 MB per minute of video, depending on how much movement there is in it. The store is capped and prunes the videos you have not watched for longest; an administrator can change the ceiling, or turn the whole thing off, with [`TRANSCODE_CACHE_MAX_GB`](../../installation/environment-variables.md#cached-video-conversions).
+
 ### Large Language Model Settings
 
 These switches enhance generated captions with the large language model an administrator selects in the Admin Area (`Large Language Model`). If that is set to `None`, the switches have no effect. All are off by default.

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -81,6 +81,10 @@ services:
       - FEATURE_REVERSE_GEOCODING=${featureReverseGeocoding:-true}
       - FEATURE_SCENE_CLASSIFICATION=${featureSceneClassification:-true}
       - FEATURE_PROCESS_EMBEDDED_MEDIA=${featureProcessEmbeddedMedia:-true}
+      - TRANSCODE_CACHE_MAX_GB=${transcodeCacheMaxGb:-10}
+      - TRANSCODE_CACHE_MIN_FREE_GB=${transcodeCacheMinFreeGb:-2}
+      - TRANSCODE_CACHE_MAX_CONCURRENT=${transcodeCacheMaxConcurrent:-1}
+      - TRANSCODE_CACHE_NICE=${transcodeCacheNice:-10}
       - DEBUG=0
     depends_on:
       db:

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -86,6 +86,32 @@ featureProcessEmbeddedMedia=true
 
 # ---------------------------------------------------------------------------------------------
 
+# Cached video conversions. A user who turns on "Always transcode videos" has
+# videos converted for them as they play, and a conversion happening live
+# cannot be sought - it has no known length. The same conversion is therefore
+# written to a file once, in the background, and later plays are served from
+# that, seekable - written after you finish watching, never alongside, so it
+# cannot slow the video down. It costs 10-20 MB per minute of video, depending
+# on how much movement there is, and only for the videos someone actually opens
+# with that setting on.
+#
+# The cache never grows past the first number, and never eats into the last of
+# the free space named by the second - that volume also holds the thumbnails
+# and, in this layout, the database. When either ceiling is reached the least
+# recently played entries are dropped. Set the size to 0 to switch caching off
+# and keep only the live streaming.
+# transcodeCacheMaxGb=10
+# transcodeCacheMinFreeGb=2
+
+# How many conversions may be written at once; each one is an ffmpeg process.
+# transcodeCacheMaxConcurrent=1
+
+# How far the conversion stands back from everything else, as a nice value.
+# It is also limited to half the cores. 0 turns the courtesy off.
+# transcodeCacheNice=10
+
+# ---------------------------------------------------------------------------------------------
+
 # Outgoing email (for the self-service "Forgot password" flow) is configured in
 # the app itself: Admin area -> Site Settings -> Email. No SMTP settings are
 # needed here.


### PR DESCRIPTION
This is the second half of #1983, and the finding underneath the one the issue was filed about. #1990 adds seek shortcuts to the lightbox; this makes them mean something for the users who need them most.

A user who turns on "Always transcode videos" gets files their browser cannot decode converted for them as they play — and, until now, could not seek a single one of them. `_transcoded_video_response` pipes the conversion straight out of ffmpeg, so its length is not known until it ends: the response carries no `Content-Length` and no `Accept-Ranges`, and a `Range` request is answered with `200` and the whole stream from the beginning rather than `206`. No duration, no scrub bar, no skipping, and nothing anywhere saying so. Nothing about the player can fix that.

So the same conversion is now also written to a file, once. The first play still streams live and starts exactly as quickly as it does today; every later play of that video is served from the file instead, as an ordinary mp4 with a length and byte ranges the browser seeks natively. Behind the bundled proxy it is handed to nginx with `X-Accel-Redirect`, which answers ranges itself.

**Installs that serve media from Django had no ranges at all**, transcoded or not — `FileResponse` sends whole files — so no video in one of those installs could be sought either. `_serve_file_direct` now honours a `Range` header and advertises `Accept-Ranges` on a full response.

**The copy is written after the live stream ends, never beside it.** Starting it alongside was measurably worse than doing nothing at all: the live conversion has to keep ahead of playback, and on a two-core server a second ffmpeg takes half the machine away from the only thing anyone is waiting for. Measured on a 2-core box with the same file — time to first byte 3.15s racing, 1.42s deferred; whole stream 7.39s against 4.14s. In a browser that reads as a video that will not start. Deferring costs nothing, because the copy is for the *next* play, and it is still written when the viewer walks away after five seconds, since closing the response closes the generator either way. The conversion is also niced and held to half the cores, so playback, thumbnails and a running scan all outrank it.

The cache is bounded twice over. It never grows past `TRANSCODE_CACHE_MAX_GB` (10 by default) and never eats into the last `TRANSCODE_CACHE_MIN_FREE_GB` (2) of the volume — which also holds the thumbnails and, in the stock layout, the database, and a full disk is a far worse outcome than a video that has to be converted again. Crossing either ceiling drops the least recently played entries; when that is not enough the video simply is not cached and streams live as before, which is today's behaviour. Setting the size to `0` switches caching off entirely.

Nothing is served before its conversion has finished — the rename is the commit — so an interrupted one leaves no half-playable file behind, only a part-file that the next request cleans up. The part-file is created with `O_EXCL`, which is the only claim that holds across the several worker processes the backend runs. A cached copy is deleted along with its photo.

**Small libraries are unaffected either way.** Nothing is written unless somebody turns that setting on and opens a video, so an install where nobody does pays exactly nothing. The cost is per video watched, not per video owned, and it is bounded by a number the administrator sets.

While in here, both ffmpeg commands stop upscaling. `scale=-2:720` is a target rather than a ceiling, so a 640x352 phone clip — the kind that most often needs converting in the first place — was being enlarged to 1280x720, spending disk and CPU to add nothing a viewer can see. That turned one 2.3 MB video into a 7.5 MB one. With the height capped and the cached copy encoded at `veryfast` rather than `ultrafast`, a 44-second clip that used to convert to 21.8 MB now converts to 4.4 MB.

50 new tests cover the range parser and response, the eviction and free-space rules, the single-flight claim, the publish-only-on-success rule, the deferral, and the serving paths in both proxy and no-proxy modes. The full backend suite passes with no new failures against a `dev` baseline. Verified end to end on a running stack as well: first play chunked with `Cache-Control: no-store`, the copy appearing afterwards, then `200` with a real `Content-Length` and `Accept-Ranges`, and `Range: bytes=1000000-1000999` answered with `206` and the right `Content-Range`.

The three settings are documented on the environment-variables page, added to `librephotos.env` and the bundled compose file, and the behaviour is described in the user-facing settings documentation.

(Analysis and code by Claude, directed and browser-tested by me.)
