### PR TITLE
fix(backend): keep Tag.photo_count true when photos stop counting

### DIFF
--- a/apps/backend/api/autoalbum.py
+++ b/apps/backend/api/autoalbum.py
@@ -12,6 +12,7 @@ from api.models import (
     LongRunningJob,
     Photo,
 )
+from api.models.tag import refresh_tag_photo_counts, tag_ids_for_photos
 from api.util import logger
 
 # Batch size for delete_missing_photos. The function snapshots a list of
@@ -232,11 +233,12 @@ def delete_missing_photos(user, job_id):
         # the original per-photo .remove() loops were pure overhead — cascade
         # on Photo.delete() handles the through-rows. Face.photo is
         # on_delete=CASCADE so Face rows (and their post_delete file cleanup)
-        # come along too. AlbumThing.photos.through has a receiver that
-        # maintains photo_count / cover_photos, but cascade bypasses the
-        # signal, so we snapshot affected AlbumThing ids per batch and run
-        # the refresh once after each batch completes.
+        # come along too. AlbumThing.photos.through and Tag.photos.through both
+        # have receivers that maintain photo_count / cover_photos, but cascade
+        # bypasses the signal, so we snapshot the affected ids per batch and
+        # run the refresh once after each batch completes.
         affected_album_thing_ids: set[int] = set()
+        affected_tag_ids: set[int] = set()
         for start in range(0, target, _DELETE_MISSING_BATCH_SIZE):
             batch_pks = missing_pks[start : start + _DELETE_MISSING_BATCH_SIZE]
             batch_qs = Photo.objects.filter(pk__in=batch_pks)
@@ -245,6 +247,7 @@ def delete_missing_photos(user, job_id):
                     "id", flat=True
                 )
             )
+            affected_tag_ids.update(tag_ids_for_photos(batch_qs))
             batch_qs.delete()
             lrj.update_progress(current=start + len(batch_pks), target=target)
 
@@ -252,6 +255,8 @@ def delete_missing_photos(user, job_id):
             album_thing.photo_count = album_thing.photos.filter(hidden=False).count()
             album_thing.save(update_fields=["photo_count"])
             album_thing.update_default_cover_photo()
+
+        refresh_tag_photo_counts(affected_tag_ids)
 
         # File.hash is composed as `md5 + str(user.id)` (see api/models/file.py),
         # so the user-owned subset of missing files is identified by that suffix.

--- a/apps/backend/api/models/duplicate.py
+++ b/apps/backend/api/models/duplicate.py
@@ -185,7 +185,16 @@ class Duplicate(models.Model):
         # Trash others if requested
         if trash_others:
             other_photos = self.photos.exclude(pk=kept_photo.pk)
+            # Trashing takes these photos out of their tags' counts, and a
+            # plain UPDATE fires no m2m signal to say so.
+            from api.models.tag import (
+                refresh_tag_photo_counts,
+                tag_ids_for_photos,
+            )
+
+            affected_tag_ids = tag_ids_for_photos(other_photos)
             self.trashed_count = other_photos.update(in_trashcan=True)
+            refresh_tag_photo_counts(affected_tag_ids)
 
         self.save()
         return self

--- a/apps/backend/api/models/stack_review.py
+++ b/apps/backend/api/models/stack_review.py
@@ -168,7 +168,16 @@ class StackReview(models.Model):
         # Trash others if requested
         if trash_others:
             other_photos = self.stack.photos.exclude(pk=kept_photo.pk)
+            # Trashing takes these photos out of their tags' counts, and a
+            # plain UPDATE fires no m2m signal to say so.
+            from api.models.tag import (
+                refresh_tag_photo_counts,
+                tag_ids_for_photos,
+            )
+
+            affected_tag_ids = tag_ids_for_photos(other_photos)
             self.trashed_count = other_photos.update(in_trashcan=True)
+            refresh_tag_photo_counts(affected_tag_ids)
 
         self.save()
         return self

--- a/apps/backend/api/models/tag.py
+++ b/apps/backend/api/models/tag.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Coalesce
 from django.db.models.signals import m2m_changed
 from django.dispatch import receiver
 
@@ -6,6 +8,12 @@ from api.models.photo import Photo
 from api.models.user import User, get_deleted_user
 
 NAME_MAX_LENGTH = 512
+
+# The photos a tag counts: the same ones its album shows, so the tile's count
+# and the gallery behind it cannot disagree. Kept in one place because two
+# separate code paths compute the count and a drift between them would be
+# invisible until a user noticed the numbers were wrong.
+VISIBLE_PHOTO_FILTER = {"hidden": False, "in_trashcan": False, "removed": False}
 
 
 class Tag(models.Model):
