### PR TITLE
Only start the ML services their feature flags call for

### DIFF
--- a/apps/backend/api/management/commands/start_service.py
+++ b/apps/backend/api/management/commands/start_service.py
@@ -2,7 +2,12 @@ from django.core.management.base import BaseCommand
 from django_q.models import Schedule
 from django_q.tasks import schedule
 
-from api.services import SERVICES, start_service
+from api.services import (
+    SERVICE_FEATURE_FLAGS,
+    SERVICES,
+    is_service_enabled,
+    start_service,
+)
 
 
 class Command(BaseCommand):
@@ -24,6 +29,11 @@ class Command(BaseCommand):
         service = kwargs["service"]
         if service == "all":
             for svc in SERVICES.keys():
+                if not is_service_enabled(svc):
+                    self.stdout.write(
+                        f"Skipping {svc}: {SERVICE_FEATURE_FLAGS[svc]} is disabled"
+                    )
+                    continue
                 start_service(svc)
             if not Schedule.objects.filter(func="api.services.check_services").exists():
                 schedule(

--- a/apps/backend/api/management/commands/start_service.py
+++ b/apps/backend/api/management/commands/start_service.py
@@ -3,8 +3,8 @@ from django_q.models import Schedule
 from django_q.tasks import schedule
 
 from api.services import (
-    SERVICE_FEATURE_FLAGS,
     SERVICES,
+    disabled_reason,
     is_service_enabled,
     start_service,
 )
@@ -30,9 +30,7 @@ class Command(BaseCommand):
         if service == "all":
             for svc in SERVICES.keys():
                 if not is_service_enabled(svc):
-                    self.stdout.write(
-                        f"Skipping {svc}: {SERVICE_FEATURE_FLAGS[svc]} is disabled"
-                    )
+                    self.stdout.write(f"Skipping {svc}: {disabled_reason(svc)}")
                     continue
                 start_service(svc)
             if not Schedule.objects.filter(func="api.services.check_services").exists():

--- a/apps/backend/api/services.py
+++ b/apps/backend/api/services.py
@@ -60,17 +60,58 @@ SERVICE_FEATURE_FLAGS = {
 }
 
 
+def _ocr_model_selected():
+    """Whether an admin has picked an OCR model in the site settings.
+
+    OCR's switch is a site setting rather than an environment variable, and it
+    ships with nothing selected, so the sidecar would otherwise be started on
+    every deployment for a feature none of them has turned on. Reusing
+    ml_models' notion of "not selected" keeps this gate, the model download and
+    the OCR jobs from ever disagreeing about what the value means.
+
+    A configuration the process cannot read counts as selected: the flags fail
+    open for the same reason, and a database that is not up yet must not be able
+    to take a service away.
+    """
+    try:
+        from constance import config as site_config
+
+        from api.ml_models import _is_model_not_selected
+
+        return not _is_model_not_selected(site_config.OCR_MODEL)
+    except Exception:
+        return True
+
+
+# Services whose switch is a site setting rather than an environment flag. The
+# per-minute watchdog re-reads these, so selecting an OCR model starts the
+# sidecar without a restart.
+SERVICE_SITE_GATES = {"ocr": _ocr_model_selected}
+
+
 def is_service_enabled(service):
-    """Whether this deployment's feature flags call for the service to run.
+    """Whether this deployment's configuration calls for the service to run.
 
     A flag the settings module does not define counts as enabled, so an
     unrecognised switch can never take a service away from a deployment that
     had it before.
     """
+    gate = SERVICE_SITE_GATES.get(service)
+    if gate is not None and not gate():
+        return False
+
     flag = SERVICE_FEATURE_FLAGS.get(service)
     if flag is None:
         return True
     return bool(getattr(settings, flag, True))
+
+
+def disabled_reason(service):
+    """Why is_service_enabled turned the service down, for a log or an error."""
+    flag = SERVICE_FEATURE_FLAGS.get(service)
+    if flag is not None and not bool(getattr(settings, flag, True)):
+        return f"{flag} is disabled"
+    return "no model is selected for it in the site settings"
 
 
 def check_services():
@@ -128,11 +169,7 @@ def _service_environment():
 
 def start_service(service):
     if not is_service_enabled(service):
-        logger.info(
-            "Service '%s' not started: %s is disabled",
-            service,
-            SERVICE_FEATURE_FLAGS[service],
-        )
+        logger.info("Service '%s' not started: %s", service, disabled_reason(service))
         return False
 
     # Check system compatibility before attempting to start the service

--- a/apps/backend/api/services.py
+++ b/apps/backend/api/services.py
@@ -39,11 +39,49 @@ SERVICES = {
 
 HTTP_OK = 200
 
+# The feature flag each service serves; None means core scan/search, always on.
+#
+# llm is gated on captioning because captioning is its only consumer: port 8008
+# is reached from api.llm.generate_prompt and the Moondream branch of
+# api.image_captioning.generate_caption, and both are called only from
+# PhotoCaption's caption generation, which already stops when
+# FEATURE_IMAGE_CAPTIONING is off. If anything else ever calls generate_prompt
+# — chat, cluster naming — this has to go back to None.
+SERVICE_FEATURE_FLAGS = {
+    "image_similarity": None,
+    "thumbnail": None,
+    "face_recognition": "FEATURE_FACE_DETECTION",
+    "clip_embeddings": None,
+    "llm": "FEATURE_IMAGE_CAPTIONING",
+    "image_captioning": "FEATURE_IMAGE_CAPTIONING",
+    "exif": None,
+    "tags": "FEATURE_SCENE_CLASSIFICATION",
+    "ocr": None,
+}
+
+
+def is_service_enabled(service):
+    """Whether this deployment's feature flags call for the service to run.
+
+    A flag the settings module does not define counts as enabled, so an
+    unrecognised switch can never take a service away from a deployment that
+    had it before.
+    """
+    flag = SERVICE_FEATURE_FLAGS.get(service)
+    if flag is None:
+        return True
+    return bool(getattr(settings, flag, True))
+
 
 def check_services():
     for service in SERVICES.keys():
         if service in INCOMPATIBLE_SERVICES:
             logger.info(f"Skipping restart of incompatible service: {service}")
+            continue
+
+        if not is_service_enabled(service):
+            # Silent on purpose: this runs every minute, and startup already
+            # logged the reason once.
             continue
 
         if not is_healthy(service):
@@ -89,6 +127,14 @@ def _service_environment():
 
 
 def start_service(service):
+    if not is_service_enabled(service):
+        logger.info(
+            "Service '%s' not started: %s is disabled",
+            service,
+            SERVICE_FEATURE_FLAGS[service],
+        )
+        return False
+
     # Check system compatibility before attempting to start the service
     if not is_service_compatible(service):
         logger.error(f"Service '{service}' is not compatible with this system")

--- a/apps/backend/api/tests/test_service_feature_flags.py
+++ b/apps/backend/api/tests/test_service_feature_flags.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase, override_settings
+from rest_framework.test import APIClient
 
+from api.models import User
 from api.services import (
     SERVICE_FEATURE_FLAGS,
     SERVICES,
@@ -17,6 +19,7 @@ from api.services import (
     is_service_enabled,
     start_service,
 )
+from api.tests.utils import create_password
 
 
 def spawned_services(popen_mock):
@@ -208,3 +211,84 @@ class CheckServicesTest(SimpleTestCase):
             ],
             logs.output,
         )
+
+
+class ServiceAdminApiTest(TestCase):
+    """The admin Services page has to tell "switched off" from "crashed".
+
+    Reporting a flag-disabled service as merely unhealthy sends an admin looking
+    for a fault that is not there, and offers a Start button whose 500 tells them
+    nothing about why.
+    """
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            "admin", "admin@test.com", create_password()
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin)
+
+    @patch("api.views.services.is_healthy", return_value=True)
+    def test_an_enabled_service_reports_its_health(self, _healthy):
+        response = self.client.get("/api/services/face_recognition/")
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {
+                "service_name": "face_recognition",
+                "healthy": True,
+                "enabled": True,
+                "feature_flag": "FEATURE_FACE_DETECTION",
+            },
+            response.json(),
+        )
+
+    def test_a_core_service_names_no_flag(self):
+        with patch("api.views.services.is_healthy", return_value=True):
+            response = self.client.get("/api/services/thumbnail/")
+
+        self.assertIsNone(response.json()["feature_flag"])
+        self.assertTrue(response.json()["enabled"])
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    @patch("api.views.services.is_healthy", return_value=False)
+    def test_a_disabled_service_is_reported_as_disabled(self, healthy_mock):
+        response = self.client.get("/api/services/face_recognition/")
+
+        self.assertEqual(200, response.status_code)
+        self.assertFalse(response.json()["enabled"])
+        self.assertEqual("FEATURE_FACE_DETECTION", response.json()["feature_flag"])
+        healthy_mock.assert_not_called()
+
+    @override_settings(FEATURE_IMAGE_CAPTIONING=False)
+    @patch("api.views.services.start_service")
+    def test_starting_a_disabled_service_is_a_conflict_naming_the_flag(
+        self, start_mock
+    ):
+        response = self.client.post("/api/services/llm/start/")
+
+        self.assertEqual(409, response.status_code)
+        self.assertEqual("FEATURE_IMAGE_CAPTIONING", response.json()["feature_flag"])
+        self.assertIn("FEATURE_IMAGE_CAPTIONING", response.json()["error"])
+        start_mock.assert_not_called()
+
+    @patch("api.views.services.start_service", return_value=True)
+    def test_starting_an_enabled_service_still_succeeds(self, _start):
+        response = self.client.post("/api/services/tags/start/")
+
+        self.assertEqual(200, response.status_code)
+
+    @patch("api.views.services.start_service", return_value=False)
+    def test_an_enabled_service_that_fails_to_start_is_still_a_server_error(
+        self, _start
+    ):
+        """409 is for the switch; a genuine failure must not be dressed up as one."""
+        response = self.client.post("/api/services/tags/start/")
+
+        self.assertEqual(500, response.status_code)
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_an_unknown_service_is_still_a_404(self):
+        response = self.client.post("/api/services/not_a_service/start/")
+
+        self.assertEqual(404, response.status_code)

--- a/apps/backend/api/tests/test_service_feature_flags.py
+++ b/apps/backend/api/tests/test_service_feature_flags.py
@@ -1,0 +1,210 @@
+"""The FEATURE_* switches decide which ML services are spawned and watched.
+
+Without this, a deployment that turned face detection or captioning off still
+paid for every model: `start_service all` spawned all nine sidecars and the
+per-minute watchdog restarted any that were killed to reclaim the memory.
+"""
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from api.services import (
+    SERVICE_FEATURE_FLAGS,
+    SERVICES,
+    check_services,
+    is_service_enabled,
+    start_service,
+)
+
+
+def spawned_services(popen_mock):
+    """The service names behind the scripts a Popen mock was asked to run."""
+    names = set()
+    for call in popen_mock.call_args_list:
+        script = call.args[0][1]
+        if script == "image_similarity/main.py":
+            names.add("image_similarity")
+        else:
+            names.add(script.split("/")[1])
+    return names
+
+
+class ServiceFeatureFlagMappingTest(SimpleTestCase):
+    def test_every_service_has_a_verdict(self):
+        """A new service without an entry would silently become always-on."""
+        self.assertEqual(set(SERVICES), set(SERVICE_FEATURE_FLAGS))
+
+    def test_every_service_is_enabled_out_of_the_box(self):
+        for service in SERVICES:
+            self.assertTrue(is_service_enabled(service), service)
+
+    def test_flags_name_real_settings(self):
+        from django.conf import settings
+
+        for service, flag in SERVICE_FEATURE_FLAGS.items():
+            if flag is not None:
+                self.assertTrue(hasattr(settings, flag), f"{service} -> {flag}")
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_face_recognition_follows_face_detection(self):
+        self.assertFalse(is_service_enabled("face_recognition"))
+        self.assertTrue(is_service_enabled("thumbnail"))
+
+    @override_settings(FEATURE_SCENE_CLASSIFICATION=False)
+    def test_tags_follows_scene_classification(self):
+        self.assertFalse(is_service_enabled("tags"))
+
+    @override_settings(FEATURE_IMAGE_CAPTIONING=False)
+    def test_captioning_takes_the_llm_service_with_it(self):
+        """Port 8008 is only ever reached from the captioning code paths."""
+        self.assertFalse(is_service_enabled("image_captioning"))
+        self.assertFalse(is_service_enabled("llm"))
+
+    def test_a_missing_setting_leaves_the_service_enabled(self):
+        """An unrecognised switch must not take a service away."""
+        with patch.dict(
+            SERVICE_FEATURE_FLAGS, {"thumbnail": "FEATURE_NOT_IN_ANY_SETTINGS"}
+        ):
+            self.assertTrue(is_service_enabled("thumbnail"))
+
+
+@patch("api.services.is_service_compatible", return_value=True)
+@patch("api.services.subprocess.Popen")
+class StartServiceTest(SimpleTestCase):
+    def test_an_enabled_service_is_spawned(self, popen_mock, _compatible):
+        self.assertTrue(start_service("face_recognition"))
+        popen_mock.assert_called_once()
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_a_disabled_service_is_refused(self, popen_mock, _compatible):
+        self.assertFalse(start_service("face_recognition"))
+        popen_mock.assert_not_called()
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_the_other_services_are_unaffected(self, popen_mock, _compatible):
+        self.assertTrue(start_service("thumbnail"))
+        popen_mock.assert_called_once()
+
+    @override_settings(FEATURE_IMAGE_CAPTIONING=False)
+    def test_the_refusal_is_logged_at_info(self, popen_mock, _compatible):
+        with self.assertLogs("ownphotos", level="INFO") as logs:
+            start_service("llm")
+
+        self.assertTrue(
+            any(
+                "llm" in line and "FEATURE_IMAGE_CAPTIONING" in line
+                for line in logs.output
+            ),
+            logs.output,
+        )
+
+
+@patch("api.services.is_service_compatible", return_value=True)
+@patch("api.services.subprocess.Popen")
+class StartAllCommandTest(TestCase):
+    """`manage.py start_service all` is what the Docker entrypoints run."""
+
+    def test_everything_starts_by_default(self, popen_mock, _compatible):
+        call_command("start_service", "all")
+
+        self.assertEqual(set(SERVICES), spawned_services(popen_mock))
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_a_disabled_service_is_skipped(self, popen_mock, _compatible):
+        call_command("start_service", "all")
+
+        started = spawned_services(popen_mock)
+        self.assertNotIn("face_recognition", started)
+        self.assertEqual(set(SERVICES) - {"face_recognition"}, started)
+
+    @override_settings(
+        FEATURE_FACE_DETECTION=False,
+        FEATURE_IMAGE_CAPTIONING=False,
+        FEATURE_SCENE_CLASSIFICATION=False,
+    )
+    def test_only_the_core_pipeline_starts_when_every_flag_is_off(
+        self, popen_mock, _compatible
+    ):
+        call_command("start_service", "all")
+
+        self.assertEqual(
+            {"image_similarity", "thumbnail", "clip_embeddings", "exif", "ocr"},
+            spawned_services(popen_mock),
+        )
+
+    def test_the_watchdog_is_still_scheduled(self, popen_mock, _compatible):
+        from django_q.models import Schedule
+
+        with override_settings(FEATURE_FACE_DETECTION=False):
+            call_command("start_service", "all")
+
+        self.assertTrue(
+            Schedule.objects.filter(func="api.services.check_services").exists()
+        )
+
+
+@patch("api.services.is_healthy", return_value=False)
+@patch("api.services.stop_service")
+@patch("api.services.start_service")
+class CheckServicesTest(SimpleTestCase):
+    """The per-minute watchdog must not resurrect what a flag switched off."""
+
+    def _restarted(self, start_mock):
+        return {call.args[0] for call in start_mock.call_args_list}
+
+    def test_every_unhealthy_service_is_restarted_by_default(
+        self, start_mock, stop_mock, _healthy
+    ):
+        check_services()
+
+        self.assertEqual(set(SERVICES), self._restarted(start_mock))
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_a_disabled_service_is_not_restarted(self, start_mock, stop_mock, _healthy):
+        check_services()
+
+        restarted = self._restarted(start_mock)
+        self.assertNotIn("face_recognition", restarted)
+        self.assertNotIn(
+            "face_recognition", {c.args[0] for c in stop_mock.call_args_list}
+        )
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_the_enabled_unhealthy_services_are_still_restarted(
+        self, start_mock, stop_mock, _healthy
+    ):
+        check_services()
+
+        self.assertEqual(
+            set(SERVICES) - {"face_recognition"}, self._restarted(start_mock)
+        )
+
+    @override_settings(FEATURE_FACE_DETECTION=False)
+    def test_a_disabled_service_is_not_even_probed(
+        self, start_mock, stop_mock, healthy_mock
+    ):
+        """Skipping before the health check keeps a request off a dead port."""
+        check_services()
+
+        self.assertNotIn(
+            "face_recognition", {call.args[0] for call in healthy_mock.call_args_list}
+        )
+
+    @override_settings(FEATURE_IMAGE_CAPTIONING=False)
+    def test_the_watchdog_stays_quiet_about_skipped_services(
+        self, start_mock, stop_mock, _healthy
+    ):
+        """It runs every minute; a skip line per service would flood the log."""
+        with self.assertLogs("ownphotos", level="INFO") as logs:
+            check_services()
+
+        self.assertFalse(
+            [
+                line
+                for line in logs.output
+                if "FEATURE_IMAGE_CAPTIONING" in line or "'llm'" in line
+            ],
+            logs.output,
+        )

--- a/apps/backend/api/tests/test_service_feature_flags.py
+++ b/apps/backend/api/tests/test_service_feature_flags.py
@@ -7,19 +7,26 @@ per-minute watchdog restarted any that were killed to reclaim the memory.
 
 from unittest.mock import patch
 
+from constance.test import override_config
 from django.core.management import call_command
+from django.db.utils import OperationalError
 from django.test import SimpleTestCase, TestCase, override_settings
 from rest_framework.test import APIClient
 
 from api.models import User
 from api.services import (
     SERVICE_FEATURE_FLAGS,
+    SERVICE_SITE_GATES,
     SERVICES,
     check_services,
     is_service_enabled,
     start_service,
 )
 from api.tests.utils import create_password
+
+# The site settings that have to say yes before the services they gate are
+# started at all; the flag tests are about the environment, not about these.
+EVERY_MODEL_SELECTED = override_config(OCR_MODEL="ppocrv6_small")
 
 
 def spawned_services(popen_mock):
@@ -40,7 +47,8 @@ class ServiceFeatureFlagMappingTest(SimpleTestCase):
         self.assertEqual(set(SERVICES), set(SERVICE_FEATURE_FLAGS))
 
     def test_every_service_is_enabled_out_of_the_box(self):
-        for service in SERVICES:
+        """Services gated on a site setting are covered by OcrSiteGateTest."""
+        for service in set(SERVICES) - set(SERVICE_SITE_GATES):
             self.assertTrue(is_service_enabled(service), service)
 
     def test_flags_name_real_settings(self):
@@ -104,6 +112,7 @@ class StartServiceTest(SimpleTestCase):
         )
 
 
+@EVERY_MODEL_SELECTED
 @patch("api.services.is_service_compatible", return_value=True)
 @patch("api.services.subprocess.Popen")
 class StartAllCommandTest(TestCase):
@@ -211,6 +220,80 @@ class CheckServicesTest(SimpleTestCase):
             ],
             logs.output,
         )
+
+
+@patch("api.services.is_service_compatible", return_value=True)
+@patch("api.services.subprocess.Popen")
+class OcrSiteGateTest(TestCase):
+    """OCR's switch is a site setting, not an environment flag.
+
+    It ships with no model selected and the jobs already finish cleanly in that
+    state, so until an admin picks one the sidecar is a process nothing will
+    ever call. Reading the setting rather than an environment variable is what
+    lets the per-minute watchdog pick the choice up without a restart.
+    """
+
+    def test_no_model_selected_keeps_the_sidecar_down(self, popen_mock, _compatible):
+        self.assertFalse(is_service_enabled("ocr"))
+
+    @override_config(OCR_MODEL="ppocrv6_small")
+    def test_selecting_a_model_enables_it(self, popen_mock, _compatible):
+        self.assertTrue(is_service_enabled("ocr"))
+
+    @override_config(OCR_MODEL="none")
+    def test_the_lowercase_spelling_of_none_also_counts_as_unselected(
+        self, popen_mock, _compatible
+    ):
+        """The dropdown sends "none"; the default is "None"."""
+        self.assertFalse(is_service_enabled("ocr"))
+
+    def test_start_all_skips_it_while_no_model_is_selected(
+        self, popen_mock, _compatible
+    ):
+        call_command("start_service", "all")
+
+        self.assertNotIn("ocr", spawned_services(popen_mock))
+
+    @override_config(OCR_MODEL="ppocrv6_small")
+    def test_start_all_spawns_it_once_a_model_is_selected(
+        self, popen_mock, _compatible
+    ):
+        call_command("start_service", "all")
+
+        self.assertIn("ocr", spawned_services(popen_mock))
+
+    @override_config(OCR_MODEL="ppocrv6_small")
+    @patch("api.services.is_healthy", return_value=False)
+    @patch("api.services.stop_service")
+    def test_the_watchdog_brings_it_up_after_the_admin_selects_a_model(
+        self, stop_mock, healthy_mock, popen_mock, _compatible
+    ):
+        """No restart required: check_services re-reads the setting every minute."""
+        check_services()
+
+        self.assertIn("ocr", spawned_services(popen_mock))
+
+    def test_an_unreadable_configuration_leaves_the_service_enabled(
+        self, popen_mock, _compatible
+    ):
+        """Fail open, like an unrecognised flag: a database that is not up yet
+        must not be able to take a service away."""
+        with patch(
+            "constance.base.Config.__getattr__",
+            side_effect=OperationalError("no such table: constance_config"),
+        ):
+            self.assertTrue(is_service_enabled("ocr"))
+
+    def test_the_refusal_names_the_site_setting_rather_than_a_flag(
+        self, popen_mock, _compatible
+    ):
+        with self.assertLogs("ownphotos", level="INFO") as logs:
+            start_service("ocr")
+
+        self.assertTrue(
+            any("site settings" in line for line in logs.output), logs.output
+        )
+        self.assertFalse([line for line in logs.output if "None is disabled" in line])
 
 
 class ServiceAdminApiTest(TestCase):

--- a/apps/backend/api/views/services.py
+++ b/apps/backend/api/views/services.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from api.services import (
     SERVICE_FEATURE_FLAGS,
     SERVICES,
+    disabled_reason,
     is_healthy,
     is_service_enabled,
     start_service,
@@ -52,11 +53,13 @@ class ServiceViewSet(viewsets.ViewSet):
             )
 
         if not is_service_enabled(service_name):
-            flag = SERVICE_FEATURE_FLAGS[service_name]
             return Response(
                 {
-                    "error": f"Service {service_name} is not started: {flag} is disabled",
-                    "feature_flag": flag,
+                    "error": (
+                        f"Service {service_name} is not started: "
+                        f"{disabled_reason(service_name)}"
+                    ),
+                    "feature_flag": SERVICE_FEATURE_FLAGS.get(service_name),
                 },
                 status=status.HTTP_409_CONFLICT,
             )

--- a/apps/backend/api/views/services.py
+++ b/apps/backend/api/views/services.py
@@ -3,7 +3,14 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
-from api.services import SERVICES, is_healthy, start_service, stop_service
+from api.services import (
+    SERVICE_FEATURE_FLAGS,
+    SERVICES,
+    is_healthy,
+    is_service_enabled,
+    start_service,
+    stop_service,
+)
 
 
 class ServiceViewSet(viewsets.ViewSet):
@@ -21,8 +28,18 @@ class ServiceViewSet(viewsets.ViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        healthy = is_healthy(service_name)
-        return Response({"service_name": service_name, "healthy": healthy})
+        enabled = is_service_enabled(service_name)
+        # A switched-off service is not probed, for the same reason the watchdog
+        # does not probe it: nothing is listening, and every probe costs a
+        # connection refusal and a stack trace in the log.
+        return Response(
+            {
+                "service_name": service_name,
+                "healthy": is_healthy(service_name) if enabled else False,
+                "enabled": enabled,
+                "feature_flag": SERVICE_FEATURE_FLAGS.get(service_name),
+            }
+        )
 
     @action(detail=True, methods=["post"])
     def start(self, request, pk=None):
@@ -32,6 +49,16 @@ class ServiceViewSet(viewsets.ViewSet):
             return Response(
                 {"error": f"Service {service_name} not found"},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not is_service_enabled(service_name):
+            flag = SERVICE_FEATURE_FLAGS[service_name]
+            return Response(
+                {
+                    "error": f"Service {service_name} is not started: {flag} is disabled",
+                    "feature_flag": flag,
+                },
+                status=status.HTTP_409_CONFLICT,
             )
 
         start_result = start_service(service_name)

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -189,7 +189,7 @@ The backend runs its heavy models in separate sidecar processes, and a watchdog 
 
 The remaining services — `exif`, `thumbnail`, `ocr`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
 
-A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running.
+A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running. The Admin Area's **Services** list shows one as **Disabled** rather than as unhealthy, and offers no Start button for it.
 
 ### Cached video conversions
 

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -141,14 +141,28 @@ Accepted "on" values are `true`, `1`, `yes` and `on` (any capitalisation); anyth
 | Variable | `.env` key | What turning it off stops |
 | --- | --- | --- |
 | `FEATURE_VIDEO` | `featureVideo` | Video files are no longer imported. A scan skips them the same way it skips a file it cannot read, so no `Photo` is created and no video thumbnail is generated. The motion video inside a "live photo" is not extracted either, so those stay ordinary still images. |
-| `FEATURE_FACE_DETECTION` | `featureFaceDetection` | No faces are extracted from photos, neither during a scan nor when you upload one. The face scan is left out of the scan pipeline and **Scan faces** in the UI reports an error instead of starting a job. |
+| `FEATURE_FACE_DETECTION` | `featureFaceDetection` | No faces are extracted from photos, neither during a scan nor when you upload one. The face scan is left out of the scan pipeline and **Scan faces** in the UI reports an error instead of starting a job. The face recognition service is not started, so its model is never loaded. |
 | `FEATURE_FACE_CLUSTER` | `featureFaceCluster` | Faces are still detected, but never grouped into people to label. Clustering is skipped at the end of a face scan and **Train faces** reports an error. |
-| `FEATURE_IMAGE_CAPTIONING` | `featureImageCaptioning` | No automatic captions are generated, neither during a scan nor from the "Generate caption" button on a photo. Captions you typed yourself are unaffected. |
+| `FEATURE_IMAGE_CAPTIONING` | `featureImageCaptioning` | No automatic captions are generated, neither during a scan nor from the "Generate caption" button on a photo. Captions you typed yourself are unaffected. Neither the captioning service nor the LLM service is started — the LLM is only ever used to write and polish captions, so it has nothing left to do. |
 | `FEATURE_REVERSE_GEOCODING` | `featureReverseGeocoding` | GPS coordinates are no longer turned into place names, so no requests go to your map provider. Photos keep their coordinates and still show up on the map of an album and of a single photo, but without a place name they do not appear on the Places page, get no Places album, and cannot be searched by place. Searching for a place in the search bar still works. |
-| `FEATURE_SCENE_CLASSIFICATION` | `featureSceneClassification` | Photos are no longer tagged by what is in them (beach, kitchen, sunset, ...), so the "Things" albums stay empty for new photos. |
+| `FEATURE_SCENE_CLASSIFICATION` | `featureSceneClassification` | Photos are no longer tagged by what is in them (beach, kitchen, sunset, ...), so the "Things" albums stay empty for new photos. The tagging service is not started, so the places365 model is never loaded. |
 | `FEATURE_PROCESS_EMBEDDED_MEDIA` | `featureProcessEmbeddedMedia` | The short video stored inside a "live photo" or motion photo is no longer extracted, so those files stay ordinary stills. `FEATURE_VIDEO` has to be on as well for extraction to happen. See [Feature Toggles](../user-guide/feature-toggles.md) for the one way this switch differs from the others. |
 
 Turning a feature off never deletes anything that was already generated - the existing captions, faces and place names stay in the database and remain visible. Turning it back on picks up where the scan left off.
+
+#### The machine learning services follow the switches
+
+The backend runs its heavy models in separate sidecar processes, and a watchdog restarts any of them that dies. A switch that is off keeps its service from being started at all, and the watchdog leaves it alone rather than bringing it back a minute later — which is where the memory saving actually comes from, since a loaded model costs its memory whether or not anything asks it a question.
+
+| Switch | Service that stops being started |
+| --- | --- |
+| `FEATURE_FACE_DETECTION` | `face_recognition` |
+| `FEATURE_IMAGE_CAPTIONING` | `image_captioning`, `llm` |
+| `FEATURE_SCENE_CLASSIFICATION` | `tags` |
+
+The remaining services — `exif`, `thumbnail`, `ocr`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
+
+A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running.
 
 With the bundled Compose setup, set the lowerCamelCase keys in your `.env`:
 

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -187,7 +187,9 @@ The backend runs its heavy models in separate sidecar processes, and a watchdog 
 | `FEATURE_IMAGE_CAPTIONING` | `image_captioning`, `llm` |
 | `FEATURE_SCENE_CLASSIFICATION` | `tags` |
 
-The remaining services — `exif`, `thumbnail`, `ocr`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
+The remaining services — `exif`, `thumbnail`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
+
+`ocr` has no environment variable either, but it is not always on: it follows the **OCR model** choice in Site Settings, which ships with nothing selected. The service starts once a model is picked, and stops being started if the choice is set back to none — the watchdog re-reads the setting every minute, so neither direction needs a restart. A configuration the backend cannot read counts as a model being selected, so a database that is still starting can never take the service away.
 
 A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running. The Admin Area's **Services** list shows one as **Disabled** rather than as unhealthy, and offers no Start button for it.
 

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -150,20 +150,6 @@ Accepted "on" values are `true`, `1`, `yes` and `on` (any capitalisation); anyth
 
 Turning a feature off never deletes anything that was already generated - the existing captions, faces and place names stay in the database and remain visible. Turning it back on picks up where the scan left off.
 
-#### The machine learning services follow the switches
-
-The backend runs its heavy models in separate sidecar processes, and a watchdog restarts any of them that dies. A switch that is off keeps its service from being started at all, and the watchdog leaves it alone rather than bringing it back a minute later — which is where the memory saving actually comes from, since a loaded model costs its memory whether or not anything asks it a question.
-
-| Switch | Service that stops being started |
-| --- | --- |
-| `FEATURE_FACE_DETECTION` | `face_recognition` |
-| `FEATURE_IMAGE_CAPTIONING` | `image_captioning`, `llm` |
-| `FEATURE_SCENE_CLASSIFICATION` | `tags` |
-
-The remaining services — `exif`, `thumbnail`, `ocr`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
-
-A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running.
-
 With the bundled Compose setup, set the lowerCamelCase keys in your `.env`:
 
 ```bash
@@ -186,6 +172,24 @@ services:
 :::note
 `FEATURE_PROCESS_EMBEDDED_MEDIA` is checked only at the moment a file is first imported. Turning it on for a library that has already been scanned extracts nothing for the photos already there — not even with **Rescan All Photos** — so only files added afterwards are affected.
 :::
+
+#### The machine learning services follow the switches
+
+:::note
+This part is not in a released image yet. It is available on the `dev` branch and will appear in the next release; on 1.1.0 the switches stop the processing, but the services still start.
+:::
+
+The backend runs its heavy models in separate sidecar processes, and a watchdog restarts any of them that dies. A switch that is off keeps its service from being started at all, and the watchdog leaves it alone rather than bringing it back a minute later — which is where the memory saving actually comes from, since a loaded model costs its memory whether or not anything asks it a question.
+
+| Switch | Service that stops being started |
+| --- | --- |
+| `FEATURE_FACE_DETECTION` | `face_recognition` |
+| `FEATURE_IMAGE_CAPTIONING` | `image_captioning`, `llm` |
+| `FEATURE_SCENE_CLASSIFICATION` | `tags` |
+
+The remaining services — `exif`, `thumbnail`, `ocr`, `clip_embeddings` and `image_similarity` — carry the scanning and search that the rest of LibrePhotos is built on, so they have no switch and always run. The other feature flags (`FEATURE_VIDEO`, `FEATURE_FACE_CLUSTER`, `FEATURE_REVERSE_GEOCODING`, `FEATURE_PROCESS_EMBEDDED_MEDIA`) gate work that happens inside the backend itself and have no service of their own to stop.
+
+A skipped service is named once in the backend log at startup, so `docker logs backend` tells you why something is not running.
 
 ### Cached video conversions
 

--- a/apps/docs/docs/user-guide/feature-toggles.md
+++ b/apps/docs/docs/user-guide/feature-toggles.md
@@ -91,7 +91,7 @@ Feature toggles are implemented as environment variables you would have to confi
 
 All of these default to on. See [Advanced docker-compose usage](../installation/environment-variables.md) for what turning each one off actually stops, and for the matching `.env` keys of the bundled Compose setup.
 
-Turning off face detection, image captioning or scene classification also keeps the matching machine learning service from starting, so its model is never loaded and never restarted by the watchdog. That is where the memory these switches save actually comes from.
+Turning off face detection, image captioning or scene classification also keeps the matching machine learning service from starting, so its model is never loaded and never restarted by the watchdog. That is where the memory these switches save actually comes from. (This part is not in a released image yet — it is on the `dev` branch and will appear in the next release; on 1.1.0 the switches stop the processing, but the services still start.)
 
 :::note Embedded media
 The **Embedded media** switch is checked only the first time a file is imported. Enabling it on a library that has already been scanned extracts nothing for the photos that are already there, not even with **Rescan All Photos**, which skips extraction for files it has already imported. Only files added afterwards are affected. Turning it off never removes clips that were already extracted; those stay on disk under `protected_media/embedded_media/`.

--- a/apps/docs/docs/user-guide/feature-toggles.md
+++ b/apps/docs/docs/user-guide/feature-toggles.md
@@ -91,6 +91,8 @@ Feature toggles are implemented as environment variables you would have to confi
 
 All of these default to on. See [Advanced docker-compose usage](../installation/environment-variables.md) for what turning each one off actually stops, and for the matching `.env` keys of the bundled Compose setup.
 
+Turning off face detection, image captioning or scene classification also keeps the matching machine learning service from starting, so its model is never loaded and never restarted by the watchdog. That is where the memory these switches save actually comes from.
+
 :::note Embedded media
 The **Embedded media** switch is checked only the first time a file is imported. Enabling it on a library that has already been scanned extracts nothing for the photos that are already there, not even with **Rescan All Photos**, which skips extraction for files it has already imported. Only files added afterwards are affected. Turning it off never removes clips that were already extracted; those stay on disk under `protected_media/embedded_media/`.
 :::

--- a/apps/frontend/src/api_client/services/hooks/useServicesQuery.ts
+++ b/apps/frontend/src/api_client/services/hooks/useServicesQuery.ts
@@ -19,14 +19,13 @@ export const useServicesHealthQuery = (serviceNames: string[], options?: { enabl
   useQuery({
     queryKey: [...ServiceHealthQueryKeys, serviceNames],
     queryFn: async () => {
-      const results: Record<string, boolean> = {};
+      const results: Record<string, ServiceHealthResponse> = {};
       const healthChecks = serviceNames.map(async name => {
         try {
           const response = await fetchClient.get(`/services/${name}/`);
-          const parsed = parseWithNotification(ServiceHealthResponse, response, `Failed to parse health for ${name}`);
-          results[name] = parsed.healthy;
+          results[name] = parseWithNotification(ServiceHealthResponse, response, `Failed to parse health for ${name}`);
         } catch {
-          results[name] = false;
+          results[name] = { service_name: name, healthy: false, enabled: true, feature_flag: null };
         }
       });
       await Promise.all(healthChecks);

--- a/apps/frontend/src/api_client/services/types.ts
+++ b/apps/frontend/src/api_client/services/types.ts
@@ -7,9 +7,14 @@ export const ServicesListResponse = z.object({
 export type ServicesListResponse = z.infer<typeof ServicesListResponse>;
 
 // GET /api/services/{service_name}/
+// enabled/feature_flag are optional so that a backend predating them reads as an
+// ordinary always-on service rather than failing the parse, which the health
+// query would then report as unhealthy.
 export const ServiceHealthResponse = z.object({
   service_name: z.string(),
   healthy: z.boolean(),
+  enabled: z.boolean().optional(),
+  feature_flag: z.string().nullable().optional(),
 });
 export type ServiceHealthResponse = z.infer<typeof ServiceHealthResponse>;
 

--- a/apps/frontend/src/components/settings/ServiceList.test.tsx
+++ b/apps/frontend/src/components/settings/ServiceList.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * A service the server was told not to run is not a fault, but the page used to
+ * present it as one: the same red "Unhealthy" badge as a crashed sidecar, and a
+ * Start button whose only answer was a 500. An admin who turned face detection
+ * off then went looking for a breakage that was never there.
+ */
+import { MantineProvider } from "@mantine/core";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ServiceList } from "./ServiceList";
+
+const t = vi.fn((key: string) => key);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t }),
+}));
+
+const health: Record<string, unknown> = {};
+
+vi.mock("../../api_client/api", () => ({
+  queryClient: { invalidateQueries: vi.fn() },
+}));
+
+vi.mock("../../api_client/services/hooks/useServiceActionMutation", () => ({
+  useServiceActionMutation: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+}));
+
+vi.mock("../../api_client/services/hooks/useServicesQuery", () => ({
+  ServiceHealthQueryKeys: ["serviceHealth"],
+  useServicesListQuery: () => ({
+    data: { services: { face_recognition: 8005, thumbnail: 8003 } },
+    isLoading: false,
+  }),
+  useServicesHealthQuery: () => ({ data: health, isLoading: false }),
+}));
+
+// jsdom ships no matchMedia; MantineProvider needs it.
+beforeAll(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  window.matchMedia = (query: string) =>
+    ({
+      matches: query.includes("min-width"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+});
+
+async function render() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <ServiceList />
+      </MantineProvider>
+    );
+  });
+  const unmount = async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  };
+  return { container, unmount };
+}
+
+function startButtons(container: HTMLElement) {
+  return [...container.querySelectorAll("button")].filter(button => button.textContent?.includes("services.start"));
+}
+
+describe("ServiceList", () => {
+  beforeEach(() => {
+    t.mockClear();
+    health.face_recognition = {
+      service_name: "face_recognition",
+      healthy: false,
+      enabled: false,
+      feature_flag: "FEATURE_FACE_DETECTION",
+    };
+    health.thumbnail = { service_name: "thumbnail", healthy: false, enabled: true, feature_flag: null };
+  });
+
+  it("marks a switched-off service disabled rather than unhealthy", async () => {
+    const { container, unmount } = await render();
+
+    const row = [...container.querySelectorAll("tbody tr")].find(tr => tr.textContent?.includes("Face Recognition"))!;
+    expect(row.textContent).toContain("services.disabled");
+    expect(row.textContent).not.toContain("services.unhealthy");
+
+    await unmount();
+  });
+
+  it("names the environment variable that switched the service off", async () => {
+    const { unmount } = await render();
+
+    expect(t).toHaveBeenCalledWith("services.disabled_by", { flag: "FEATURE_FACE_DETECTION" });
+
+    await unmount();
+  });
+
+  it("offers no Start button for a switched-off service", async () => {
+    // Starting one is a 409 the admin can do nothing about until they change
+    // the server's environment.
+    const { container, unmount } = await render();
+
+    expect(startButtons(container)).toHaveLength(1);
+
+    await unmount();
+  });
+
+  it("still reports a genuinely dead service as unhealthy and offers to start it", async () => {
+    const { container, unmount } = await render();
+
+    const row = [...container.querySelectorAll("tbody tr")].find(tr => tr.textContent?.includes("Thumbnail"))!;
+    expect(row.textContent).toContain("services.unhealthy");
+    expect(startButtons(row as HTMLElement)).toHaveLength(1);
+
+    await unmount();
+  });
+
+  it("falls back to a generic explanation when no flag is named", async () => {
+    health.face_recognition = {
+      service_name: "face_recognition",
+      healthy: false,
+      enabled: false,
+      feature_flag: null,
+    };
+
+    const { container, unmount } = await render();
+
+    expect(container.textContent).toContain("services.disabled");
+    expect(t).toHaveBeenCalledWith("services.disabled_hint");
+
+    await unmount();
+  });
+});

--- a/apps/frontend/src/components/settings/ServiceList.tsx
+++ b/apps/frontend/src/components/settings/ServiceList.tsx
@@ -19,6 +19,7 @@ const SERVICE_LABELS: Record<string, string> = {
   image_captioning: "Image Captioning",
   exif: "EXIF",
   tags: "Tags",
+  ocr: "OCR",
 };
 
 export function ServiceList() {
@@ -64,7 +65,9 @@ export function ServiceList() {
         <Table.Tbody>
           {servicesList &&
             Object.entries(servicesList.services).map(([name, port]) => {
-              const healthy = healthMap?.[name];
+              const health = healthMap?.[name];
+              const healthy = health?.healthy;
+              const disabled = health?.enabled === false;
               const isThisServicePending = isPending && pendingAction?.serviceName === name;
 
               return (
@@ -72,9 +75,21 @@ export function ServiceList() {
                   <Table.Td>{SERVICE_LABELS[name] ?? name}</Table.Td>
                   <Table.Td>{port}</Table.Td>
                   <Table.Td>
-                    {healthMap === undefined ? (
-                      <Loader size="xs" />
-                    ) : (
+                    {healthMap === undefined && <Loader size="xs" />}
+                    {healthMap !== undefined && disabled && (
+                      <Tooltip
+                        label={
+                          health?.feature_flag
+                            ? t("services.disabled_by", { flag: health.feature_flag })
+                            : t("services.disabled_hint")
+                        }
+                      >
+                        <Badge color="gray" variant="light">
+                          {t("services.disabled")}
+                        </Badge>
+                      </Tooltip>
+                    )}
+                    {healthMap !== undefined && !disabled && (
                       <Badge color={healthy ? "green" : "red"} variant="filled">
                         {healthy ? t("services.healthy") : t("services.unhealthy")}
                       </Badge>
@@ -82,7 +97,7 @@ export function ServiceList() {
                   </Table.Td>
                   <Table.Td>
                     <Group gap="xs">
-                      {!healthy && (
+                      {!healthy && !disabled && (
                         <Button
                           size="xs"
                           color="green"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -849,7 +849,7 @@
     "unhealthy": "Unhealthy",
     "disabled": "Disabled",
     "disabled_by": "Switched off by {{flag}}. Set {{flag}}=true and restart to run this service.",
-    "disabled_hint": "Switched off by the server configuration.",
+    "disabled_hint": "Switched off in the site settings — select a model to run this service.",
     "start": "Start",
     "stop": "Stop",
     "refresh": "Refresh health status"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -847,6 +847,9 @@
     "actions": "Actions",
     "healthy": "Healthy",
     "unhealthy": "Unhealthy",
+    "disabled": "Disabled",
+    "disabled_by": "Switched off by {{flag}}. Set {{flag}}=true and restart to run this service.",
+    "disabled_hint": "Switched off by the server configuration.",
     "start": "Start",
     "stop": "Stop",
     "refresh": "Refresh health status"


### PR DESCRIPTION
## What

The `FEATURE_*` switches disable the processing, but every ML sidecar service still started unconditionally (`start_service all` in the entrypoints), and the per-minute `check_services` watchdog restarted anything that went down — including services an admin stopped on purpose because their feature is off. Reported in #1979 (JimCircadian's comments after the original issue was resolved).

Now the service layer knows about the switches:

| Switch off | Service no longer started |
| --- | --- |
| `FEATURE_FACE_DETECTION` | `face_recognition` |
| `FEATURE_IMAGE_CAPTIONING` | `image_captioning`, `llm` |
| `FEATURE_SCENE_CLASSIFICATION` | `tags` |
| `OCR_MODEL` site setting: no model selected | `ocr` |

- `start_service` refuses a disabled service (info log, returns `False`); `start_service all` skips them with one log line each at startup.
- `check_services` skips disabled services before the health probe — no restart, no HTTP request to a dead port, and no log spam every minute.
- A missing flag defaults to enabled (`getattr(..., True)`), so an upgrade with no `FEATURE_*` vars set behaves exactly as today.
- `exif`, `thumbnail`, `clip_embeddings`, `image_similarity` stay always-on — they carry core scanning and search (see below for why clip/similarity kept no flag).

## OCR follows its existing site setting, not a new env var

OCR already ships dark behind the `OCR_MODEL` site setting (`_is_model_not_selected` makes OCR jobs finish cleanly when nothing is selected), so a `FEATURE_OCR` env var would just duplicate it. Instead `is_service_enabled("ocr")` consults the same helper the download gate and the jobs use, failing open if the DB isn't readable (same precedent as the guarded constance read in `api/util.py`). Because the watchdog re-evaluates every minute, selecting a model in the admin brings the sidecar up within a minute, no restart needed. Entrypoints run `migrate` before `start_service all`, and that command already queries the DB for its schedule, so no new ordering requirement.

## Admin UI: "off on purpose" is no longer "crashed"

`GET /api/services/<name>/` now returns `enabled` and `feature_flag` next to `healthy`, and skips the health probe for a disabled service. `POST .../start` on a disabled service returns **409** naming the switch instead of a generic 500. The Settings → Services page shows a neutral gray **Disabled** badge with a tooltip naming the env var (or pointing at the site settings for OCR) and no Start button, instead of the red unhealthy badge. The new response fields are optional in the frontend schema, so a frontend against an older backend degrades to today's behavior.

## Why `llm` follows `FEATURE_IMAGE_CAPTIONING`

Port 8008 has exactly two call sites in the backend (`api/llm.py:63` via `generate_prompt`, and the Moondream branch of `api/image_captioning.py:21`), and both are reachable only through `PhotoCaption.generate_captions_im2txt`, which already returns early when captioning is off. A code comment records this so the mapping gets reverted if a non-captioning consumer ever appears.

## Why `clip_embeddings`/`image_similarity` deliberately kept no flag

They were investigated for a `FEATURE_SEMANTIC_SEARCH` switch and rejected for this PR. The two are one unit (the similarity index is built from the clip service's output), but a safe flag needs seven coordinated guards — scan chain, `batch_calculate_clip_embedding`, the `semantic_search_topk` serializer transition, `filters.py` and `views/search.py` (which branch on `semantic_search_topk` independently and must agree), the Nextcloud watcher, and the `build_similarity_index` command — plus `PhotoSerializer.similar_photos`, which calls the similarity service per serialized photo on every photo listing. Gating that means silently changing serializer output, and "similar photos" is a different feature from search; there is also already a per-user knob (`semantic_search_topk`, default 0) covering much of the same ground. If wanted, it should be its own PR with a decision on whether `similar_photos` shares the flag.

## Tests

`api/tests/test_service_feature_flags.py` grew to 43 tests: disabled services are refused, skipped by `all`, never probed or restarted by the watchdog; enabled unhealthy services still restart; everything starts by default; the OCR gate follows the site setting and fails open on DB errors; the services view reports `enabled`/`feature_flag` and 409s correctly. `subprocess.Popen` is mocked throughout — nothing spawns. 131 backend tests across the touched modules pass; frontend: new `ServiceList.test.tsx` (5 tests), full vitest suite 171/171, `lint:error` clean, tsc error count unchanged vs. base (308). Ruff clean.

## Docs

`environment-variables.md` and `feature-toggles.md` explain the switch→service mapping, the OCR model gate, and the Disabled badge, with a note that this is dev-only until the next release (docs deploy from dev — the confusion in #1979 started exactly this way).

Refs #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
