### PR TITLE
fix(backend): cap the live video transcode at half the cores

### DIFF
--- a/apps/backend/api/tests/test_live_transcode_threads.py
+++ b/apps/backend/api/tests/test_live_transcode_threads.py
@@ -1,0 +1,36 @@
+"""The thread cap on the conversion a viewer is waiting for.
+
+"Always transcode videos" spawns one ffmpeg per request, and ffmpeg takes every
+core it can see. Playback only needs the stream to stay ahead of itself, so the
+cores beyond that buy a lead nobody perceives while the web UI, the scan and
+every other viewer go without. The background conversion in
+:mod:`api.transcode_cache` is capped for the same reason; this is the live half.
+"""
+
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from api.views import views
+
+
+class LiveTranscodeCommandTest(TestCase):
+    def _ffmpeg_command(self):
+        with mock.patch("api.views.views.subprocess.Popen") as popen:
+            views.VideoTranscoder("/in.mkv")
+        return popen.call_args[0][0]
+
+    def test_the_encoder_is_capped_instead_of_taking_every_core(self):
+        # The flag has to sit after the input, or it limits decoding rather
+        # than encoding, which is where the CPU goes.
+        command = self._ffmpeg_command()
+        threads = command.index("-threads")
+        self.assertGreater(threads, command.index("/in.mkv"))
+        self.assertEqual(command[threads + 1], str(settings.TRANSCODE_LIVE_THREADS))
+
+    def test_the_cap_can_be_tuned_to_the_hardware(self):
+        with override_settings(TRANSCODE_LIVE_THREADS=3):
+            command = self._ffmpeg_command()
+        threads = command.index("-threads")
+        self.assertEqual(command[threads + 1], "3")

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -572,6 +572,10 @@ class VideoTranscoder:
             "ffmpeg",
             "-i",
             path,
