### PR TITLE
ci: harden the image, docs and mobile release pipelines

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
@@ -77,6 +79,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -37,6 +37,9 @@ on:
       DOCKER_HUB_ACCESS_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-amd64:
     runs-on: ubuntu-24.04

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -43,9 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
             echo "tag=${{ inputs.image }}:dev-amd64" >> "$GITHUB_OUTPUT"
           fi
       - name: Build and push (AMD64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -75,9 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -90,7 +90,7 @@ jobs:
             echo "tag=${{ inputs.image }}:dev-arm64" >> "$GITHUB_OUTPUT"
           fi
       - name: Build and push (ARM64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -110,9 +110,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
         working-directory: apps/docs
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: apps/docs/.nvmrc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       # https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: apps/docs/build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
       - 'apps/docs/**'
       - '.github/workflows/docs.yml'
 
+# The gh-pages push uses the workflow token.
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/image-backend-base-gpu.yml
+++ b/.github/workflows/image-backend-base-gpu.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push (AMD64 only; GPU base is not useful on ARM)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: deploy/docker/backend-gpu/base
           file: deploy/docker/backend-gpu/base/Dockerfile

--- a/.github/workflows/image-backend-base-gpu.yml
+++ b/.github/workflows/image-backend-base-gpu.yml
@@ -7,6 +7,9 @@ on:
       - 'deploy/docker/backend-gpu/base/**'
       - '.github/workflows/image-backend-base-gpu.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/image-backend-base-gpu.yml
+++ b/.github/workflows/image-backend-base-gpu.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           tool-cache: false
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx

--- a/.github/workflows/image-backend-base.yml
+++ b/.github/workflows/image-backend-base.yml
@@ -15,4 +15,6 @@ jobs:
       image: reallibrephotos/librephotos-base
       context: deploy/docker/backend/base
       dockerfile: deploy/docker/backend/base/Dockerfile
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/image-backend-base.yml
+++ b/.github/workflows/image-backend-base.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/image-backend-base.yml'
       - '.github/workflows/_build-image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     uses: ./.github/workflows/_build-image.yml

--- a/.github/workflows/image-backend-gpu.yml
+++ b/.github/workflows/image-backend-gpu.yml
@@ -22,7 +22,9 @@ jobs:
       amd64-only: true
       build-args: |
         IMAGE_TAG=dev
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   release:
     if: github.event_name == 'release' && github.event.action == 'created'
@@ -34,4 +36,6 @@ jobs:
       release-tag: ${{ github.event.release.tag_name }}
       build-args: |
         IMAGE_TAG=${{ github.event.release.tag_name }}
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/image-backend-gpu.yml
+++ b/.github/workflows/image-backend-gpu.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/image-backend-gpu.yml'
       - '.github/workflows/_build-image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     if: github.event_name != 'release'

--- a/.github/workflows/image-backend.yml
+++ b/.github/workflows/image-backend.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/image-backend.yml'
       - '.github/workflows/_build-image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     if: github.event_name != 'release'

--- a/.github/workflows/image-backend.yml
+++ b/.github/workflows/image-backend.yml
@@ -19,7 +19,9 @@ jobs:
     with:
       image: reallibrephotos/librephotos
       dockerfile: deploy/docker/backend/Dockerfile
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   release:
     if: github.event_name == 'release' && github.event.action == 'created'
@@ -28,4 +30,6 @@ jobs:
       image: reallibrephotos/librephotos
       dockerfile: deploy/docker/backend/Dockerfile
       release-tag: ${{ github.event.release.tag_name }}
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/image-frontend.yml
+++ b/.github/workflows/image-frontend.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/image-frontend.yml'
       - '.github/workflows/_build-image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     if: github.event_name != 'release'

--- a/.github/workflows/image-frontend.yml
+++ b/.github/workflows/image-frontend.yml
@@ -20,7 +20,9 @@ jobs:
       dockerfile: deploy/docker/frontend/Dockerfile
       build-args: |
         GIT_HASH=${{ github.sha }}
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   release:
     if: github.event_name == 'release' && github.event.action == 'created'
@@ -31,4 +33,6 @@ jobs:
       release-tag: ${{ github.event.release.tag_name }}
       build-args: |
         GIT_HASH=${{ github.sha }}
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/image-proxy.yml
+++ b/.github/workflows/image-proxy.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/proxy/Dockerfile
@@ -41,16 +41,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: deploy/docker/proxy/Dockerfile

--- a/.github/workflows/image-proxy.yml
+++ b/.github/workflows/image-proxy.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
@@ -35,14 +37,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: reallibrephotos/librephotos-proxy:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   release:
     if: github.event_name == 'release' && github.event.action == 'created'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx

--- a/.github/workflows/image-proxy.yml
+++ b/.github/workflows/image-proxy.yml
@@ -9,6 +9,9 @@ on:
       - 'deploy/docker/proxy/**'
       - '.github/workflows/image-proxy.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     if: github.event_name != 'release'

--- a/.github/workflows/image-unified.yml
+++ b/.github/workflows/image-unified.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/image-unified.yml'
       - '.github/workflows/_build-image.yml'
 
+permissions:
+  contents: read
+
 jobs:
   dev:
     if: github.event_name != 'release'

--- a/.github/workflows/image-unified.yml
+++ b/.github/workflows/image-unified.yml
@@ -21,7 +21,9 @@ jobs:
       dockerfile: deploy/docker/unified/Dockerfile
       build-args: |
         IMAGE_TAG=dev
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   release:
     if: github.event_name == 'release' && github.event.action == 'created'
@@ -32,4 +34,6 @@ jobs:
       release-tag: ${{ github.event.release.tag_name }}
       build-args: |
         IMAGE_TAG=${{ github.event.release.tag_name }}
-    secrets: inherit
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -11,6 +11,9 @@ on:
       - 'apps/backend/**'
       - '.github/workflows/lint-backend.yml'
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -26,6 +26,8 @@ jobs:
         working-directory: apps/frontend
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: apps/frontend/.nvmrc

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-mobile.yml
+++ b/.github/workflows/lint-mobile.yml
@@ -6,6 +6,9 @@ on:
       - 'apps/mobile/**'
       - '.github/workflows/lint-mobile.yml'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-mobile.yml
+++ b/.github/workflows/lint-mobile.yml
@@ -17,6 +17,8 @@ jobs:
         working-directory: apps/mobile
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: apps/mobile/.node-version

--- a/.github/workflows/mobile-cd.yml
+++ b/.github/workflows/mobile-cd.yml
@@ -7,6 +7,10 @@ on:
       - 'apps/mobile/**'
       - '.github/workflows/mobile-cd.yml'
 
+# The rolling mobile release is created with the workflow token.
+permissions:
+  contents: write
+
 jobs:
   beta-distribution:
     runs-on: ubuntu-latest

--- a/.github/workflows/mobile-cd.yml
+++ b/.github/workflows/mobile-cd.yml
@@ -19,6 +19,8 @@ jobs:
         working-directory: apps/mobile
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: apps/mobile/.node-version

--- a/.github/workflows/mobile-cd.yml
+++ b/.github/workflows/mobile-cd.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: apps/mobile/.node-version
-          cache: yarn
-          cache-dependency-path: apps/mobile/yarn.lock
+          # No yarn cache on this job, it publishes the signed APK and a
+          # cache entry primed elsewhere must not feed a release build.
 
       - name: Install node modules
         run: yarn install
@@ -37,15 +37,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('apps/mobile/gradle/wrapper/gradle-wrapper.properties') }}
+          # Ref-scoped, same reason as above.
+          key: ${{ runner.os }}-gradle-wrapper-${{ github.ref_name }}-${{ hashFiles('apps/mobile/gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Cache Gradle Dependencies
         uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('apps/mobile/gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-caches-${{ github.ref_name }}-${{ hashFiles('apps/mobile/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-caches-
+            ${{ runner.os }}-gradle-caches-${{ github.ref_name }}-
 
       - name: Make Gradlew Executable
         run: cd android && chmod +x ./gradlew

--- a/.github/workflows/mobile-cd.yml
+++ b/.github/workflows/mobile-cd.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Sign App APK
         id: sign_apk
-        uses: r0adkll/sign-android-release@v1
+        uses: r0adkll/sign-android-release@dbeba6b98a60b0fd540c02443c7f428cdedf0e7f # v1.0.4
         with:
           releaseDirectory: apps/mobile/android/app/build/outputs/apk/release
           signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}

--- a/.github/workflows/mobile-cd.yml
+++ b/.github/workflows/mobile-cd.yml
@@ -72,12 +72,12 @@ jobs:
           path: librephotos-latest-signed.apk
 
       - name: Create APK Release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: "mobile/latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: "mobile/latest"
           prerelease: true
           draft: false
-          title: "Latest Mobile Release"
+          name: "Latest Mobile Release"
           files: |
             librephotos-latest-signed.apk

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -11,6 +11,9 @@ on:
       - 'apps/backend/**'
       - '.github/workflows/test-backend.yml'
 
+permissions:
+  contents: read
+
 jobs:
   django:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           # 3.11 here, but 3.14 in lint-backend.yml: ruff only parses the code


### PR DESCRIPTION
Seven small commits, all on the workflow security posture, nothing touches application code.

**Pins.** Every third party action now points to a full commit SHA inside the major already in use, tag kept in a comment for readability and cross-checking. A tag or branch ref is a movable pointer: whoever controls the action repository can repoint it, and the next run executes their code with this repo's secrets, the Docker Hub tokens and the Android signing key included. That is the March 2025 tj-actions/changed-files incident (CVE-2025-30066). First party actions (actions/*) stay on their tags, though Scorecard's pinned-dependencies check would want those pinned too. Your renovate config already automerges pin and digest updates, so the pins maintain themselves.

**Archived action replaced.** `marvinpinto/action-automatic-releases` is archived, no security patches are coming, and the ref was the floating `latest` tag on top. The maintained `softprops/action-gh-release` takes over with the inputs mapped one to one. One nuance worth your eyes: it updates the rolling `mobile/latest` release in place instead of deleting and recreating it, the attached APK is replaced either way.

**Permissions.** Every workflow now declares what its jobs use. The image pipeline authenticates with Docker Hub credentials and never touches the workflow token, so it runs read-only, as do lint and tests. The docs deploy keeps `contents: write` for the gh-pages push, the mobile pipeline keeps it for the beta release.

**Secrets.** The reusable image workflow declares exactly two secrets, the Docker Hub pair, but every caller passed `secrets: inherit`, which also handed the Android signing key and store passwords to the image builds. Explicit forwarding gives them what they use and nothing else.

**Release caches.** The proxy image build restored the shared buildx cache while pushing the image, and the mobile job's gradle and yarn caches restored across contexts while producing the signed APK that ships (the May 2026 TanStack cache poisoning vector). The proxy build drops its cache, its Dockerfile is a thin nginx assembly, the gradle keys now carry the ref, and the yarn cache comes off the release path. Interesting detail: the mobile cache exposure only became analyzable after the archived action was replaced, the archived one was invisible to publish-detection.

**Checkout credentials.** Eleven checkouts persisted the workflow token in `.git/config` with nothing ever pushing through it, they now set `persist-credentials: false`.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.