@@ -38,12 +46,61 @@ def update_photo_count(sender, instance, action, reverse, model, pk_set, **kwarg
         return
     tags = Tag.objects.filter(pk__in=pk_set or []) if reverse else [instance]
     for tag in tags:
-        # The same photos the tag's album shows, so the tile's count and the
-        # gallery behind it cannot disagree.
-        tag.photo_count = tag.photos.filter(
-            hidden=False, in_trashcan=False, removed=False
-        ).count()
+        tag.photo_count = tag.photos.filter(**VISIBLE_PHOTO_FILTER).count()
         tag.save(update_fields=["photo_count"])
+
+
+def tag_ids_for_photos(photos):
+    """The ids of every tag holding one of ``photos``.
+
+    Snapshot these *before* deleting the photos: the through-rows go with them,
+    and afterwards there is nothing left to say which tags were affected.
+    """
+    return list(
+        Tag.objects.filter(photos__in=photos).values_list("pk", flat=True).distinct()
+    )
+
+
+def refresh_tag_photo_counts(tag_ids):
+    """Recompute ``photo_count`` for ``tag_ids``, in one statement.
+
+    The ``m2m_changed`` receiver above only fires when a photo is attached to
+    or detached from a tag. A photo that stops counting some other way --
+    trashed, hidden, or deleted outright, where the cascade drops the
+    through-row without sending the signal -- used to leave the stored count
+    behind, so an emptied tag showed "1 photo" over a placeholder tile.
+
+    Written as a set-based UPDATE rather than a ``save()`` per tag because
+    trashing a large selection can touch every tag in the library; this is the
+    same reasoning as the batched AlbumThing refresh in ``delete_missing_photos``
+    (#1848), which predates this model.
+    """
+    if not tag_ids:
+        return 0
+
+    visible_count = (
+        Tag.photos.through.objects.filter(
+            tag_id=OuterRef("pk"),
+            **{
+                f"photo__{field}": value
+                for field, value in VISIBLE_PHOTO_FILTER.items()
+            },
+        )
+        .values("tag_id")
+        .annotate(total=Count("pk"))
+        .values("total")
+    )
+    return Tag.objects.filter(pk__in=tag_ids).update(
+        photo_count=Coalesce(Subquery(visible_count, output_field=IntegerField()), 0)
+    )
+
+
+def refresh_tags_for_photos(photos):
+    """Refresh the counts of every tag holding one of ``photos``.
+
+    For a queryset whose photos are only changing visibility, not going away.
+    """
+    return refresh_tag_photo_counts(tag_ids_for_photos(photos))
 
 
 def get_tag(name, owner):

--- a/apps/backend/api/tests/metadata/test_tag_photo_count.py
+++ b/apps/backend/api/tests/metadata/test_tag_photo_count.py
@@ -1,0 +1,179 @@
+"""Tests for keeping ``Tag.photo_count`` true when photos stop counting.
+
+The ``m2m_changed`` receiver on ``Tag.photos`` only fires when a photo is
+attached to or detached from a tag. Everything here covers the other ways a
+photo leaves a tag's count -- trashed, hidden, or deleted outright -- which
+fire no signal at all.
+"""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from api.models import Photo, Tag
+from api.models.tag import refresh_tag_photo_counts, tag_ids_for_photos
+from api.tests.utils import create_test_photo, create_test_photos, create_test_user
+
+
+def _results(response):
+    data = response.json()
+    if isinstance(data, dict) and "results" in data:
+        return data["results"]
+    return data
+
+
+class TagPhotoCountStaysTrueTest(TestCase):
+    """``photo_count`` when a photo stops counting without leaving the tag.
+
+    The ``m2m_changed`` receiver only fires on attach/detach. A photo that is
+    trashed, hidden or deleted outright keeps (or loses) its through-row
+    without any signal, and the stored count used to be left behind -- an
+    emptied tag showed "1 photo" over a placeholder tile.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.photos = create_test_photos(number_of_photos=2, owner=self.user)
+        self.tag = Tag.objects.create(name="beach", owner=self.user)
+        self.tag.photos.add(*self.photos)
+        self.tag.refresh_from_db()
+        self.assertEqual(self.tag.photo_count, 2)
+
+    def _count(self):
+        self.tag.refresh_from_db()
+        return self.tag.photo_count
+
+    def test_trashing_a_photo_drops_it_from_the_count(self):
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"image_hashes": [self.photos[0].image_hash], "deleted": True},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 1)
+
+    def test_restoring_a_photo_brings_it_back_to_the_count(self):
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"image_hashes": [self.photos[0].image_hash], "deleted": True},
+            format="json",
+        )
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"image_hashes": [self.photos[0].image_hash], "deleted": False},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 2)
+
+    def test_trashing_through_select_all_drops_the_photos(self):
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"select_all": True, "query": {}, "deleted": True},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 0)
+
+    def test_hiding_a_photo_drops_it_from_the_count(self):
+        self.client.post(
+            "/api/photosedit/hide",
+            {"image_hashes": [self.photos[0].image_hash], "hidden": True},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 1)
+
+    def test_unhiding_a_photo_brings_it_back(self):
+        self.client.post(
+            "/api/photosedit/hide",
+            {"image_hashes": [self.photos[0].image_hash], "hidden": True},
+            format="json",
+        )
+        self.client.post(
+            "/api/photosedit/hide",
+            {"image_hashes": [self.photos[0].image_hash], "hidden": False},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 2)
+
+    def test_hiding_through_select_all_drops_the_photos(self):
+        self.client.post(
+            "/api/photosedit/hide",
+            {"select_all": True, "query": {}, "hidden": True},
+            format="json",
+        )
+
+        self.assertEqual(self._count(), 0)
+
+    def test_the_tag_survives_losing_its_last_photo(self):
+        # Deliberate: a tag can be created before anything carries it, and
+        # deleting photos must not silently delete tags.
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"select_all": True, "query": {}, "deleted": True},
+            format="json",
+        )
+
+        self.assertTrue(Tag.objects.filter(pk=self.tag.pk).exists())
+        self.assertEqual(self._count(), 0)
+
+    def test_an_emptied_tag_is_still_listed_with_a_zero_count(self):
+        # Unlike AlbumThing, the tag list has no photo_count > 0 filter: an
+        # empty tag has to stay reachable so the user can rename or delete it.
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"select_all": True, "query": {}, "deleted": True},
+            format="json",
+        )
+
+        listed = _results(self.client.get("/api/tags/"))
+
+        self.assertEqual([tag["name"] for tag in listed], ["beach"])
+        self.assertEqual(listed[0]["photo_count"], 0)
+        self.assertEqual(listed[0]["cover_photos"], [])
+
+    def test_a_hard_deleted_photo_drops_out_of_the_count(self):
+        affected = tag_ids_for_photos(Photo.objects.filter(pk=self.photos[0].pk))
+        self.photos[0].delete()
+        refresh_tag_photo_counts(affected)
+
+        self.assertEqual(self._count(), 1)
+
+    def test_the_refresh_leaves_other_users_tags_alone(self):
+        other_user = create_test_user()
+        other_photo = create_test_photo(owner=other_user)
+        other_tag = Tag.objects.create(name="beach", owner=other_user)
+        other_tag.photos.add(other_photo)
+
+        self.client.post(
+            "/api/photosedit/setdeleted",
+            {"select_all": True, "query": {}, "deleted": True},
+            format="json",
+        )
+
+        other_tag.refresh_from_db()
+        self.assertEqual(other_tag.photo_count, 1)
+
+    def test_the_refresh_is_one_statement_however_many_tags_it_touches(self):
+        for name in ("holiday", "sunset", "family"):
+            tag = Tag.objects.create(name=name, owner=self.user)
+            tag.photos.add(*self.photos)
+        tag_ids = list(Tag.objects.filter(owner=self.user).values_list("pk", flat=True))
+
+        with CaptureQueriesContext(connection) as queries:
+            refresh_tag_photo_counts(tag_ids)
+
+        self.assertEqual(len(queries.captured_queries), 1)
+        for tag in Tag.objects.filter(pk__in=tag_ids):
+            self.assertEqual(tag.photo_count, 2)
+
+    def test_refreshing_nothing_touches_the_database(self):
+        with CaptureQueriesContext(connection) as queries:
+            refresh_tag_photo_counts([])
+
+        self.assertEqual(len(queries.captured_queries), 0)

--- a/apps/backend/api/tests/photos/test_delete_missing_photos.py
+++ b/apps/backend/api/tests/photos/test_delete_missing_photos.py
@@ -10,6 +10,7 @@ from api import autoalbum
 from api.autoalbum import delete_missing_photos
 from api.models import AlbumDate, AlbumPlace, File, LongRunningJob, Photo
 from api.models.album_thing import AlbumThing
+from api.models.tag import Tag
 from api.tests.utils import create_test_photo, create_test_user
 
 
@@ -299,3 +300,78 @@ class DeleteMissingPhotosBatchingTest(TestCase):
         lrj = LongRunningJob.objects.get(job_id=job_id)
         self.assertEqual(lrj.progress_target, 5)
         self.assertEqual(lrj.progress_current, 5)
+
+
+class DeleteMissingPhotosTagTest(TestCase):
+    """The same photo_count refresh, for the Tag model.
+
+    ``Tag`` arrived after the AlbumThing sweep above (#1930 vs #1848) and was
+    not wired into it, so deleting a library's missing photos left every tag
+    holding them with a stale count -- a tag whose only photo had gone still
+    read "1 photo" over a placeholder tile.
+    """
+
+    def _make_tag(self, owner, photos, name="beach"):
+        tag = Tag.objects.create(name=name, owner=owner)
+        tag.photos.add(*photos)
+        return tag
+
+    def test_photo_count_reflects_remaining_photos_after_deletion(self):
+        user = create_test_user()
+        kept = create_test_photo(owner=user)
+        # Survival of `kept` requires populated `files` and a `main_file`.
+        kept.files.add(kept.main_file)
+        missing = [create_test_photo(owner=user) for _ in range(3)]
+
+        tag = self._make_tag(user, [kept, *missing])
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        tag.refresh_from_db()
+        self.assertEqual(tag.photo_count, 1)
+        self.assertEqual(list(tag.photos.values_list("pk", flat=True)), [kept.pk])
+
+    def test_an_emptied_tag_survives_with_a_zero_count(self):
+        user = create_test_user()
+        missing = [create_test_photo(owner=user) for _ in range(2)]
+        tag = self._make_tag(user, missing)
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        tag.refresh_from_db()
+        self.assertEqual(tag.photo_count, 0)
+        self.assertTrue(Tag.objects.filter(pk=tag.pk).exists())
+
+    def test_tags_are_refreshed_once_not_once_per_photo(self):
+        user = create_test_user()
+        missing = [create_test_photo(owner=user) for _ in range(10)]
+        self._make_tag(user, missing)
+
+        with CaptureQueriesContext(connection) as queries:
+            delete_missing_photos(user, str(uuid.uuid4()))
+
+        tag_updates = [
+            query["sql"]
+            for query in queries.captured_queries
+            if query["sql"].strip().upper().startswith("UPDATE")
+            and "api_tag" in query["sql"]
+            and "photo_count" in query["sql"]
+        ]
+        self.assertEqual(len(tag_updates), 1)
+
+    def test_another_users_tag_is_left_alone(self):
+        user = create_test_user()
+        other_user = create_test_user()
+        missing = create_test_photo(owner=user)
+        theirs = create_test_photo(owner=other_user)
+        theirs.files.add(theirs.main_file)
+
+        mine = self._make_tag(user, [missing])
+        not_mine = self._make_tag(other_user, [theirs])
+
+        delete_missing_photos(user, str(uuid.uuid4()))
+
+        mine.refresh_from_db()
+        not_mine.refresh_from_db()
+        self.assertEqual(mine.photo_count, 0)
+        self.assertEqual(not_mine.photo_count, 1)

--- a/apps/backend/api/views/photos.py
+++ b/apps/backend/api/views/photos.py
@@ -14,6 +14,7 @@ from api.models import AlbumUser, File, Photo, User
 from api.models.photo_stack import PhotoStack
 from api.models.person import Person
 from api.models.photo_caption import PhotoCaption
+from api.models.tag import refresh_tag_photo_counts, tag_ids_for_photos
 from api.permissions import IsOwnerOrReadOnly, IsPhotoOrAlbumSharedTo
 from api.serializers.album_user import AlbumUserListSerializer
 from api.serializers.photos import (
@@ -237,7 +238,12 @@ class SetPhotosDeleted(APIView):
                         f"Reset {len(stack_ids)} photo stacks to pending after restore"
                     )
 
+            # Snapshot the tags before the update, then refresh: a trashed
+            # photo drops out of its tags' counts (and a restored one comes
+            # back), and no signal fires for a plain UPDATE.
+            affected_tag_ids = tag_ids_for_photos(photos_qs)
             count = photos_qs.update(in_trashcan=val_deleted)
+            refresh_tag_photo_counts(affected_tag_ids)
 
             if val_deleted:
                 logger.info(
@@ -280,9 +286,12 @@ class SetPhotosDeleted(APIView):
 
         # Bulk update in one query
         if photos_to_update:
-            Photo.objects.filter(
+            updated_photos = Photo.objects.filter(
                 image_hash__in=photos_to_update, owner=request.user
-            ).update(in_trashcan=val_deleted)
+            )
+            affected_tag_ids = tag_ids_for_photos(updated_photos)
+            updated_photos.update(in_trashcan=val_deleted)
+            refresh_tag_photo_counts(affected_tag_ids)
 
             # If restoring from trash, reset stacks to pending for re-evaluation
             if not val_deleted:
@@ -459,7 +468,11 @@ class SetPhotosHidden(APIView):
             # photos to prevent hiding/unhiding other users' public photos.
             photos_qs = photos_qs.filter(owner=request.user)
 
+            # Hiding takes a photo out of its tags' counts the same way
+            # trashing does; see SetPhotosDeleted above.
+            affected_tag_ids = tag_ids_for_photos(photos_qs)
             count = photos_qs.update(hidden=val_hidden)
+            refresh_tag_photo_counts(affected_tag_ids)
 
             if val_hidden:
                 logger.info(
@@ -501,9 +514,12 @@ class SetPhotosHidden(APIView):
 
         # Bulk update in one query
         if photos_to_update:
-            Photo.objects.filter(
+            updated_photos = Photo.objects.filter(
                 image_hash__in=photos_to_update, owner=request.user
-            ).update(hidden=val_hidden)
+            )
+            affected_tag_ids = tag_ids_for_photos(updated_photos)
+            updated_photos.update(hidden=val_hidden)
+            refresh_tag_photo_counts(affected_tag_ids)
 
         # Handle missing photos
         found_hashes = {photo.image_hash for photo in photos}


### PR DESCRIPTION
`Tag` keeps a denormalised `photo_count`, maintained by an `m2m_changed` receiver on `Tag.photos`. That receiver only fires when a photo is attached to or detached from a tag, so a photo that stops counting some other way leaves the stored number behind. Trash the only photo carrying a tag and the tile still advertises "1 photo" while the album behind it is empty and the cover falls back to a placeholder. I measured all four ways a photo can stop counting — trashed, hidden, `removed`, hard-deleted — and every one of them was stale.

This is the same bug `delete_missing_photos` already fixes for `AlbumThing` in #1848. `Tag` arrived afterwards in #1930 and was never wired into that sweep, whose comment still names only `AlbumThing`.

`refresh_tag_photo_counts()` recomputes a set of tags in a single `UPDATE` with a correlated subquery, rather than a `save()` per tag, because trashing a large selection can touch every tag in the library — the same reasoning behind the batched `AlbumThing` refresh. `tag_ids_for_photos()` snapshots the affected ids, which has to happen *before* a delete, since the through-rows go with the photos. The visibility rule the count is built on now lives in one constant that both the receiver and the refresh read, so the two definitions cannot drift apart unnoticed.

It is wired into the paths that make a visible photo invisible: trash and restore, hide and unhide (both the explicit and the select-all branches), the `delete_missing_photos` sweep, and the duplicate/stack-review resolutions that trash the photos they did not keep. It is deliberately *not* wired into permanent delete or `cleanup_deleted_photos`, because those only touch photos that are already trashed or `removed`, which the count has already excluded — there is nothing to recompute, and adding a call there would only cost a query.

On scale: small libraries are unaffected either way, since the refresh is one statement whether it covers one tag or a thousand. Large ones are the point — the count becomes correct without reintroducing the per-tag `COUNT` storm #1848 removed, and there is a test asserting the refresh stays a single statement however many tags it touches.

Worth stating explicitly because it is a design decision and not an oversight: a tag survives losing its last photo, with a count of zero. You may well want to create a tag before anything carries it, and deleting photos should never silently delete tags. Unlike `AlbumThingViewSet`, the tag list has no `photo_count > 0` filter, so an emptied tag stays visible and can still be renamed or deleted. There are tests pinning that too.

16 new tests, 10 of which fail without the fix — 6 in the trash/hide paths and 4 in the delete sweep, verified by stashing only the call sites so the helper-level tests kept passing. 3175 backend tests overall, with the same set of environmental failures as an unmodified `origin/dev` in the same environment. `ruff check` and `ruff format --check` clean. No migration: the field already exists, this only keeps it honest.

There is a sibling PR adding bulk tag assignment. The two share no files and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