+            # After the input, so it caps the encoder -- where the CPU goes.
+            # Before it, ffmpeg would read it as a decoder setting.
+            "-threads",
+            str(getattr(settings, "TRANSCODE_LIVE_THREADS", 0)),
             "-vcodec",
             "libx264",
             "-preset",

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -52,6 +52,17 @@ TRANSCODE_CACHE_MAX_CONCURRENT = int(
 # niced and given half the cores, because playback, thumbnails and the scan all
 # matter more than a copy nobody is waiting for.
 TRANSCODE_CACHE_NICE = int(os.environ.get("TRANSCODE_CACHE_NICE", "10"))
+# How much of the machine the conversion someone *is* waiting for may take.
+# ffmpeg helps itself to every core, and playback only needs the stream to stay
+# ahead of itself, so the rest buys a lead nobody perceives while the interface,
+# the scan and every other viewer go without. Half, and never fewer than one.
+# Set it to 0 to hand ffmpeg the whole machine again.
+# The `or` is load-bearing: compose passes this through with an empty default,
+# because the real one is computed rather than a literal, so the variable
+# arrives set to "" on every containerised install. "0" is truthy and survives.
+TRANSCODE_LIVE_THREADS = int(
+    os.environ.get("TRANSCODE_LIVE_THREADS") or max(1, (os.cpu_count() or 2) // 2)
+)
 LOGS_ROOT = BASE_LOGS
 # Create the directory before anything in this module writes to it. secret.key
 # lives in there too and is written some 40 lines further down, so an install

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -185,6 +185,7 @@ The cache costs somewhere between 10 and 20 MB per minute of video — how much 
 | `TRANSCODE_CACHE_MIN_FREE_GB` | `transcodeCacheMinFreeGb` | `2` | How much free space to leave alone on the volume, in GB. The cache never writes into this, and a conversion already running is abandoned if the free space drops into it. |
 | `TRANSCODE_CACHE_MAX_CONCURRENT` | `transcodeCacheMaxConcurrent` | `1` | How many conversions may be written at once. Each is an ffmpeg process, so raising this trades CPU for having more videos become seekable sooner. |
 | `TRANSCODE_CACHE_NICE` | `transcodeCacheNice` | `10` | How far the background conversion stands back from everything else, as a `nice` value. `0` turns the courtesy off. |
+| `TRANSCODE_LIVE_THREADS` | `transcodeLiveThreads` | half the cores | How many cores the live conversion may use. ffmpeg takes every one by default, which starves the interface, a running scan and every other viewer for a lead nobody sees. Raise it if a video stutters on slow hardware; `0` hands ffmpeg the whole machine. |
 
 When either ceiling is reached, the least recently played entries are deleted until the new one fits; if even that is not enough, the video simply is not cached and plays live as before. Nothing is ever served before its conversion has finished, so an interrupted one leaves no half-playable file behind.
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - TRANSCODE_CACHE_MIN_FREE_GB=${transcodeCacheMinFreeGb:-2}
       - TRANSCODE_CACHE_MAX_CONCURRENT=${transcodeCacheMaxConcurrent:-1}
       - TRANSCODE_CACHE_NICE=${transcodeCacheNice:-10}
+      - TRANSCODE_LIVE_THREADS=${transcodeLiveThreads:-}
       - DEBUG=0
     depends_on:
       db:

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -110,6 +110,11 @@ featureProcessEmbeddedMedia=true
 # It is also limited to half the cores. 0 turns the courtesy off.
 # transcodeCacheNice=10
 
+# How many cores the conversion someone is waiting for may use. Left unset it
+# takes half of them, which stays well ahead of playback; raise it if a video
+# stutters on slow hardware, or set 0 to hand ffmpeg the whole machine.
+# transcodeLiveThreads=
+
 # ---------------------------------------------------------------------------------------------
 
 # Outgoing email (for the self-service "Forgot password" flow) is configured in


### PR DESCRIPTION
Fixes the `-threads` half of #1920.

## The problem

`VideoTranscoder.__init__` passes ffmpeg no `-threads`, so every request from a
user with **Always transcode videos** on starts an encoder that helps itself to
every core. Since f6ed7a6 that also covers the plain `/media/photos/<hash>`
request the lightbox makes, and there is no cap on how many transcoders run at
once. One viewer watching one video can take the machine away from the
interface, a running scan and everyone else.

Playback only needs the stream to stay ahead of itself. The cores past that buy
a lead nobody perceives.

## The change

The background conversion in `api/transcode_cache.py` already answers this
question: `nice`, plus `-threads max(1, cpu_count // 2)` placed after `-i` so it
binds the encoder rather than the decoder. This gives the live conversion the
same thread cap (not the `nice`, since somebody is waiting for this one), read
from a new `TRANSCODE_LIVE_THREADS` setting so an operator can raise it if a
video stutters on slow hardware, or set `0` to hand ffmpeg the whole machine
back. Plumbed through compose, `librephotos.env` and the environment-variables
table like the rest of the `TRANSCODE_*` family.

Two things worth being straight about:

- **This caps the encoder, not the whole process.** Decoding still auto-detects,
  and the `scale` filter graph still uses `filter_threads`. At `ultrafast` 720p
  the encoder dominates, so the practical effect is what the issue asks for, but
  a 4K HEVC source will still spend real CPU in decode. The merged background
  command has the same shape.
- **An env var is not the site setting the issue asked for.** `CONSTANCE_CONFIG`
  would put it in the admin area, at the cost of a DB read per playback and
  frontend work; the whole `TRANSCODE_CACHE_*` family is env-only today, so this
  follows that. Happy to move it if you would rather have it in Site Settings.

## What I left out, and why

The issue also asks for rate limiting the output to a little over real time. I
did not do that here, because it is a bigger call than it looks:
`_cache_after_streaming` starts the seekable cache copy only once the live
stream's generator closes, so pinning the live stream to real time pushes the
start of that copy out by the difference between the video's duration and its
transcode time. A ten-minute video that converts in three would have its
seekable copy start seven minutes later. It also removes the one substitute for
seeking a viewer has today, which is letting a faster-than-real-time stream run
on into the browser's buffer. Worth its own issue and its own decision, rather
than riding along with the thread cap.

## Testing

`apps/backend/api/tests/test_live_transcode_threads.py` builds the command with
`subprocess.Popen` patched and asserts the cap is present, sits after the input,
carries the configured value, and follows `override_settings`. Both tests fail
on `dev` (`-threads` is not in the list).

`python manage.py test api.tests` under `librephotos.settings.test_sqlite`:
2063 tests, no new failures. My local run has 28 pre-existing failures from
missing native dependencies on macOS (exiftool, libvips, libmagic, the ML
models); an unmodified `dev` worktree fails the identical 28, and none of them
touch this code. `ruff check` and `ruff format --check` are clean at the pinned
0.15.22.

For transparency: I use AI tooling while working on patches like this one. The
change, the reasoning and the testing above are mine and I stand behind them.
---
Disclosure: this change was prepared with AI assistance (Claude Code). The repro and tests described above were run before it was opened.
