### PR TITLE
feat: tag a whole selection at once, from the keyboard

### DIFF
--- a/apps/backend/api/tests/metadata/test_tags_api_and_model.py
+++ b/apps/backend/api/tests/metadata/test_tags_api_and_model.py
@@ -1,6 +1,7 @@
 """Tests for the Tag entity: the API, the EXIF keyword import and migration 0130."""
 
 from importlib import import_module
+from unittest.mock import patch
 
 from django.db import connection
 from django.test import TestCase
@@ -841,3 +842,156 @@ class Migration0130BackfillTest(TestCase):
         metadata.refresh_from_db()
         self.assertEqual(metadata.keywords, ["beach"])
         self.assertTrue(Photo.objects.filter(id=photo.id).exists())
+
+
+class TagSelectAllTest(TestCase):
+    """Tagging a whole view without the client enumerating every hash.
+
+    The dialog behind this sends the same ``select_all`` payload the bulk
+    favourite/hide/delete endpoints take, so a 150k-photo selection is one
+    request describing the photoset rather than 150k ids.
+    """
+
+    def setUp(self):
+        self.user = create_test_user()
+        self.other_user = create_test_user()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.photos = create_test_photos(number_of_photos=3, owner=self.user)
+        self.tag = Tag.objects.create(name="beach", owner=self.user)
+
+    def test_select_all_attaches_every_photo_in_the_view(self):
+        response = self.client.post(
+            f"/api/tags/{self.tag.id}/add/",
+            {"select_all": True, "query": {}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["photo_count"], 3)
+        self.assertEqual(self.tag.photos.count(), 3)
+
+    def test_excluded_hashes_are_left_alone(self):
+        self.client.post(
+            f"/api/tags/{self.tag.id}/add/",
+            {
+                "select_all": True,
+                "query": {},
+                "excluded_hashes": [self.photos[0].image_hash],
+            },
+            format="json",
+        )
+
+        attached = set(self.tag.photos.values_list("id", flat=True))
+        self.assertEqual(attached, {self.photos[1].id, self.photos[2].id})
+
+    def test_the_query_narrows_what_gets_tagged(self):
+        video = create_test_photo(owner=self.user, video=True)
+
+        self.client.post(
+            f"/api/tags/{self.tag.id}/add/",
+            {"select_all": True, "query": {"video": True}},
+            format="json",
+        )
+
+        self.assertEqual(list(self.tag.photos.all()), [video])
+
+    def test_select_all_removes_as_well_as_adds(self):
+        self.tag.photos.add(*self.photos)
+
+        response = self.client.post(
+            f"/api/tags/{self.tag.id}/remove/",
+            {
+                "select_all": True,
+                "query": {},
+                "excluded_hashes": [self.photos[0].image_hash],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(self.tag.photos.all()), [self.photos[0]])
+
+    def test_select_all_cannot_reach_another_users_photos(self):
+        # build_photo_queryset drops the owner filter for a public photoset,
+        # so without the view's own owner guard this would hang the tag on
+        # someone else's photo (the shape of issue #1982).
+        theirs = create_test_photo(owner=self.other_user, public=True)
+        mine = create_test_photo(owner=self.user, public=True)
+
+        self.client.post(
+            f"/api/tags/{self.tag.id}/add/",
+            {"select_all": True, "query": {"public": True}},
+            format="json",
+        )
+
+        attached = set(self.tag.photos.values_list("id", flat=True))
+        self.assertIn(mine.id, attached)
+        self.assertNotIn(theirs.id, attached)
+
+    def test_a_selection_larger_than_one_batch_is_fully_linked(self):
+        with patch("api.views.tags.PHOTO_LINK_BATCH_SIZE", 2):
+            self.client.post(
+                f"/api/tags/{self.tag.id}/add/",
+                {"select_all": True, "query": {}},
+                format="json",
+            )
+
+        self.assertEqual(self.tag.photos.count(), 3)
+
+    def test_an_explicit_list_larger_than_one_batch_is_fully_linked(self):
+        with patch("api.views.tags.PHOTO_LINK_BATCH_SIZE", 2):
+            self.client.post(
+                f"/api/tags/{self.tag.id}/add/",
+                {"photos": [str(photo.id) for photo in self.photos]},
+                format="json",
+            )
+
+        self.assertEqual(self.tag.photos.count(), 3)
+
+    def test_a_select_all_over_an_empty_view_is_not_an_error(self):
+        Photo.objects.filter(owner=self.user).delete()
+
+        response = self.client.post(
+            f"/api/tags/{self.tag.id}/add/",
+            {"select_all": True, "query": {}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.tag.photos.count(), 0)
+
+    def test_select_all_does_not_scale_its_query_count_with_the_photoset(self):
+        # One statement per batch, not per photo: the guard that keeps a
+        # library-wide tag from turning into 150k round trips.
+        with CaptureQueriesContext(connection) as queries:
+            self.client.post(
+                f"/api/tags/{self.tag.id}/add/",
+                {"select_all": True, "query": {}},
+                format="json",
+            )
+        for_three = len(queries.captured_queries)
+
+        create_test_photos(number_of_photos=5, owner=self.user)
+        other_tag = Tag.objects.create(name="holiday", owner=self.user)
+        with CaptureQueriesContext(connection) as queries:
+            self.client.post(
+                f"/api/tags/{other_tag.id}/add/",
+                {"select_all": True, "query": {}},
+                format="json",
+            )
+        for_eight = len(queries.captured_queries)
+
+        self.assertEqual(for_three, for_eight)
+
+    def test_another_users_tag_stays_out_of_reach_in_select_all_mode(self):
+        theirs = Tag.objects.create(name="theirs", owner=self.other_user)
+
+        response = self.client.post(
+            f"/api/tags/{theirs.id}/add/",
+            {"select_all": True, "query": {}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(theirs.photos.count(), 0)

--- a/apps/backend/api/views/tags.py
+++ b/apps/backend/api/views/tags.py
@@ -16,7 +16,13 @@ from api.serializers.tag import (
 )
 from api.views.albums import _with_photo_summary_relations
 from api.views.pagination import StandardResultsSetPagination
+from api.views.photo_filters import build_photo_queryset
 from api.views.photos import _get_photo_filter_kwargs
+
+# A select-all tag edit can cover a whole library, so the links are written in
+# batches instead of one statement over every row. Small selections still take
+# a single pass, so nothing changes for a handful of photos.
+PHOTO_LINK_BATCH_SIZE = 2000
 
 
 class TagViewSet(viewsets.ModelViewSet):
@@ -92,12 +98,20 @@ class TagViewSet(viewsets.ModelViewSet):
         serializer.save(owner=self.request.user)
 
     def _resolve_photos(self, request):
-        """Resolve the request's photo ids/hashes to photos the user owns.
+        """Resolve the request's photos to the ones the user owns.
+
+        Either an explicit list of ids/hashes, or ``select_all=True`` plus the
+        ``query`` describing the photoset on screen -- the same payload the
+        bulk favourite/hide/delete endpoints take, so tagging a whole filtered
+        view does not depend on the client enumerating every hash first.
 
         An id the requester does not own is a 404 rather than a silent no-op:
         answering 200 for an empty queryset had the UI report a save that never
         happened.
         """
+        if request.data.get("select_all"):
+            return self._select_all_photos(request)
+
         identifiers = request.data.get("photos")
         if not isinstance(identifiers, list) or not identifiers:
             return None
@@ -123,6 +137,47 @@ class TagViewSet(viewsets.ModelViewSet):
 
         return photos
 
+    def _select_all_photos(self, request):
+        """The photos behind a ``select_all`` payload, as a lazy queryset."""
+        query = request.data.get("query")
+        excluded_hashes = request.data.get("excluded_hashes") or []
+
+        photos = build_photo_queryset(
+            request.user, query if isinstance(query, dict) else {}
+        )
+        # build_photo_queryset does not scope to the requester when
+        # query.public is set, so bind the write target to the requester's own
+        # photos -- the same guard the bulk photo endpoints carry (issue
+        # #1982). Without it a public photoset would let one account hang its
+        # tags on another account's photos.
+        photos = photos.filter(owner=request.user)
+        if excluded_hashes:
+            photos = photos.exclude(image_hash__in=excluded_hashes)
+        return photos
+
+    @staticmethod
+    def _link_photos(relation_method, photos):
+        """Add or remove ``photos`` on a tag's m2m, a batch at a time.
+
+        Takes primary keys rather than instances so a select-all edit never
+        loads the whole photoset into memory.
+        """
+        if isinstance(photos, list):
+            pks = [photo.pk for photo in photos]
+        else:
+            pks = photos.values_list("pk", flat=True).iterator(
+                chunk_size=PHOTO_LINK_BATCH_SIZE
+            )
+
+        batch = []
+        for pk in pks:
+            batch.append(pk)
+            if len(batch) == PHOTO_LINK_BATCH_SIZE:
+                relation_method(*batch)
+                batch = []
+        if batch:
+            relation_method(*batch)
+
     @extend_schema(
         parameters=[OpenApiParameter("photo", OpenApiTypes.STR)],
         description=(
@@ -140,7 +195,11 @@ class TagViewSet(viewsets.ModelViewSet):
         return Response({"results": serializer.data})
 
     @extend_schema(
-        description="Attach photos to this tag.",
+        description=(
+            "Attach photos to this tag: either an explicit `photos` list of "
+            "ids/image hashes, or `select_all: true` with the `query` "
+            "describing the photoset on screen and optional `excluded_hashes`."
+        ),
         responses={200: TagSerializer},
     )
     @action(detail=True, methods=["post"], url_path="add")
@@ -152,11 +211,14 @@ class TagViewSet(viewsets.ModelViewSet):
                 {"error": "No photos provided"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        tag.photos.add(*photos)
+        self._link_photos(tag.photos.add, photos)
         return Response(TagSerializer(tag).data)
 
     @extend_schema(
-        description="Detach photos from this tag.",
+        description=(
+            "Detach photos from this tag. Takes the same explicit `photos` "
+            "list or `select_all` payload as the add action."
+        ),
         responses={200: TagSerializer},
     )
     @action(detail=True, methods=["post"], url_path="remove")
@@ -168,7 +230,7 @@ class TagViewSet(viewsets.ModelViewSet):
                 {"error": "No photos provided"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        tag.photos.remove(*photos)
+        self._link_photos(tag.photos.remove, photos)
         return Response(TagSerializer(tag).data)
 
     @extend_schema(

--- a/apps/docs/docs/user-guide/albums.md
+++ b/apps/docs/docs/user-guide/albums.md
@@ -139,7 +139,7 @@ Anywhere you can select photos — the timeline, a search result, a person, plac
 
 1. Select the photos and videos you want to tag.
 2. Press **`t`**, or open the **plus menu** (＋) and click **Tags**.
-3. Type the tags, separating several with a comma. Tags you already use complete as you type; anything new is created for you.
+3. Type the tags, separating several with a comma. Suggestions narrow as you type — tags that *begin* with what you typed come first, so a letter or two is usually enough — and anything new is created for you.
 4. Click **Add tags** (or press Enter on an empty box).
 
 Every tag in the box is applied to every photo in the selection. Tagging is additive — it never removes a tag a photo already has.

--- a/apps/docs/docs/user-guide/albums.md
+++ b/apps/docs/docs/user-guide/albums.md
@@ -26,6 +26,9 @@ Unlike People, Places and Things albums, event albums are **not** created during
 ### Places Albums
 Automatically generated albums based on the GPS location data in your photos.
 
+### Tag Albums
+Albums for **your own tags** — the labels you type yourself, as opposed to the objects the tagging model detects. Every tag gets an album, and the **Tags** section of the Albums page lists them with a photo count. Tags also come in from your files: keywords stored in a photo's XMP `Subject` or IPTC `Keywords` (including `.xmp` sidecars, so tags applied in Lightroom or digiKam are picked up) become tags during a scan. See [Tagging photos](#tagging-photos) below for how to apply them, and [Search](./search.md) for finding photos by tag.
+
 ### Things Albums
 Automatically generated albums based on detected objects and scenes in your photos. Things Albums are filtered by the currently active **Tagging Model** (configurable in Site Settings), so only tags from the selected model are shown. Switching models does not delete your existing tags, but it also does not create tags for the newly selected model — until tags exist for that model, the Things section will look empty. To generate them, run a full **Rescan** from **Settings → Library** (in the *Scan Library* section, open the dropdown next to **Scan** and choose **Rescan**), which retags your existing photos. Albums created from `#hashtags` you typed into photo captions are always shown, regardless of the active model.
 
@@ -119,6 +122,53 @@ Once an album is public, it appears under **Sharing → Links**, where you can c
 Default privacy settings for new public links can be configured in **Settings → Public Sharing Defaults**.
 
 Public albums are accessible at `/public/s/{slug}` and include a lightbox viewer with the same navigation experience as the main app.
+
+---
+
+## Tagging photos
+
+Tags are yours to type: a place name, a project, "to print", whatever you sort by. A photo can carry any number of them.
+
+### Tagging a selection
+
+:::note
+Tagging several photos at once is not in a released image yet. It is available on the `dev` branch and will appear in the next release.
+:::
+
+Anywhere you can select photos — the timeline, a search result, a person, place, thing or user album, or a folder — you can tag the whole selection at once:
+
+1. Select the photos and videos you want to tag.
+2. Press **`t`**, or open the **plus menu** (＋) and click **Tags**.
+3. Type the tags, separating several with a comma. Tags you already use complete as you type; anything new is created for you.
+4. Click **Add tags** (or press Enter on an empty box).
+
+Every tag in the box is applied to every photo in the selection. Tagging is additive — it never removes a tag a photo already has.
+
+**Select all** works too: with the whole view selected, the tags apply to everything the current view holds, whatever its filters (including the Photos / Videos selector), minus any photo you unchecked. That is one request for the whole library rather than one per photo, so it stays quick on a large one.
+
+:::note
+`t` is used instead of Ctrl+T because browsers reserve Ctrl+T for opening a new tab and a web page cannot intercept it.
+:::
+
+### Tagging one photo
+
+Open a photo and use the **Tags** section of the [sidebar](./viewing-photos.md) — the pencil button opens the same comma-separated editor, and here it both adds and removes: whatever you leave in the box is what the photo ends up with. Click a tag badge to jump to that tag's album.
+
+### Renaming, merging and deleting tags
+
+On the Albums page, open **Tags → View all**. The three-dot menu on any tag offers:
+
+- **Rename** — the tag keeps its photos.
+- **Merge** — pick another tag to fold into this one; its photos move over and it is deleted.
+- **Delete** — removes the tag. Your photos are untouched.
+
+:::note
+Tags are per user: two accounts can each have a tag called `holiday` without seeing each other's.
+:::
+
+:::caution
+A tag you add in LibrePhotos is not written back into the image file yet. A tag that *came* from a file's keywords stays in that file, but new tags live only in LibrePhotos' database.
+:::
 
 ---
 

--- a/apps/docs/docs/user-guide/albums.md
+++ b/apps/docs/docs/user-guide/albums.md
@@ -166,6 +166,8 @@ On the Albums page, open **Tags → View all**. The three-dot menu on any tag of
 Tags are per user: two accounts can each have a tag called `holiday` without seeing each other's.
 :::
 
+A tag outlives its photos. Trashing, hiding or deleting the last photo that carried a tag leaves the tag in place: it stays in the Tags list with a placeholder tile so you can still rename or delete it, and its own page tells you it is empty. That is deliberate — you may well want to create a tag before anything carries it, and deleting photos should never silently delete tags.
+
 :::caution
 A tag you add in LibrePhotos is not written back into the image file yet. A tag that *came* from a file's keywords stays in that file, but new tags live only in LibrePhotos' database.
 :::

--- a/apps/docs/docs/user-guide/viewing-photos.md
+++ b/apps/docs/docs/user-guide/viewing-photos.md
@@ -131,7 +131,7 @@ Tags from each model are stored independently, but the lightbox only shows tags 
 
 ### Tags
 
-Your own tags for the photo, shown as teal badges. This section always appears in the sidebar when you are signed in, showing **No tags** when none are set. Click the pencil button to open an editor where you can add or remove tags — separate entries with a comma, and existing tags are offered as autocomplete suggestions — then use the check to save or the X to cancel. Click a tag badge to open that tag's album.
+Your own tags for the photo, shown as teal badges. This section always appears in the sidebar when you are signed in, showing **No tags** when none are set. Click the pencil button to open an editor where you can add or remove tags — separate entries with a comma, and existing tags are offered as autocomplete suggestions, the ones beginning with what you typed first — then use the check to save or the X to cancel. Click a tag badge to open that tag's album.
 
 These are not the same as the automatic **Tags** list SigLIP 2 adds under the caption: those come from the tagging model and are not editable here.
 

--- a/apps/docs/docs/user-guide/viewing-photos.md
+++ b/apps/docs/docs/user-guide/viewing-photos.md
@@ -133,7 +133,7 @@ Tags from each model are stored independently, but the lightbox only shows tags 
 
 Your own tags for the photo, shown as teal badges. This section always appears in the sidebar when you are signed in, showing **No tags** when none are set. Click the pencil button to open an editor where you can add or remove tags — separate entries with a comma, and existing tags are offered as autocomplete suggestions, the ones beginning with what you typed first — then use the check to save or the X to cancel. Click a tag badge to open that tag's album.
 
-These are not the same as the automatic **Tags** list SigLIP 2 adds under the caption: those come from the tagging model and are not editable here.
+These are not the same as the **Auto tags** list SigLIP 2 adds under the caption: those come from the tagging model and are not editable here.
 
 To tag many photos in one go, select them in the grid and press **`t`** instead — see [Tagging photos](./albums.md#tagging-photos).
 

--- a/apps/docs/docs/user-guide/viewing-photos.md
+++ b/apps/docs/docs/user-guide/viewing-photos.md
@@ -135,6 +135,8 @@ Your own tags for the photo, shown as teal badges. This section always appears i
 
 These are not the same as the automatic **Tags** list SigLIP 2 adds under the caption: those come from the tagging model and are not editable here.
 
+To tag many photos in one go, select them in the grid and press **`t`** instead — see [Tagging photos](./albums.md#tagging-photos).
+
 Tags are not shown on public or shared album pages.
 
 ### Keywords

--- a/apps/frontend/src/api_client/tags/hooks/index.ts
+++ b/apps/frontend/src/api_client/tags/hooks/index.ts
@@ -4,4 +4,5 @@ export * from "./useCreateTagMutation";
 export * from "./useRenameTagMutation";
 export * from "./useDeleteTagMutation";
 export * from "./useTagPhotosMutations";
+export * from "./useTagPhotosByNameMutation";
 export * from "./useMergeTagsMutation";

--- a/apps/frontend/src/api_client/tags/hooks/useTagPhotosByNameMutation.ts
+++ b/apps/frontend/src/api_client/tags/hooks/useTagPhotosByNameMutation.ts
@@ -1,0 +1,58 @@
+import { useMutation } from "@tanstack/react-query";
+import { notification } from "../../../service/notifications";
+import { parseWithNotification } from "../../../util/zodUtils";
+import { fetchClient, queryClient } from "../../api";
+import { Tag, TagList, TagPhotosByNameParams } from "../types";
+import { TagAlbumQueryKeys } from "./useFetchTagAlbumQuery";
+import { TagsQueryKeys } from "./useFetchTagsQuery";
+
+/** Resolve a typed name to its tag, creating the tag when it is new.
+ *
+ * POST /tags/ answers with the existing tag when the account already owns the
+ * name, so this needs no separate existence check -- which matters because the
+ * cached tag list is only the first page.
+ */
+async function resolveTag(name: string, cached: TagList | undefined) {
+  const known = cached?.find(tag => tag.name === name);
+  if (known) {
+    return { tag: known, created: false };
+  }
+  const response = await fetchClient.post(`/tags/`, { name });
+  return { tag: parseWithNotification(Tag, response, "Failed to parse tag"), created: true };
+}
+
+/**
+ * Attach several tags, given by name, to a whole selection in one go.
+ *
+ * Deliberately not built out of `useCreateTagMutation` +
+ * `useAddPhotosToTagMutation`: those each raise their own toast, so tagging a
+ * selection with three new tags would stack up six of them. Here the whole
+ * edit reports once, and either all of it lands or the caller hears about it.
+ */
+export const useTagPhotosByNameMutation = () =>
+  useMutation({
+    mutationFn: async ({ names, photos, selectAll, photoCount }: TagPhotosByNameParams) => {
+      const cached = queryClient.getQueryData<TagList>([...TagsQueryKeys]);
+      const payload = selectAll ?? { photos: photos ?? [] };
+
+      const applied: string[] = [];
+      // Sequential on purpose: two names that are both new and both normalise
+      // to the same tag would otherwise race on the unique (name, owner)
+      // constraint, and a library-wide add is heavy enough server-side that
+      // firing them in parallel only moves the queue.
+      for (const name of names) {
+        // eslint-disable-next-line no-await-in-loop
+        const { tag } = await resolveTag(name, cached);
+        // eslint-disable-next-line no-await-in-loop
+        await fetchClient.post(`/tags/${tag.id}/add/`, payload);
+        applied.push(tag.name);
+      }
+
+      notification.taggedPhotos(applied, photoCount);
+      return applied;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...TagsQueryKeys] });
+      queryClient.invalidateQueries({ queryKey: [...TagAlbumQueryKeys] });
+    },
+  });

--- a/apps/frontend/src/api_client/tags/types.ts
+++ b/apps/frontend/src/api_client/tags/types.ts
@@ -60,3 +60,20 @@ export type MergeTagsParams = {
   sourceId: number;
   sourceName: string;
 };
+
+/** A select-all payload: the query behind the photoset, minus what was unchecked. */
+export type TagSelectAllFields = {
+  select_all: true;
+  query: Record<string, unknown>;
+  excluded_hashes: string[];
+};
+
+export type TagPhotosByNameParams = {
+  /** Tag names as typed, comma-separated entry already split. */
+  names: string[];
+  /** Explicit photo ids or image hashes. Ignored when selectAll is given. */
+  photos?: string[];
+  selectAll?: TagSelectAllFields;
+  /** How many photos the caller believes it is tagging, for the toast. */
+  photoCount: number;
+};

--- a/apps/frontend/src/components/lightbox/Description.tsx
+++ b/apps/frontend/src/components/lightbox/Description.tsx
@@ -180,7 +180,9 @@ export function Description(props: Props) {
           <Stack>
             <Group>
               <Tags />
-              <Title order={4}>{t("lightbox.sidebar.tags", "Tags")}</Title>
+              {/* The tagging model's own output, not the user's tags -- both
+                  used to render as "Tags" in the same sidebar. */}
+              <Title order={4}>{t("lightbox.sidebar.autotags")}</Title>
             </Group>
             <Group>
               {photoDetail.captions_json.siglip2.tags.map((tag: string) => (

--- a/apps/frontend/src/components/lightbox/TagsSection.tsx
+++ b/apps/frontend/src/components/lightbox/TagsSection.tsx
@@ -12,6 +12,7 @@ import {
   useRemovePhotosFromTagMutation,
 } from "../../api_client/tags/hooks";
 import { notification } from "../../service/notifications";
+import { TAG_SUGGESTION_LIMIT, tagOptionsFilter } from "../../util/tagOptionsFilter";
 
 interface TagsSectionProps {
   photoDetail: PhotoType;
@@ -101,6 +102,8 @@ export function TagsSection({ photoDetail }: TagsSectionProps) {
           value={draftTags}
           onChange={setDraftTags}
           data={(allTags ?? []).map(tag => tag.name)}
+          filter={tagOptionsFilter}
+          limit={TAG_SUGGESTION_LIMIT}
           placeholder={t("lightbox.sidebar.addTag")}
           splitChars={[","]}
           clearable

--- a/apps/frontend/src/components/modals/ModalTagEdit.module.css
+++ b/apps/frontend/src/components/modals/ModalTagEdit.module.css
@@ -1,0 +1,8 @@
+.tile {
+  object-fit: cover;
+  width: 40px;
+  height: 40px;
+  aspect-ratio: 1;
+  border-radius: 4px;
+  flex-shrink: 0;
+}

--- a/apps/frontend/src/components/modals/ModalTagEdit.test.tsx
+++ b/apps/frontend/src/components/modals/ModalTagEdit.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * The bulk tag dialog: type comma-separated names, hit Add, and every selected
+ * photo gets every tag.
+ *
+ * What is worth guarding here is the request shape, because the dialog is the
+ * only place that fans one typed line out over several endpoints:
+ *   - a name the account already owns must not be re-created,
+ *   - a new name is POSTed to /tags/ once and then used by id,
+ *   - each name gets exactly one /tags/<id>/add/ call carrying the whole
+ *     selection, not one call per photo,
+ *   - in select-all mode the selection is the query, and `selectedImages`
+ *     holds the EXCLUDED photos instead.
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../i18n";
+import { ModalTagEdit } from "./ModalTagEdit";
+
+const stubs = vi.hoisted(() => ({
+  post: vi.fn(),
+  tags: [
+    { id: 7, name: "beach", photo_count: 2, cover_photos: [] },
+    { id: 8, name: "holiday", photo_count: 5, cover_photos: [] },
+  ],
+  taggedPhotos: vi.fn(),
+}));
+
+vi.mock("../../api_client/apiClient", () => ({ serverAddress: "" }));
+vi.mock("../../service/notifications", () => ({
+  notification: new Proxy(
+    {},
+    {
+      get: (_target, name) => (name === "taggedPhotos" ? stubs.taggedPhotos : () => {}),
+    }
+  ),
+}));
+vi.mock("../../api_client/tags/hooks/useFetchTagsQuery", () => ({
+  TagsQueryKeys: ["tags"],
+  useFetchTagsQuery: () => ({ data: stubs.tags }),
+}));
+vi.mock("../../api_client/api", () => ({
+  fetchClient: { post: stubs.post },
+  queryClient: {
+    invalidateQueries: () => {},
+    // The cached list is the shortcut past a create request.
+    getQueryData: () => stubs.tags,
+  },
+}));
+
+beforeAll(async () => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore - jsdom has no ResizeObserver, the modal needs it
+  globalThis.ResizeObserver = class {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  };
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage("en");
+});
+
+beforeEach(() => {
+  stubs.post.mockReset();
+  stubs.post.mockResolvedValue({ id: 99, name: "new", photo_count: 0 });
+  stubs.taggedPhotos.mockReset();
+});
+
+const selection = [
+  { id: "photo-1", image_hash: "a".repeat(32), type: "photo" },
+  { id: "photo-2", image_hash: "b".repeat(32), type: "video" },
+];
+
+/** React tracks the previous value on the node itself, so plain assignment is swallowed. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** TagsInput renders a hidden input for the committed value; the first one is the search box. */
+function tagInput(): HTMLInputElement {
+  return document.querySelector("input") as HTMLInputElement;
+}
+
+function pressKey(key: string) {
+  tagInput().dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+function addButton(): HTMLButtonElement {
+  return Array.from(document.querySelectorAll("button")).find(
+    button => button.textContent === "Add tags"
+  ) as HTMLButtonElement;
+}
+
+type RenderOptions = {
+  selectAllMode?: boolean;
+  selectAllQuery?: Record<string, unknown>;
+  totalCount?: number;
+  selectedImages?: typeof selection;
+};
+
+async function renderModal(options: RenderOptions = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let closed = false;
+
+  function Harness() {
+    const [isOpen, setIsOpen] = useState(true);
+    return (
+      <ModalTagEdit
+        isOpen={isOpen}
+        onRequestClose={() => {
+          closed = true;
+          setIsOpen(false);
+        }}
+        selectedImages={options.selectedImages ?? selection}
+        selectAllMode={options.selectAllMode}
+        selectAllQuery={options.selectAllQuery as never}
+        totalCount={options.totalCount}
+      />
+    );
+  }
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { mutations: { retry: false } } })}>
+        <MantineProvider>
+          <Harness />
+        </MantineProvider>
+      </QueryClientProvider>
+    );
+  });
+
+  return {
+    /**
+     * Type a line the way the user does. TagsInput turns text into a pill on
+     * the keydown of a split char, so a comma has to arrive as a keystroke --
+     * assigning the whole line at once would leave it as one long tag.
+     */
+    async type(line: string) {
+      const segments = line.split(",");
+      for (let index = 0; index < segments.length; index += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          setInputValue(tagInput(), segments[index]);
+        });
+        if (index < segments.length - 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await act(async () => {
+            pressKey(",");
+          });
+        }
+      }
+    },
+    async pressEnter() {
+      await act(async () => {
+        pressKey("Enter");
+      });
+    },
+    async submit() {
+      await act(async () => {
+        addButton().click();
+      });
+    },
+    wasClosed: () => closed,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("ModalTagEdit", () => {
+  it("reuses a tag the account already owns instead of creating it again", async () => {
+    const modal = await renderModal();
+    await modal.type("beach,");
+    await modal.submit();
+
+    expect(stubs.post).toHaveBeenCalledTimes(1);
+    expect(stubs.post).toHaveBeenCalledWith("/tags/7/add/", {
+      photos: ["photo-1", "photo-2"],
+    });
+    await modal.unmount();
+  });
+
+  it("creates a tag it has never seen, then tags with the id it got back", async () => {
+    stubs.post.mockResolvedValueOnce({ id: 42, name: "sunset", photo_count: 0 });
+
+    const modal = await renderModal();
+    await modal.type("sunset,");
+    await modal.submit();
+
+    expect(stubs.post.mock.calls[0]).toEqual(["/tags/", { name: "sunset" }]);
+    expect(stubs.post.mock.calls[1]).toEqual(["/tags/42/add/", { photos: ["photo-1", "photo-2"] }]);
+    await modal.unmount();
+  });
+
+  it("splits a comma-separated line into one add per tag, each with the whole selection", async () => {
+    const modal = await renderModal();
+    await modal.type("beach, holiday,");
+    await modal.submit();
+
+    expect(stubs.post.mock.calls).toEqual([
+      ["/tags/7/add/", { photos: ["photo-1", "photo-2"] }],
+      ["/tags/8/add/", { photos: ["photo-1", "photo-2"] }],
+    ]);
+    await modal.unmount();
+  });
+
+  it("trims and dedupes what was typed", async () => {
+    const modal = await renderModal();
+    await modal.type("  beach , beach,");
+    await modal.submit();
+
+    expect(stubs.post.mock.calls).toEqual([["/tags/7/add/", { photos: ["photo-1", "photo-2"] }]]);
+    await modal.unmount();
+  });
+
+  it("sends the select-all payload instead of a photo list, with the unchecked photos excluded", async () => {
+    const modal = await renderModal({
+      selectAllMode: true,
+      selectAllQuery: { person: 3 },
+      totalCount: 150000,
+    });
+    await modal.type("beach,");
+    await modal.submit();
+
+    expect(stubs.post).toHaveBeenCalledWith("/tags/7/add/", {
+      select_all: true,
+      query: { person: 3 },
+      excluded_hashes: ["a".repeat(32), "b".repeat(32)],
+    });
+    await modal.unmount();
+  });
+
+  it("reports the edit once, however many tags it applied", async () => {
+    const modal = await renderModal();
+    await modal.type("beach, holiday,");
+    await modal.submit();
+
+    expect(stubs.taggedPhotos).toHaveBeenCalledTimes(1);
+    expect(stubs.taggedPhotos).toHaveBeenCalledWith(["beach", "holiday"], 2);
+    await modal.unmount();
+  });
+
+  it("keeps the dialog open when the save fails, so the typing is not lost", async () => {
+    stubs.post.mockRejectedValueOnce(new Error("boom"));
+
+    const modal = await renderModal();
+    await modal.type("beach,");
+    await modal.submit();
+
+    expect(modal.wasClosed()).toBe(false);
+    expect(stubs.taggedPhotos).not.toHaveBeenCalled();
+    await modal.unmount();
+  });
+
+  it("takes a tag that was typed but never committed to a pill", async () => {
+    // The most common case of all: one tag, no comma, straight to the button.
+    const modal = await renderModal();
+    await modal.type("beach");
+    await modal.submit();
+
+    expect(stubs.post.mock.calls).toEqual([["/tags/7/add/", { photos: ["photo-1", "photo-2"] }]]);
+    await modal.unmount();
+  });
+
+  it("submits on Enter once the box is empty, and not while a name is still being typed", async () => {
+    const modal = await renderModal();
+    await modal.type("beach");
+    // This Enter is TagsInput committing the pill, not a submit.
+    await modal.pressEnter();
+    expect(stubs.post).not.toHaveBeenCalled();
+
+    await modal.pressEnter();
+    expect(stubs.post.mock.calls).toEqual([["/tags/7/add/", { photos: ["photo-1", "photo-2"] }]]);
+    await modal.unmount();
+  });
+
+  it("will not fire with nothing typed", async () => {
+    const modal = await renderModal();
+    await modal.submit();
+
+    expect(stubs.post).not.toHaveBeenCalled();
+    await modal.unmount();
+  });
+});

--- a/apps/frontend/src/components/modals/ModalTagEdit.tsx
+++ b/apps/frontend/src/components/modals/ModalTagEdit.tsx
@@ -1,0 +1,139 @@
+import { Badge, Button, Divider, Group, Modal, Stack, TagsInput, Text, Title } from "@mantine/core";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { BulkPhotoQuery } from "../../api_client/photos/types";
+import { useFetchTagsQuery, useTagPhotosByNameMutation } from "../../api_client/tags/hooks";
+import { notification } from "../../service/notifications";
+import { Tile } from "../Tile";
+import classes from "./ModalTagEdit.module.css";
+
+/** How many thumbnails of the selection to show before falling back to a count. */
+const MAX_PREVIEW_TILES = 12;
+
+type Props = Readonly<{
+  isOpen: boolean;
+  onRequestClose: () => void;
+  /** In select-all mode this holds the EXCLUDED items, not the selection. */
+  selectedImages: any[];
+  selectAllMode?: boolean;
+  selectAllQuery?: BulkPhotoQuery;
+  totalCount?: number;
+}>;
+
+export function ModalTagEdit(props: Props) {
+  const { isOpen, onRequestClose, selectedImages, selectAllMode = false, selectAllQuery, totalCount } = props;
+  const { t } = useTranslation();
+  const [draftTags, setDraftTags] = useState<string[]>([]);
+  // What is typed but not yet committed to a pill. TagsInput only turns text
+  // into a pill on a comma, Enter or a blur, so without this a user who types
+  // one tag and reaches straight for the button finds it disabled.
+  const [pendingTag, setPendingTag] = useState("");
+
+  const { data: allTags } = useFetchTagsQuery();
+  const { mutateAsync: tagPhotos, isPending } = useTagPhotosByNameMutation();
+
+  const excludedHashes = selectAllMode ? selectedImages.map(image => image.image_hash) : [];
+  const photoCount = selectAllMode ? Math.max(0, (totalCount ?? 0) - selectedImages.length) : selectedImages.length;
+
+  // Trimmed, deduped, and empties dropped -- "beach, , beach," is one tag.
+  const names = Array.from(
+    new Set([...draftTags, pendingTag].map(name => name.trim()).filter(name => name.length > 0))
+  );
+
+  function close() {
+    onRequestClose();
+    setDraftTags([]);
+    setPendingTag("");
+  }
+
+  async function handleSubmit() {
+    if (names.length === 0) {
+      return;
+    }
+
+    try {
+      await tagPhotos({
+        names,
+        photos: selectAllMode ? undefined : selectedImages.map(image => image.id),
+        selectAll: selectAllMode
+          ? { select_all: true, query: selectAllQuery ?? {}, excluded_hashes: excludedHashes }
+          : undefined,
+        photoCount,
+      });
+    } catch {
+      // Keep the dialog open so the typed tags are not lost, and say so: a
+      // spinner that just stops looks exactly like a successful save.
+      notification.requestFailed(t("modaltag.title"), t("modaltag.savefailed"));
+      return;
+    }
+
+    close();
+  }
+
+  return (
+    <Modal zIndex={1500} opened={isOpen} title={<Title order={3}>{t("modaltag.title")}</Title>} onClose={close}>
+      <Stack>
+        <Text c="dimmed">{t("modaltag.selectedimages", { count: photoCount })}</Text>
+
+        {selectAllMode ? (
+          <Badge color="blue" size="lg" variant="light">
+            {t("selectionbar.all")} {photoCount} {t("selectionbar.selected")}
+            {excludedHashes.length > 0 && ` (${excludedHashes.length} ${t("selectionbar.excluded")})`}
+          </Badge>
+        ) : (
+          <Group gap="xs">
+            {selectedImages.slice(0, MAX_PREVIEW_TILES).map(image => (
+              <Tile
+                key={`tagsel-${image.id}`}
+                className={classes.tile}
+                height={40}
+                width={40}
+                image_hash={image.image_hash}
+                video={image.type === "video"}
+              />
+            ))}
+            {selectedImages.length > MAX_PREVIEW_TILES && (
+              <Text size="sm" c="dimmed">
+                {t("modaltag.andmore", { count: selectedImages.length - MAX_PREVIEW_TILES })}
+              </Text>
+            )}
+          </Group>
+        )}
+
+        <Divider />
+
+        <TagsInput
+          data-autofocus
+          label={t("modaltag.label")}
+          description={t("modaltag.hint")}
+          value={draftTags}
+          onChange={setDraftTags}
+          searchValue={pendingTag}
+          onSearchChange={setPendingTag}
+          data={(allTags ?? []).map(tag => tag.name)}
+          placeholder={t("modaltag.placeholder")}
+          splitChars={[","]}
+          clearable
+          // Enter already commits the tag being typed; only submit once the
+          // input is empty, so a trailing Enter does not fire the dialog while
+          // the user is still listing names.
+          onKeyDown={event => {
+            if (event.key === "Enter" && pendingTag.trim().length === 0 && draftTags.length > 0) {
+              event.preventDefault();
+              handleSubmit();
+            }
+          }}
+        />
+
+        <Group justify="flex-end">
+          <Button variant="default" onClick={close} disabled={isPending}>
+            {t("cancel")}
+          </Button>
+          <Button onClick={handleSubmit} loading={isPending} disabled={names.length === 0 || photoCount === 0}>
+            {t("modaltag.add")}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/apps/frontend/src/components/modals/ModalTagEdit.tsx
+++ b/apps/frontend/src/components/modals/ModalTagEdit.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { BulkPhotoQuery } from "../../api_client/photos/types";
 import { useFetchTagsQuery, useTagPhotosByNameMutation } from "../../api_client/tags/hooks";
 import { notification } from "../../service/notifications";
+import { TAG_SUGGESTION_LIMIT, tagOptionsFilter } from "../../util/tagOptionsFilter";
 import { Tile } from "../Tile";
 import classes from "./ModalTagEdit.module.css";
 
@@ -111,6 +112,8 @@ export function ModalTagEdit(props: Props) {
           searchValue={pendingTag}
           onSearchChange={setPendingTag}
           data={(allTags ?? []).map(tag => tag.name)}
+          filter={tagOptionsFilter}
+          limit={TAG_SUGGESTION_LIMIT}
           placeholder={t("modaltag.placeholder")}
           splitChars={[","]}
           clearable

--- a/apps/frontend/src/components/photolist/PhotoListView.tsx
+++ b/apps/frontend/src/components/photolist/PhotoListView.tsx
@@ -13,7 +13,7 @@ import {
   useComputedColorScheme,
   useMantineTheme,
 } from "@mantine/core";
-import { useDebouncedCallback, useViewportSize } from "@mantine/hooks";
+import { useDebouncedCallback, useHotkeys, useViewportSize } from "@mantine/hooks";
 import { IconLink, IconSettings } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "@tanstack/react-router";
@@ -36,6 +36,7 @@ import { EmptyState } from "../common/EmptyState";
 import { Lightbox } from "../lightbox/Lightbox";
 import { AlbumCoverPickerModal } from "../modals/AlbumCoverPickerModal";
 import { AlbumEditModal } from "../modals/AlbumEdit/AlbumEditModal";
+import { ModalTagEdit } from "../modals/ModalTagEdit";
 import Pig from "../react-pig";
 import type { PigHandle } from "../react-pig";
 import { ScrollScrubber } from "../scrollscrubber/ScrollScrubber";
@@ -131,6 +132,7 @@ function PhotoListViewComponent({
   const { height } = useViewportSize();
   const pigRef = useRef<PigHandle>(null);
   const [modalAddToAlbumOpen, setModalAddToAlbumOpen] = useState(false);
+  const [modalTagOpen, setModalTagOpen] = useState(false);
   const [modalSharePhotosOpen, setModalSharePhotosOpen] = useState(false);
   const [modalAlbumShareOpen, setModalAlbumShareOpen] = useState(false);
   const [modalCoverPickerOpen, setModalCoverPickerOpen] = useState(false);
@@ -316,6 +318,23 @@ function PhotoListViewComponent({
     selectionStateRef.current = updatedState;
     setSelectionState(updatedState);
   };
+
+  // Tag the selection from the keyboard, the way Shotwell's Ctrl+T does. A
+  // bare "t" rather than a modifier because browsers reserve Ctrl+T for a new
+  // tab and a page cannot take it back -- and because the lightbox already
+  // binds bare f/h/p/i/z for the same kind of action. Mantine's useHotkeys
+  // ignores INPUT/TEXTAREA/SELECT, so this never fires from the search box.
+  useHotkeys([
+    [
+      "t",
+      () => {
+        const { selectMode, selectAllMode, selectedItems } = selectionStateRef.current;
+        if (!isPublic && (selectAllMode || (selectMode && selectedItems.length > 0))) {
+          setModalTagOpen(true);
+        }
+      },
+    ],
+  ]);
 
   // Clear any active selection when the media-type filter changes: the set of
   // photos on screen changes, so a carried-over selection (and its "N selected"
@@ -688,6 +707,7 @@ function PhotoListViewComponent({
                     onSharePhotos={() => setModalSharePhotosOpen(true)}
                     onShareAlbum={() => setModalAlbumShareOpen(true)}
                     onAddToAlbum={() => setModalAddToAlbumOpen(true)}
+                    onAddTags={() => setModalTagOpen(true)}
                     updateSelectionState={updateSelectionState}
                   />
                 )}
@@ -781,6 +801,24 @@ function PhotoListViewComponent({
           isOpen={modalAddToAlbumOpen}
           onRequestClose={() => {
             setModalAddToAlbumOpen(false);
+            updateSelectionState({
+              selectedItems: [],
+              selectMode: false,
+              selectAllMode: false,
+              selectAllQuery: undefined,
+            });
+          }}
+          selectedImages={selectionState.selectedItems}
+          selectAllMode={selectionState.selectAllMode}
+          selectAllQuery={selectionState.selectAllQuery}
+          totalCount={selectionState.totalCount || numberOfItems || idx2hash.length}
+        />
+      )}
+      {!isPublic && (
+        <ModalTagEdit
+          isOpen={modalTagOpen}
+          onRequestClose={() => {
+            setModalTagOpen(false);
             updateSelectionState({
               selectedItems: [],
               selectMode: false,

--- a/apps/frontend/src/components/photolist/SelectionActions.tsx
+++ b/apps/frontend/src/components/photolist/SelectionActions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Menu, Tooltip } from "@mantine/core";
+import { ActionIcon, Group, Menu, Text, Tooltip } from "@mantine/core";
 import {
   IconAlbum as Album,
   IconDotsVertical as DotsVertical,
@@ -16,6 +16,7 @@ import {
   IconShare as Share,
   IconStar as Star,
   IconStarOff as StarOff,
+  IconTag as Tag,
   IconTrash as Trash,
 } from "@tabler/icons-react";
 import { useLocation } from "@tanstack/react-router";
@@ -51,6 +52,7 @@ type Props = {
   setAlbumCover: (actionType: string, photoId?: string) => void;
   onShareAlbum: () => void;
   onAddToAlbum: () => void;
+  onAddTags: () => void;
   title: string;
   albumID?: number | string;
   ownerUsername?: string;
@@ -82,6 +84,7 @@ export function SelectionActions(props: Readonly<Props>) {
     setAlbumCover,
     albumID,
     onAddToAlbum,
+    onAddTags,
   } = props;
 
   // Helper to reset selection state after action
@@ -184,6 +187,21 @@ export function SelectionActions(props: Readonly<Props>) {
           <Menu.Item leftSection={<Album />} onClick={() => hasSelection && onAddToAlbum()}>
             {" Album"}
           </Menu.Item>
+
+          <Tooltip label={t("selectionactions.tagdescription")} position="left">
+            <Menu.Item
+              leftSection={<Tag />}
+              rightSection={
+                <Text size="xs" c="dimmed">
+                  t
+                </Text>
+              }
+              disabled={!hasSelection}
+              onClick={() => hasSelection && onAddTags()}
+            >
+              {t("selectionactions.tag")}
+            </Menu.Item>
+          </Tooltip>
         </Menu.Dropdown>
       </Menu>
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1338,6 +1338,11 @@
       "title": "No places found",
       "description": "Photos with GPS location data will be automatically grouped by place."
     },
+    "tag": {
+      "title": "This tag has no photos",
+      "description": "The photos that carried it were deleted, or you have not tagged anything with it yet. Select photos anywhere and press t to tag them.",
+      "action": "Back to all tags"
+    },
     "things": {
       "title": "No things detected",
       "description": "Objects and scenes are detected automatically during photo scanning."

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -281,6 +281,16 @@
     "name": "Person name",
     "joined": "Joined"
   },
+  "modaltag": {
+    "title": "Add Tags",
+    "selectedimages": "Tag the selected {{count}} photo(s)",
+    "andmore": "and {{count}} more",
+    "label": "Tags",
+    "hint": "Separate several tags with commas. Existing tags autocomplete; new ones are created.",
+    "placeholder": "beach, holiday, 2024",
+    "add": "Add tags",
+    "savefailed": "The tags could not be saved. Nothing was changed."
+  },
   "topmenu": {
     "running": "Running",
     "available": "Worker available! You can start scanning more photos, infer face labels, auto create event albums, or regenerate auto event album titles.",
@@ -475,7 +485,9 @@
     "nostackstomerge": "No stacks to merge",
     "stacksmerged": "Stacks merged successfully",
     "rotatecw": "Rotate 90° Clockwise",
-    "rotateccw": "Rotate 90° Counter-Clockwise"
+    "rotateccw": "Rotate 90° Counter-Clockwise",
+    "tag": "Tags",
+    "tagdescription": "Add tags to the selected photos (shortcut: t)"
   },
   "lightbox": {
     "sidebar": {
@@ -1213,7 +1225,9 @@
     "captionupdate": "Update Caption",
     "scan_directory_required": "Scan directory not configured - contact administrator",
     "jobcancelled": "Job has been cancelled",
-    "jobcancelledtitle": "Job Cancelled"
+    "jobcancelledtitle": "Job Cancelled",
+    "taggedphotos": "Added {{tags}} to {{count}} photo(s)",
+    "taggedphotostitle": "Photos tagged"
   },
   "rules": {
     "1": "Local time from DATE_TIME_ORIGINAL Exif tag",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -523,6 +523,7 @@
       "editKeywords": "Edit keywords",
       "addKeyword": "Add keyword…",
       "noKeywords": "No keywords",
+      "autotags": "Auto tags",
       "tags": "Tags",
       "editTags": "Edit tags",
       "addTag": "Add tag…",

--- a/apps/frontend/src/routes/_protected/album/-tags.$id.test.tsx
+++ b/apps/frontend/src/routes/_protected/album/-tags.$id.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * A tag outlives its last photo, so its album page has to say something.
+ *
+ * Before this it passed no `emptyStateConfig`, and PhotoListView falls through
+ * to `<div />` when there is nothing to show and no config — so deleting the
+ * only photo carrying a tag left the page as a bare header with a tag icon and
+ * no explanation of what had happened or where to go.
+ *
+ * The leading "-" keeps the TanStack router plugin from treating this file as
+ * a route (its `routeFileIgnorePrefix`); without it every build warns that the
+ * file exports no Route.
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import i18n from "../../../i18n";
+
+const stubs = vi.hoisted(() => ({
+  tagAlbum: { id: 7, name: "beach", grouped_photos: [] as unknown[] },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => {
+    const route = () => route;
+    route.useParams = () => ({ id: "7" });
+    route.useSearch = () => ({});
+    route.update = () => {};
+    return route;
+  },
+  useNavigate: () => () => {},
+  useLocation: () => ({ pathname: "/album/tags/7" }),
+  Link: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}));
+vi.mock("../../../api_client/tags/hooks", () => ({
+  useFetchTagAlbumQuery: () => ({ data: stubs.tagAlbum, isLoading: false }),
+}));
+// PhotoListView drags in the whole grid; the empty branch is all that matters.
+vi.mock("../../../components/photolist/PhotoListView", () => ({
+  PhotoListView: ({ emptyStateConfig, photoset }: any) => (
+    <div data-testid="photolist">
+      {photoset.length === 0 && emptyStateConfig ? (
+        <div data-testid="empty">
+          <h1>{emptyStateConfig.title}</h1>
+          <p>{emptyStateConfig.description}</p>
+          <a href={emptyStateConfig.actionLink}>{emptyStateConfig.actionLabel}</a>
+        </div>
+      ) : null}
+    </div>
+  ),
+}));
+vi.mock("../../../components/photolist/useMediaTypeFilter", () => ({
+  useMediaTypeFilter: () => undefined,
+}));
+vi.mock("../../../components/photolist/mediaTypeFilter", () => ({
+  validateMediaSearch: () => ({}),
+}));
+
+beforeAll(async () => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage("en");
+});
+
+async function renderPage() {
+  const { AlbumTagGallery } = await import("./tags.$id");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <AlbumTagGallery />
+      </MantineProvider>
+    );
+  });
+  return {
+    container,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("a tag album with no photos", () => {
+  it("explains itself instead of rendering a bare page", async () => {
+    const page = await renderPage();
+
+    const empty = page.container.querySelector('[data-testid="empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.querySelector("h1")?.textContent).toBe("This tag has no photos");
+    expect(empty?.querySelector("p")?.textContent).toContain("press t to tag them");
+    await page.unmount();
+  });
+
+  it("offers a way back to the tag list", async () => {
+    const page = await renderPage();
+
+    const action = page.container.querySelector('[data-testid="empty"] a');
+    expect(action?.textContent).toBe("Back to all tags");
+    expect(action?.getAttribute("href")).toBe("/album/tags");
+    await page.unmount();
+  });
+});

--- a/apps/frontend/src/routes/_protected/album/tags.$id.tsx
+++ b/apps/frontend/src/routes/_protected/album/tags.$id.tsx
@@ -1,9 +1,10 @@
 import { IconTag as Tag } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
-import React from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFetchTagAlbumQuery } from "../../../api_client/tags/hooks";
 import { validateMediaSearch } from "../../../components/photolist/mediaTypeFilter";
+import type { EmptyStateConfig } from "../../../components/photolist/PhotoListView";
 import { PhotoListView } from "../../../components/photolist/PhotoListView";
 import { useMediaTypeFilter } from "../../../components/photolist/useMediaTypeFilter";
 
@@ -17,6 +18,20 @@ export function AlbumTagGallery() {
   const mediaType = useMediaTypeFilter();
   const { data: tagAlbum, isLoading: fetchingTagAlbum } = useFetchTagAlbumQuery(tagID || "", mediaType);
 
+  // A tag outlives its last photo on purpose -- it can be created before
+  // anything carries it, and deleting photos should not silently delete tags.
+  // Without this the page rendered as a bare header with nothing under it.
+  const emptyStateConfig: EmptyStateConfig = useMemo(
+    () => ({
+      icon: <Tag size={40} />,
+      title: t("emptystate.tag.title"),
+      description: t("emptystate.tag.description"),
+      actionLabel: t("emptystate.tag.action"),
+      actionLink: "/album/tags",
+    }),
+    [t]
+  );
+
   return (
     <PhotoListView
       title={tagAlbum ? tagAlbum.name : t("loading")}
@@ -25,6 +40,7 @@ export function AlbumTagGallery() {
       photoset={tagAlbum ? tagAlbum.grouped_photos : []}
       idx2hash={tagAlbum ? tagAlbum.grouped_photos.flatMap(el => el.items) : []}
       mediaType={mediaType}
+      emptyStateConfig={emptyStateConfig}
       selectable
     />
   );

--- a/apps/frontend/src/service/notifications/tags.ts
+++ b/apps/frontend/src/service/notifications/tags.ts
@@ -49,8 +49,20 @@ function removePhotosFromTag(name: string, numberOfPhotos: number) {
   });
 }
 
+function taggedPhotos(names: string[], numberOfPhotos: number) {
+  showNotification({
+    message: i18n.t("toasts.taggedphotos", {
+      tags: names.join(", "),
+      count: numberOfPhotos,
+    }),
+    title: i18n.t("toasts.taggedphotostitle"),
+    color: "teal",
+  });
+}
+
 export const tags = {
   addPhotosToTag,
+  taggedPhotos,
   createTag,
   deleteTag,
   mergeTags,

--- a/apps/frontend/src/util/tagOptionsFilter.test.ts
+++ b/apps/frontend/src/util/tagOptionsFilter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { tagOptionsFilter } from "./tagOptionsFilter";
+
+const options = ["Alberta", "beach", "Beachcomber", "holiday", "seaside beach"].map(name => ({
+  value: name,
+  label: name,
+}));
+
+const filter = (search: string, limit = Infinity) =>
+  (tagOptionsFilter({ options, search, limit }) as { label: string }[]).map(item => item.label);
+
+describe("tagOptionsFilter", () => {
+  test("puts names starting with the query first", () => {
+    // Mantine's default filter would have led with Alberta, because the list
+    // is alphabetical and it matches anywhere in the name.
+    expect(filter("be")).toEqual(["beach", "Beachcomber", "Alberta", "seaside beach"]);
+  });
+
+  test("is case-insensitive in both directions", () => {
+    // "Alberta" holds "ber", not "bea", so it drops out entirely here.
+    expect(filter("BEA")).toEqual(["beach", "Beachcomber", "seaside beach"]);
+  });
+
+  test("still finds a name that only contains the query", () => {
+    expect(filter("side")).toEqual(["seaside beach"]);
+  });
+
+  test("ignores surrounding whitespace in the query", () => {
+    expect(filter("  holi ")).toEqual(["holiday"]);
+  });
+
+  test("offers everything when nothing has been typed", () => {
+    expect(filter("")).toEqual(["Alberta", "beach", "Beachcomber", "holiday", "seaside beach"]);
+  });
+
+  test("keeps the prefix matches when the limit cuts the list short", () => {
+    expect(filter("bea", 2)).toEqual(["beach", "Beachcomber"]);
+  });
+
+  test("returns nothing for a query no tag matches", () => {
+    expect(filter("zzz")).toEqual([]);
+  });
+});

--- a/apps/frontend/src/util/tagOptionsFilter.ts
+++ b/apps/frontend/src/util/tagOptionsFilter.ts
@@ -1,0 +1,41 @@
+import type { ComboboxItem, OptionsFilter } from "@mantine/core";
+
+/** How many suggestions to show at once. Enough to scan without scrolling. */
+export const TAG_SUGGESTION_LIMIT = 10;
+
+/**
+ * Suggest tags prefix-first: what you typed at the start of a name wins.
+ *
+ * Mantine's default filter keeps whatever order the options arrived in and
+ * matches anywhere in the name, so typing `be` offered `Alberta` above `beach`
+ * purely because the list is alphabetical. Names that *start* with the query
+ * come first here, and names that merely contain it follow, so the search
+ * stays useful for someone who half-remembers a tag while behaving like a
+ * jump-to-letter for someone who knows exactly what they want.
+ *
+ * Alphabetical order within each of the two groups is inherited from the
+ * server, which orders tags by name.
+ */
+export const tagOptionsFilter: OptionsFilter = ({ options, search, limit }) => {
+  // Tag data is a flat list of names, never grouped.
+  const items = options.filter((option): option is ComboboxItem => !("group" in option));
+  const query = search.trim().toLowerCase();
+
+  if (query.length === 0) {
+    return items.slice(0, limit);
+  }
+
+  const startsWithQuery: ComboboxItem[] = [];
+  const containsQuery: ComboboxItem[] = [];
+
+  items.forEach(item => {
+    const label = item.label.toLowerCase();
+    if (label.startsWith(query)) {
+      startsWithQuery.push(item);
+    } else if (label.includes(query)) {
+      containsQuery.push(item);
+    }
+  });
+
+  return [...startsWithQuery, ...containsQuery].slice(0, limit);
+};


### PR DESCRIPTION
Personal comment: it came to me as a surprise that LibrePhotos doesn't handle tags as a first class entity. It's a gallery application (and much more, yes), and as such tags assignment and management is a basic needed feature. I hope this will land well, and we can alter it if needed.

Now to Claude:
#1930 made tags a first-class entity — a model, a browse page, rename/merge/delete, EXIF keyword import — but left assignment where it already was: one photo at a time, through the lightbox sidebar. Tagging twenty holiday photos meant twenty trips through the lightbox, while assigning twenty faces to a person has been a single dialog for years. The backend has actually accepted a list of photos on `/tags/{id}/add/` since #1930; there was simply no way to reach it from the grid.

Select photos anywhere the grid allows it — the timeline, a search result, a person, place, thing or user album, a folder — and press **`t`**, or pick **Tags** from the plus menu next to Album. One dialog, comma-separated names, autocomplete over the tags the account already has, applied to the whole selection. It is modelled on Shotwell's Ctrl+T, with a bare `t` because browsers reserve Ctrl+T for a new tab and a page cannot intercept it, and because the lightbox already binds bare `f`/`h`/`p`/`i`/`z` for favourite, hide, public, info and zoom.

Names the account already uses are reused rather than re-created, and anything new is created on the way past. The whole edit reports once instead of raising a toast per tag — three new tags used to mean six notifications — and a failure leaves the dialog open with the typing intact rather than closing as though it had saved. Text that was typed but never committed to a pill counts as a name too, so the most common case of all (one tag, no comma, straight to the button) does what it looks like it does; without that the button sat disabled over a box with a tag in it.

Select All works. The add and remove actions now take the same `select_all` + `query` + `excluded_hashes` payload as the bulk favourite/hide/delete endpoints, so tagging a filtered view is one request describing the photoset rather than one id per photo. The query is bound to the requester's own photos before anything is written, because `build_photo_queryset` drops its owner filter for a public photoset — the shape of #1982, and without the guard one account could hang its tags on another's photos. Links are written in batches, so a library-wide tag neither loads every row into memory nor builds a single statement over all of them; a handful of photos still takes one pass, and there is a test pinning that the query count does not grow with the size of the photoset.

Two smaller things came out of building it.

Suggestions are now prefix-first. Mantine's default option filter matches anywhere in the name and preserves the order the options arrived in, and the API hands tags over alphabetically, so typing `be` offered `Alberta` above `beach`. Names that *start* with what you typed now come first, with the merely-contains matches behind them, which makes the box work as a jump-to-letter for someone who knows the tag while still finding one they only half remember. Shared with the lightbox editor so both behave alike.

And the tagging model's own output is now labelled **Auto tags**. It was rendering under the same translation key as the user's tags, so the lightbox sidebar showed two sections both titled "Tags", one editable and one not — the docs had to spell out that they were not the same thing. English only; Weblate carries the rest.

The tag album page also passed no `emptyStateConfig`, so a tag with no photos rendered as a bare header with nothing under it. It now says the tag is empty, points at the shortcut, and offers a way back to the tag list. A tag outliving its photos is deliberate — it can be created before anything carries it — so the page has to say so rather than look broken.

Not included, and worth naming: there is still no bulk tag *removal* UI, though the remove endpoint learned the same select-all payload here, so it is a dialog away. Writing tags back into the image file remains out of scope for the same reason as in #1930 — `XMP:Subject` is already owned by face-region write-back and needs a merge design rather than a last-writer-wins clobber.

Docs are in `apps/docs/docs/user-guide/albums.md` as a new *Tagging photos* section, plus a Tag Albums entry among the album types and a cross-reference from the lightbox sidebar page. There was no user-guide page for user-defined tags at all before this — #1930 predates the docs rule — so this covers the whole feature, not only what is new here, and it notes that bulk tagging is not in a released image yet.

3169 backend tests with the same set of environmental failures as an unmodified `origin/dev` in the same environment, 10 of them new for the select-all payload, 8 of which fail without the view change. 190 frontend tests, 19 new across the dialog, the filter and the empty state. `ruff`, `eslint`, `prettier`, `vite build` and the docs build all clean; `tsc` unchanged at its pre-existing error baseline. Exercised on a dev instance.

There is a sibling PR, #1999, fixing a stale `Tag.photo_count`. The two share no files and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
