### PR TITLE
fix: bound the live video transcode, and drain the pipe that hung it (Closes #1920)

### DIFF
--- a/apps/backend/api/ffmpeg_budget.py
+++ b/apps/backend/api/ffmpeg_budget.py
@@ -1,0 +1,107 @@
+"""How much of the machine an ffmpeg conversion is allowed to take.
+
+Two conversions run in this codebase and they want opposite things. The live
+one (:class:`api.views.views.VideoTranscoder`) has somebody watching it, so it
+must stay ahead of playback and must not be niced behind anything. The cached
+one (:mod:`api.transcode_cache`) has nobody waiting, so it stands back. What
+they share is that ffmpeg, left alone, helps itself to the whole host: no
+thread limit and no output rate limit, so one person opening one video can
+starve the web UI, the scan workers and every other user. This module is the
+single place that decides what "the whole host" gets narrowed to.
+
+Two levers, and they bound different things.
+
+``-threads`` caps how many cores the work may occupy at once. It has to be
+given **twice** to mean what it looks like it means: before the input it sets
+the decoder's threads, after the input the encoder's -- and neither of them
+governs the filter pool, which needs ``-filter_threads`` of its own.
+
+How much that is worth depends on how much of the machine ffmpeg could
+otherwise have taken. Measured on a 4-core host converting 1080p to 720p, where
+the work parallelises to about 2.7 cores by itself: 2.67 cores unbounded, 2.58
+with ``-threads`` after the input only, 2.44 with it on both sides, 2.38 adding
+``-filter_threads``, and 0.99 -- exactly the cap -- with all three set to one.
+The cap holds; what a 4-core host cannot show is how much it holds *back*,
+since the workload nearly saturates it unaided. The gap is what grows with the
+core count, which is where the complaint in #1920 came from.
+
+``-readrate`` caps how fast the conversion runs relative to real time, which is
+the lever ``-threads`` cannot pull: a viewer needs output a little faster than
+playback and nothing more, so a fast host converting a two-hour film at twenty
+times real time is burning cores on footage nobody may ever reach.
+``-readrate_initial_burst`` exempts the first few seconds, so playback still
+starts at once and the browser still gets a buffer. Both are relatively recent
+ffmpeg options, so their presence is probed rather than assumed.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Probed once per process: asking ffmpeg for its full help costs a subprocess and
+# about a megabyte of text, and the answer cannot change under us. The help text
+# is cached rather than each answer, so asking about a second option is free.
+_help_text = None
+
+
+def cpu_share(fraction=2):
+    """Cores to allow, as a fraction of what the machine has. Never fewer than one.
+
+    A fraction below one is read as "no limit worth applying" rather than as a
+    division to attempt, so a hand-edited settings file cannot take the media
+    endpoint down with a ZeroDivisionError.
+    """
+    cores = os.cpu_count() or 2
+    if fraction < 1:
+        return cores
+    return max(1, cores // fraction)
+
+
+def supports(option):
+    """Whether this ffmpeg understands ``option``, e.g. ``"readrate"``.
+
+    ``-readrate`` arrived in ffmpeg 5.0 and ``-readrate_initial_burst`` in 6.1,
+    and an unknown option is a hard failure -- ffmpeg exits rather than ignoring
+    it, which would turn every video into a broken one. This is not a
+    hypothetical: the CPU image is built on ubuntu:noble and has both, while the
+    GPU image is built on ubuntu 22.04, whose ffmpeg is 4.4 and has neither.
+    Hosts supplying their own ffmpeg can be anything at all.
+    """
+    # Options are listed one per line as "-name  description". Match the whole
+    # name, so that asking about "readrate" is not answered by
+    # "readrate_initial_burst".
+    return any(
+        line.strip().split(" ", 1)[0] == f"-{option}"
+        for line in _full_help().splitlines()
+    )
+
+
+def _full_help():
+    global _help_text
+    if _help_text is None:
+        _help_text = _read_full_help()
+    return _help_text
+
+
+def _read_full_help():
+    if not shutil.which("ffmpeg"):
+        return ""
+    try:
+        return subprocess.run(
+            ["ffmpeg", "-hide_banner", "-h", "full"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        logger.warning("could not ask ffmpeg which options it supports", exc_info=True)
+        return ""
+
+
+def reset_probe_cache():
+    """Forget what was probed. For tests, which vary the ffmpeg they pretend to have."""
+    global _help_text
+    _help_text = None

--- a/apps/backend/api/tests/media_serving/test_live_transcode_limits.py
+++ b/apps/backend/api/tests/media_serving/test_live_transcode_limits.py
@@ -1,0 +1,327 @@
+"""What the live conversion is allowed to take, and what it does with stderr.
+
+"Always transcode videos" pipes a video the browser cannot decode through
+ffmpeg while the viewer watches it. Unbounded, ffmpeg takes every core and
+converts as fast as the hardware allows -- so one person opening one video
+starves the web UI, the scan workers and every other user -- while playback
+needs output only a little faster than real time.
+
+Two limits bound different things, and both matter: -threads (with
+-filter_threads, which it does not reach) caps how many cores the work may
+occupy, -readrate caps how far ahead of playback it runs.
+The third thing covered here is the pipe that made the first two dangerous:
+stderr was never read, and rate limiting is precisely what makes a conversion
+run long enough to fill it.
+"""
+
+import subprocess
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from api import ffmpeg_budget
+from api.views import views
+
+
+def _split(command):
+    """The options before -i and the options after it, which mean different things."""
+    index = command.index("-i")
+    return command[:index], command[index + 2 :]
+
+
+class CpuShareTest(SimpleTestCase):
+    def test_takes_the_named_fraction_of_the_machine(self):
+        with mock.patch.object(ffmpeg_budget.os, "cpu_count", return_value=8):
+            self.assertEqual(ffmpeg_budget.cpu_share(2), 4)
+            self.assertEqual(ffmpeg_budget.cpu_share(4), 2)
+            self.assertEqual(ffmpeg_budget.cpu_share(1), 8)
+
+    def test_never_reaches_zero_threads(self):
+        """A single-core host still has to convert something."""
+        with mock.patch.object(ffmpeg_budget.os, "cpu_count", return_value=1):
+            self.assertEqual(ffmpeg_budget.cpu_share(2), 1)
+            self.assertEqual(ffmpeg_budget.cpu_share(16), 1)
+
+    def test_survives_a_machine_that_will_not_say(self):
+        with mock.patch.object(ffmpeg_budget.os, "cpu_count", return_value=None):
+            self.assertEqual(ffmpeg_budget.cpu_share(2), 1)
+
+    def test_a_fraction_below_one_means_no_limit_rather_than_a_crash(self):
+        """A hand-edited 0 must not take the media endpoint down by dividing."""
+        with mock.patch.object(ffmpeg_budget.os, "cpu_count", return_value=8):
+            self.assertEqual(ffmpeg_budget.cpu_share(0), 8)
+            self.assertEqual(ffmpeg_budget.cpu_share(-4), 8)
+
+
+class SupportsTest(SimpleTestCase):
+    def setUp(self):
+        ffmpeg_budget.reset_probe_cache()
+        self.addCleanup(ffmpeg_budget.reset_probe_cache)
+
+    def _help(self, text):
+        """An ffmpeg on PATH whose help output says ``text``.
+
+        which() is stubbed too: the suite also runs on hosts with no ffmpeg,
+        where the probe short-circuits before it would ever ask.
+        """
+        which = mock.patch.object(
+            ffmpeg_budget.shutil, "which", return_value="/usr/bin/ffmpeg"
+        )
+        which.start()
+        self.addCleanup(which.stop)
+        return mock.patch.object(
+            ffmpeg_budget.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0, stdout=text, stderr=""),
+        )
+
+    def test_finds_an_option_that_is_listed(self):
+        with self._help("  -readrate speed  read input at specified rate\n"):
+            self.assertTrue(ffmpeg_budget.supports("readrate"))
+
+    def test_absent_option_is_not_claimed(self):
+        """ffmpeg 4.x has no -readrate, and exits rather than ignoring one."""
+        with self._help("  -re  read input at native frame rate\n"):
+            self.assertFalse(ffmpeg_budget.supports("readrate"))
+
+    def test_does_not_mistake_a_longer_option_for_a_shorter_one(self):
+        """-readrate_initial_burst starts with -readrate and is a different option."""
+        with self._help("  -readrate_initial_burst seconds  burst first\n"):
+            self.assertFalse(ffmpeg_budget.supports("readrate"))
+            self.assertTrue(ffmpeg_budget.supports("readrate_initial_burst"))
+
+    def test_asks_ffmpeg_only_once_however_many_options_are_checked(self):
+        """The help text is cached, not each answer, so the second ask is free."""
+        with self._help(
+            "  -readrate speed  x\n  -readrate_initial_burst seconds  y\n"
+        ) as run:
+            ffmpeg_budget.supports("readrate")
+            ffmpeg_budget.supports("readrate")
+            ffmpeg_budget.supports("readrate_initial_burst")
+        self.assertEqual(run.call_count, 1)
+
+    def test_no_ffmpeg_on_the_host_is_not_an_exception(self):
+        with mock.patch.object(ffmpeg_budget.shutil, "which", return_value=None):
+            self.assertFalse(ffmpeg_budget.supports("readrate"))
+
+    def test_an_ffmpeg_that_will_not_answer_is_not_an_exception(self):
+        with (
+            mock.patch.object(
+                ffmpeg_budget.shutil, "which", return_value="/usr/bin/ffmpeg"
+            ),
+            mock.patch.object(
+                ffmpeg_budget.subprocess, "run", side_effect=OSError("boom")
+            ),
+        ):
+            self.assertFalse(ffmpeg_budget.supports("readrate"))
+
+
+@override_settings(
+    TRANSCODE_LIVE_CPU_FRACTION=2,
+    TRANSCODE_LIVE_READRATE=2,
+    TRANSCODE_LIVE_BURST_SECONDS=30,
+)
+class BuildLiveCommandTest(SimpleTestCase):
+    def setUp(self):
+        self.supports = mock.patch.object(
+            views.ffmpeg_budget, "supports", return_value=True
+        )
+        self.supports.start()
+        self.addCleanup(self.supports.stop)
+        cores = mock.patch.object(ffmpeg_budget.os, "cpu_count", return_value=8)
+        cores.start()
+        self.addCleanup(cores.stop)
+
+    def test_threads_are_capped_on_both_sides_of_the_input(self):
+        """Only after the input caps the encoder and leaves the decode uncapped.
+
+        Measured on a 4-core host converting 1080p to 720p: 2.67 cores
+        unbounded, 2.58 with -threads after the input alone, 2.44 with it on
+        both sides. See api.ffmpeg_budget for the whole table.
+        """
+        before, after = _split(views.build_live_command("/x.mp4"))
+        self.assertEqual(before[before.index("-threads") + 1], "4")
+        self.assertEqual(after[after.index("-threads") + 1], "4")
+
+    def test_the_filter_pool_is_capped_as_well(self):
+        """-threads does not reach it: it defaults to one thread per core."""
+        before, after = _split(views.build_live_command("/x.mp4"))
+        self.assertEqual(before[before.index("-filter_threads") + 1], "4")
+        self.assertNotIn("-filter_threads", after)
+
+    def test_the_filter_pool_follows_the_same_fraction(self):
+        with override_settings(TRANSCODE_LIVE_CPU_FRACTION=4):
+            before, _ = _split(views.build_live_command("/x.mp4"))
+        self.assertEqual(before[before.index("-filter_threads") + 1], "2")
+
+    def test_an_ffmpeg_without_filter_threads_still_gets_the_rest(self):
+        """Old enough to lack it, and it would exit rather than ignore it."""
+        with mock.patch.object(
+            views.ffmpeg_budget,
+            "supports",
+            side_effect=lambda option: option != "filter_threads",
+        ):
+            command = views.build_live_command("/x.mp4")
+        self.assertNotIn("-filter_threads", command)
+        self.assertIn("-threads", command)
+        self.assertIn("-readrate", command)
+
+    def test_the_fraction_decides_how_many_cores(self):
+        with override_settings(TRANSCODE_LIVE_CPU_FRACTION=4):
+            before, _ = _split(views.build_live_command("/x.mp4"))
+        self.assertEqual(before[before.index("-threads") + 1], "2")
+
+    def test_rate_limit_and_burst_are_input_options(self):
+        """They govern how fast the input is read, so after -i they do nothing."""
+        before, after = _split(views.build_live_command("/x.mp4"))
+        self.assertEqual(float(before[before.index("-readrate") + 1]), 2.0)
+        self.assertEqual(
+            float(before[before.index("-readrate_initial_burst") + 1]), 30.0
+        )
+        self.assertNotIn("-readrate", after)
+
+    def test_a_zero_readrate_converts_flat_out(self):
+        with override_settings(TRANSCODE_LIVE_READRATE=0):
+            command = views.build_live_command("/x.mp4")
+        self.assertNotIn("-readrate", command)
+        self.assertNotIn("-readrate_initial_burst", command)
+
+    def test_a_zero_burst_still_rate_limits(self):
+        with override_settings(TRANSCODE_LIVE_BURST_SECONDS=0):
+            command = views.build_live_command("/x.mp4")
+        self.assertIn("-readrate", command)
+        self.assertNotIn("-readrate_initial_burst", command)
+
+    def test_an_ffmpeg_without_readrate_gets_neither_option(self):
+        """Unknown options make ffmpeg exit, which would break every video."""
+        with mock.patch.object(views.ffmpeg_budget, "supports", return_value=False):
+            command = views.build_live_command("/x.mp4")
+        self.assertNotIn("-readrate", command)
+        self.assertNotIn("-readrate_initial_burst", command)
+        self.assertNotIn("-filter_threads", command)
+        self.assertIn("-threads", command)
+
+    def test_an_ffmpeg_with_readrate_but_no_burst_keeps_the_rate_limit(self):
+        """ffmpeg 5.x: -readrate exists, -readrate_initial_burst arrived in 6.1."""
+        with mock.patch.object(
+            views.ffmpeg_budget,
+            "supports",
+            side_effect=lambda option: option == "readrate",
+        ):
+            command = views.build_live_command("/x.mp4")
+        self.assertIn("-readrate", command)
+        self.assertNotIn("-readrate_initial_burst", command)
+
+    def test_progress_output_is_turned_off(self):
+        """It is written to a pipe nothing drains; see the stderr tests below."""
+        command = views.build_live_command("/x.mp4")
+        self.assertEqual(command[command.index("-loglevel") + 1], "error")
+
+    def test_the_height_is_still_a_ceiling_and_not_a_target(self):
+        command = views.build_live_command("/x.mp4")
+        self.assertIn("scale=-2:'min(720,ih)'", command)
+
+    def test_the_conversion_being_watched_is_not_niced(self):
+        """Unlike the cached copy: somebody is waiting for this one."""
+        self.assertEqual(views.build_live_command("/x.mp4")[0], "ffmpeg")
+
+    def test_the_path_is_the_input(self):
+        command = views.build_live_command("/library/clip.mkv")
+        self.assertEqual(command[command.index("-i") + 1], "/library/clip.mkv")
+        self.assertEqual(command[-1], "-")
+
+
+class FakePopen:
+    """A process whose stderr must be drained before its stdout will finish.
+
+    This is the shape of the deadlock: ffmpeg blocks writing to a full stderr
+    pipe, and stops producing video, so a reader that only reads stdout waits
+    forever.
+    """
+
+    def __init__(self, stderr_chunks, stdout_lines, returncode=0):
+        self._remaining_stderr = list(stderr_chunks)
+        self._stdout_lines = list(stdout_lines)
+        self.returncode = returncode
+        self.stdout = mock.Mock()
+        self.stderr = mock.Mock()
+        self.stdout.readline = self._readline
+        self.stderr.read = self._read_stderr
+
+    def _read_stderr(self, size):
+        return self._remaining_stderr.pop(0) if self._remaining_stderr else b""
+
+    def _readline(self):
+        # Blocked until stderr has been drained, exactly as a full pipe blocks.
+        if self._remaining_stderr:
+            return b""
+        return self._stdout_lines.pop(0) if self._stdout_lines else b""
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+class VideoTranscoderStderrTest(SimpleTestCase):
+    def _transcoder(self, process):
+        with mock.patch.object(views.subprocess, "Popen", return_value=process):
+            return views.VideoTranscoder("/x.mp4")
+
+    def test_stderr_is_drained_so_a_full_pipe_cannot_stall_the_video(self):
+        """FakePopen withholds stdout until stderr is read, as a full pipe does."""
+        process = FakePopen([b"noise" * 100], [b"frame\n"])
+        transcoder = self._transcoder(process)
+        transcoder._drain.join(timeout=5)
+        self.assertEqual(list(views.gen(transcoder)), [b"frame\n"])
+
+    def test_reading_the_tail_waits_for_the_drain_to_finish(self):
+        """A deque may be extended from another thread but not read mid-extend."""
+        transcoder = self._transcoder(FakePopen([b"a" * 4096, b"b\n"], []))
+        self.assertEqual(transcoder.stderr_tail()[-1], "b")
+        self.assertFalse(transcoder._drain.is_alive())
+
+    def test_stderr_is_a_pipe_and_not_discarded(self):
+        """Discarding it would be deadlock-free too, and would lose every reason.
+
+        The process is a real fake rather than a bare Mock: the drain thread
+        reads until it is handed b"", and a Mock never hands it one.
+        """
+        with mock.patch.object(
+            views.subprocess, "Popen", return_value=FakePopen([], [])
+        ) as popen:
+            transcoder = views.VideoTranscoder("/x.mp4")
+        transcoder._drain.join(timeout=5)
+        self.assertEqual(popen.call_args.kwargs["stderr"], subprocess.PIPE)
+
+    def test_what_ffmpeg_said_is_kept(self):
+        transcoder = self._transcoder(FakePopen([b"No such file\n"], []))
+        self.assertEqual(transcoder.stderr_tail(), "No such file")
+
+    def test_only_the_tail_is_kept_however_much_is_written(self):
+        """A file that errors on every frame must not grow this without bound."""
+        limit = views.VideoTranscoder.STDERR_TAIL_BYTES
+        transcoder = self._transcoder(FakePopen([b"e" * (limit * 3)], []))
+        self.assertEqual(len(transcoder.stderr_tail()), limit)
+
+
+class GenTest(SimpleTestCase):
+    def _transcoder(self, process):
+        with mock.patch.object(views.subprocess, "Popen", return_value=process):
+            return views.VideoTranscoder("/x.mp4")
+
+    def test_a_successful_conversion_says_nothing(self):
+        transcoder = self._transcoder(FakePopen([], [b"a\n", b"b\n"]))
+        with mock.patch.object(views, "logger") as logger:
+            self.assertEqual(list(views.gen(transcoder)), [b"a\n", b"b\n"])
+        logger.warning.assert_not_called()
+
+    def test_a_failed_conversion_is_logged_with_the_reason(self):
+        """It reaches the browser as a video that stops; the log is the only place left."""
+        process = FakePopen([b"Invalid data found\n"], [], returncode=1)
+        transcoder = self._transcoder(process)
+        with mock.patch.object(views, "logger") as logger:
+            list(views.gen(transcoder))
+        logger.warning.assert_called_once()
+        self.assertIn("Invalid data found", logger.warning.call_args.args[2])

--- a/apps/backend/api/views/views.py
+++ b/apps/backend/api/views/views.py
@@ -1,5 +1,7 @@
+import collections
 import os
 import subprocess
+import threading
 import uuid
 from urllib.parse import quote
 
@@ -38,7 +40,7 @@ from api.ml_models import do_all_models_exist, download_models
 from api.models import AlbumUser, LongRunningJob, Photo, User
 from api.schemas.site_settings import site_settings_schema
 from api.serializers.album_user import AlbumUserEditSerializer, AlbumUserListSerializer
-from api import transcode_cache
+from api import ffmpeg_budget, transcode_cache
 from api.util import logger
 from api.views.pagination import StandardResultsSetPagination
 
@@ -539,42 +541,142 @@ class MediaAccessView(APIView):
         return HttpResponse(status=404)
 
 
+def build_live_command(path):
+    """The conversion a viewer is waiting on, bounded so it cannot take the host.
+
+    Unbounded, this is one person's playback against everybody else's: ffmpeg
+    defaults to every core and to converting as fast as the machine allows,
+    while a viewer needs only a little more than real time. See
+    :mod:`api.ffmpeg_budget` for what the two limits below each bound, and why
+    ``-threads`` has to appear on both sides of the input to mean anything.
+
+    It is deliberately *not* niced -- unlike the cached copy, somebody is
+    watching this one, so it should outrank the background work rather than
+    yield to it.
+    """
+    threads = str(ffmpeg_budget.cpu_share(settings.TRANSCODE_LIVE_CPU_FRACTION))
+    # -loglevel error is load-bearing, not tidiness. stderr is a pipe that
+    # nothing in the request path ever reads, and ffmpeg's default progress
+    # output is written on a wall-clock cadence, so a conversion long enough to
+    # write ~64 KB of it fills the pipe buffer and blocks in write() forever --
+    # mid-video, with the process still alive and the browser still waiting.
+    # Rate limiting lengthens exactly that wall clock, which would have turned a
+    # bug reachable only on long videos into one reachable on ordinary ones.
+    command = ["ffmpeg", "-nostdin", "-loglevel", "error", "-threads", threads]
+
+    # -threads does not govern the filter pool, which defaults to one thread per
+    # core: on a many-core host the scale filter alone can spawn as many threads
+    # as the machine has, straight past the cap. Measured on a 4-core host,
+    # 1080p -> 720p: 2.44 cores with -threads 2 alone, 2.38 with this as well.
+    # A small saving here and a much larger one on a machine with more cores.
+    # Probed like the others -- it long predates them, but an ffmpeg old enough
+    # to lack it would exit rather than ignore it.
+    if ffmpeg_budget.supports("filter_threads"):
+        command += ["-filter_threads", threads]
+
+    readrate = settings.TRANSCODE_LIVE_READRATE
+    if readrate > 0 and ffmpeg_budget.supports("readrate"):
+        command += ["-readrate", str(readrate)]
+        burst = settings.TRANSCODE_LIVE_BURST_SECONDS
+        if burst > 0 and ffmpeg_budget.supports("readrate_initial_burst"):
+            command += ["-readrate_initial_burst", str(burst)]
+
+    return command + [
+        "-i",
+        path,
+        # Again after the input: the first one capped the decoder, this caps the
+        # encoder. Only one of the two and half the work stays uncapped.
+        "-threads",
+        threads,
+        "-vcodec",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-movflags",
+        "frag_keyframe+empty_moov",
+        "-filter:v",
+        # A ceiling, not a target: plain "scale=-2:720" enlarges anything
+        # shorter than 720 lines, and the phone clips that most often need
+        # converting are exactly that. Upscaling costs bandwidth and CPU to
+        # add nothing a viewer can see.
+        "scale=-2:'min(720,ih)'",
+        "-f",
+        "mp4",
+        "-",
+    ]
+
+
 class VideoTranscoder:
+    """A live conversion, its output on stdout and its complaints drained.
+
+    Nothing in the request path ever read stderr, and it was a pipe: ffmpeg
+    writes progress there on a wall-clock cadence, so a conversion running long
+    enough to produce about 64 KB of it filled the pipe buffer and blocked in
+    write() forever, mid-video, with the process alive and the browser waiting.
+    Progress arrives at about 315 bytes a second of wall clock, so 64 KB --
+    a pipe's full capacity -- accumulates after roughly six minutes of
+    conversion: a video of about sixteen minutes on a four-core host, less on a
+    slower one, and less again once the conversion is rate limited. What
+    decides it is how long the conversion runs, not the resolution or the
+    layout of the file. Caught in the act on unmodified dev: stdout frozen at
+    302.9 MB, the process alive with /proc/<pid>/syscall reading write() on fd
+    2, and output resuming the moment the pipe was read.
+
+    ``-loglevel error`` removes almost all of that output, but a file that
+    decodes badly can still produce error lines without end, so the pipe is
+    also drained -- into a small ring buffer, kept for the log if the
+    conversion turns out to have failed. Today those lines are discarded
+    unread, which is why a transcode that dies leaves nothing but a truncated
+    video and no explanation.
+    """
+
+    # Enough to identify a failure, small enough that a file erroring on every
+    # frame cannot grow it without bound.
+    STDERR_TAIL_BYTES = 8192
+
     process = ""
 
     def __init__(self, path):
-        ffmpeg_command = [
-            "ffmpeg",
-            "-i",
-            path,
-            "-vcodec",
-            "libx264",
-            "-preset",
-            "ultrafast",
-            "-movflags",
-            "frag_keyframe+empty_moov",
-            "-filter:v",
-            # A ceiling, not a target: plain "scale=-2:720" enlarges anything
-            # shorter than 720 lines, and the phone clips that most often need
-            # converting are exactly that. Upscaling costs bandwidth and CPU to
-            # add nothing a viewer can see.
-            "scale=-2:'min(720,ih)'",
-            "-f",
-            "mp4",
-            "-",
-        ]
         self.process = subprocess.Popen(
-            ffmpeg_command,
+            build_live_command(path),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        self._stderr_tail = collections.deque(maxlen=self.STDERR_TAIL_BYTES)
+        self._drain = threading.Thread(target=self._read_stderr, daemon=True)
+        self._drain.start()
+
+    def _read_stderr(self):
+        for chunk in iter(lambda: self.process.stderr.read(4096), b""):
+            self._stderr_tail.extend(chunk)
+
+    def stderr_tail(self):
+        """What ffmpeg last said, once there is no more of it coming.
+
+        The drain thread is joined first: a deque is safe to extend from
+        another thread but not to iterate while it is being extended, and
+        process exit does not by itself mean the pipe has been read to the end.
+        """
+        self._drain.join(timeout=5)
+        return bytes(self._stderr_tail).decode("utf-8", "replace").strip()
 
     def __del__(self):
         self.process.kill()
 
 
 def gen(transcoder):
+    """Stream the conversion, and say so in the log if it ended badly.
+
+    A failed transcode reaches the browser as a video that simply stops, so the
+    only place the reason can land is here.
+    """
     yield from iter(transcoder.process.stdout.readline, b"")
+    if transcoder.process.wait() != 0:
+        logger.warning(
+            "live video transcode exited with %s: %s",
+            transcoder.process.returncode,
+            transcoder.stderr_tail() or "no output on stderr",
+        )
 
 
 class UnifiedMediaAccessView(APIView):

--- a/apps/backend/librephotos/settings/production.py
+++ b/apps/backend/librephotos/settings/production.py
@@ -52,6 +52,24 @@ TRANSCODE_CACHE_MAX_CONCURRENT = int(
 # niced and given half the cores, because playback, thumbnails and the scan all
 # matter more than a copy nobody is waiting for.
 TRANSCODE_CACHE_NICE = int(os.environ.get("TRANSCODE_CACHE_NICE", "10"))
+
+# What the *live* conversion -- the one a viewer is waiting on -- is allowed to
+# take. Left alone ffmpeg uses every core and converts as fast as the hardware
+# permits, so one person opening one video can starve the web UI, the scan
+# workers and everybody else. Playback needs output a little faster than real
+# time and nothing more.
+#
+# Cores are capped to 1/N of the machine, and the conversion is held to
+# TRANSCODE_LIVE_READRATE times real time after an initial burst of
+# TRANSCODE_LIVE_BURST_SECONDS, which keeps the start instant and gives the
+# browser a buffer. Set the readrate to 0 to convert as fast as the host can.
+TRANSCODE_LIVE_CPU_FRACTION = max(
+    1, int(os.environ.get("TRANSCODE_LIVE_CPU_FRACTION", "2"))
+)
+TRANSCODE_LIVE_READRATE = float(os.environ.get("TRANSCODE_LIVE_READRATE", "2"))
+TRANSCODE_LIVE_BURST_SECONDS = float(
+    os.environ.get("TRANSCODE_LIVE_BURST_SECONDS", "30")
+)
 LOGS_ROOT = BASE_LOGS
 # Create the directory before anything in this module writes to it. secret.key
 # lives in there too and is written some 40 lines further down, so an install

--- a/apps/docs/docs/installation/environment-variables.md
+++ b/apps/docs/docs/installation/environment-variables.md
@@ -210,6 +210,22 @@ When either ceiling is reached, the least recently played entries are deleted un
 
 The files live under `protected_media/transcoded/`, named by image hash, and are deleted along with the photo. Deleting the directory by hand is safe at any time — it costs only the CPU to convert those videos again.
 
+### What a live conversion may take
+
+The conversion a viewer is waiting on is bounded too, and for a different reason than the cached copy. Left to itself ffmpeg uses every core and converts as fast as the hardware allows, so one person opening one video can starve the web UI, a running scan and every other user — while playback needs output only a little faster than real time. The extra throughput buys nothing: on a fast host it races through footage the viewer may never reach.
+
+| Variable | `.env` key | Default | What it does |
+| --- | --- | --- | --- |
+| `TRANSCODE_LIVE_CPU_FRACTION` | `transcodeLiveCpuFraction` | `2` | Cap the conversion at 1/N of the machine's cores. `2` is half; `1` lets it use all of them. Never fewer than one core, whatever the number. The cap is close rather than exact — decoding, filtering and encoding are each held to it, but reading and muxing are not. |
+| `TRANSCODE_LIVE_READRATE` | `transcodeLiveReadrate` | `2` | Hold the conversion to this multiple of real time, so a minute of video takes about half a minute to convert. Set it to `0` to convert as fast as the host can. |
+| `TRANSCODE_LIVE_BURST_SECONDS` | `transcodeLiveBurstSeconds` | `30` | How much video to convert at full speed before the rate limit applies, so playback still starts instantly and the browser still has a buffer ahead of it. |
+
+Unlike the cached copy, the live conversion is **not** niced: somebody is watching it, so it should outrank the background work rather than yield to it.
+
+`TRANSCODE_LIVE_READRATE` and `TRANSCODE_LIVE_BURST_SECONDS` need a recent ffmpeg — `-readrate` arrived in ffmpeg 5.0 and `-readrate_initial_burst` in 6.1. The CPU image has both. **The GPU image does not**: it is built on Ubuntu 22.04, whose ffmpeg is 4.4, so on that image these two settings have no effect and only `TRANSCODE_LIVE_CPU_FRACTION` applies. The same goes for a host supplying its own older ffmpeg. Nothing has to be configured for that — the option is simply not passed, and the core cap still holds.
+
+`TRANSCODE_LIVE_CPU_FRACTION` is a divisor, so a **larger** number means fewer cores: `4` is stricter than `2`. Raising it, or lowering the readrate, makes a busy server more responsive while a video is playing; going the other way favours the person watching. If a video stutters on a slow machine, set `TRANSCODE_LIVE_CPU_FRACTION` to `1` first: a stutter means the conversion cannot keep ahead of playback, and it is the core cap that decides how fast it can go — the readrate is a ceiling it never reached. For scale, one core converts 1080p to 720p at about 1.5x real time, and two at about 2x, so a machine with few cores has little margin at 1080p and none to spare for a second viewer.
+
 ### Logging
 
 The backend writes its log files into the directory named by `BASE_LOGS`. `ownphotos.log` is the one to look at first; it is also downloadable from the Admin Area (see [Internal files](../user-guide/internal-files.md) and [Library](../user-guide/library.md)).

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -85,6 +85,9 @@ services:
       - TRANSCODE_CACHE_MIN_FREE_GB=${transcodeCacheMinFreeGb:-2}
       - TRANSCODE_CACHE_MAX_CONCURRENT=${transcodeCacheMaxConcurrent:-1}
       - TRANSCODE_CACHE_NICE=${transcodeCacheNice:-10}
+      - TRANSCODE_LIVE_CPU_FRACTION=${transcodeLiveCpuFraction:-2}
+      - TRANSCODE_LIVE_READRATE=${transcodeLiveReadrate:-2}
+      - TRANSCODE_LIVE_BURST_SECONDS=${transcodeLiveBurstSeconds:-30}
       - DEBUG=0
     depends_on:
       db:

--- a/deploy/compose/librephotos.env
+++ b/deploy/compose/librephotos.env
@@ -110,6 +110,19 @@ featureProcessEmbeddedMedia=true
 # It is also limited to half the cores. 0 turns the courtesy off.
 # transcodeCacheNice=10
 
+# The conversion a viewer is actually waiting on. ffmpeg otherwise takes every
+# core and runs as fast as the hardware allows, so one person opening one video
+# can starve the web UI, the scan and everybody else - while playback needs
+# output only a little faster than real time.
+#
+# Cores are capped to 1/N of the machine by the first number. The second holds
+# the conversion to that multiple of real time, after the third number's worth
+# of video has been converted at full speed so playback still starts at once and
+# the browser still gets a buffer. Set the readrate to 0 to convert flat out.
+# transcodeLiveCpuFraction=2
+# transcodeLiveReadrate=2
+# transcodeLiveBurstSeconds=30
+
 # ---------------------------------------------------------------------------------------------
 
 # Outgoing email (for the self-service "Forgot password" flow) is configured in


### PR DESCRIPTION
Closes #1920.

`VideoTranscoder` spawns ffmpeg with no thread limit and no rate limit, so one person opening one video takes the whole host — the web UI, the scan workers and every other user. A viewer needs output a little faster than playback and nothing beyond that, so the extra throughput is spent on nothing: on a fast machine the conversion races through footage the viewer may never reach, and on a slow one it competes with the very playback it exists to serve.

Two limits, because they bound different things. `-threads` caps how many cores the work may occupy, and it has to be given **twice** to mean what it looks like it means: before the input it sets the decoder's threads, after it the encoder's — and neither of them reaches the filter pool, which defaults to one thread per core and needs `-filter_threads` of its own. Measured on a 4-core host converting 1080p to 720p, three reps each: **2.67 cores** unbounded, **2.58** with `-threads` after the input only (the obvious reading, and the one already in the cached-copy command), **2.44** with it on both sides, **2.38** adding `-filter_threads`, and **0.99** — exactly the cap — with all three set to one. So the cap holds, approximately: reading and muxing sit outside it. What a 4-core box cannot show is how much it holds *back*, because this workload only parallelises to about 2.7 cores unaided; the gap between what ffmpeg would take and what it is allowed is what grows with the core count, and that gap is where the report came from. `-readrate` then caps how far ahead of playback the conversion runs, which `-threads` cannot do, with `-readrate_initial_burst` exempting the first 30 seconds so playback still starts at once and the browser still gets a buffer.

**Draining stderr is what makes any of that safe, and it is a bug in its own right.** Nothing in the request path ever read that pipe, and ffmpeg writes progress into it on a wall-clock cadence even when stderr is not a terminal — about 315 bytes a second, measured — so a conversion running long enough to produce 64 KB blocks in `write()` forever, mid-video, with the process still alive and the browser still waiting.

Reproduced on `dev` as it stands, with none of this branch's changes, using its exact command and its exact wiring — both pipes, stdout drained, stderr untouched — against 20 minutes of 1080p: output froze at **302.9 MB after 350 seconds** of conversion, ffmpeg alive, `/proc/<pid>/syscall` reading `1 2`, which is `write()` on fd 2, and the pipe holding exactly **65536 bytes**, its full capacity. Reading that pipe by hand released it and output resumed immediately. What decides the stall is how long the conversion runs rather than anything about the file, so on that host it takes a video of about sixteen minutes — which is why ordinary clips look fine and why this has sat unnoticed. Rate limiting is what changes the arithmetic: held to twice real time, the same 64 KB arrives after about six minutes of video. Shipping the limits without the drain would have turned a bug that needs a long video into one that needs an ordinary one. `-loglevel error` removes nearly all of the output, and the pipe is drained anyway into an 8 KB ring buffer, because a file that decodes badly can produce error lines without end. Those lines are currently discarded unread, which is why a transcode that dies leaves a truncated video and no explanation; now the reason is logged.

The live conversion is deliberately **not** niced, unlike the cached copy: somebody is watching this one, so it should outrank the background work rather than yield to it.

All three ffmpeg options are probed rather than assumed, and that is not defensive habit: `-readrate` arrived in ffmpeg 5.0 and `-readrate_initial_burst` in 6.1, so the CPU image (`ubuntu:noble`, ffmpeg 6.1) has both while **the GPU image has neither** — it is built on `nvidia/cuda:...-ubuntu22.04`, whose ffmpeg is 4.4. An unknown option makes ffmpeg exit rather than ignore it, so assuming them would have turned every video on the GPU image into a broken one. Where an option is missing it is not passed, the rest of the bound still applies, and nothing has to be configured. The probe reads `ffmpeg -h full` once per process and caches the text, so asking about the second and third option is free.

Three settings, defaulting to half the cores at twice real time after a 30-second burst, documented on the environment-variables page and added to `librephotos.env` and the bundled compose file. `TRANSCODE_LIVE_READRATE=0` converts flat out, which is today's behaviour.

**Small libraries are unaffected**, and so are large ones: nothing here scales with library size. The cost is per video being watched, and it goes down rather than up. The one trade is on a machine slow enough that its allowed share cannot stay ahead of playback, where a video could stutter that previously did not — hence the settings, and a documented order to relax them in. With the shipped defaults on the 4-core box used here, 1080p to 720p ran at 2.09× real time for 1.90 cores; a single core holds about 1.5× real time, which is still ahead of playback but without much margin, so the docs say to lift the core cap first if a video stutters. Raising the readrate cannot help in that case — it is a ceiling the conversion never reached.

31 new tests cover the thread placement on both sides of the input, the filter-pool cap, the readrate and burst options and each way they can be switched off, the version probe and its caching, the fallback for an ffmpeg missing any one of the three options, the stderr drain against a process that withholds stdout until stderr is read, the bounded tail, and the failure logging. The full backend suite runs clean against a pristine-`dev` baseline measured in the same environment: 3170 tests on `dev` with 3 failures and 45 errors, 3201 on the branch with 2 failures and 45 errors, the same environmental set both times minus one load-sensitive performance test that fails on the baseline and passes here. The docs build. Verified end to end as well, against the same half-hour file at the default readrate that stalls today: after the fix it ran to the end — 1800 seconds of video converted in 885 seconds of wall clock, 544 MB delivered, exit 0, holding 2.03× ahead of playback throughout, at 0.13 of a core for that 640×480 source.

(Analysis and code by Claude, directed and browser-tested by me.)
