### PR TITLE
feat: add a face the scan missed, by drawing a box on the photo

### DIFF
--- a/apps/backend/api/models/album_auto.py
+++ b/apps/backend/api/models/album_auto.py
@@ -35,6 +35,12 @@ def _collect_photo_details(photos):
             places = geolocation["places"]
         timestamps.append(photo.exif_timestamp)
         for face in photo.faces.all():
+            # Most faces in a library are unnamed, and a deleted one should not
+            # name an album. Dereferencing face.person.name for those raised
+            # AttributeError, and _generate_title() catches every exception --
+            # so a single unnamed face silently cost the album its whole title.
+            if face.deleted or face.person is None:
+                continue
             people.append(face.person.name)
     return places, people, timestamps
 

--- a/apps/backend/api/models/photo.py
+++ b/apps/backend/api/models/photo.py
@@ -548,6 +548,7 @@ class Photo(models.Model):
         face.image.save(image_path, ContentFile(face_io.getvalue()))
         face_io.close()
         face.save()
+        return face
 
     def _retry_face_extraction(self, second_try):
         # When using multiple processes, then we can save at the same time, which leads to this error

--- a/apps/backend/api/serializers/album_auto.py
+++ b/apps/backend/api/serializers/album_auto.py
@@ -29,7 +29,7 @@ class AlbumAutoSerializer(serializers.ModelSerializer):
         for photo in obj.photos.all():
             faces = photo.faces.all()
             for face in faces:
-                if face.person is None:
+                if face.deleted or face.person is None:
                     continue
                 serialized_person = PersonSerializer(face.person).data
                 if serialized_person not in res:

--- a/apps/backend/api/serializers/photos.py
+++ b/apps/backend/api/serializers/photos.py
@@ -634,6 +634,10 @@ class PhotoSerializer(serializers.ModelSerializer):
                 "face_id": f.id,
             }
             for f in obj.faces.all()
+            # A deleted face is hidden everywhere else in LibrePhotos -- the face
+            # dashboard and the person's face list both filter it out -- so it must
+            # not come back in the photo's own face list either.
+            if not f.deleted
         ]
 
     def get_embedded_media(self, obj: Photo) -> list[dict]:
@@ -987,5 +991,5 @@ class PublicPhotoDetailSerializer(serializers.ModelSerializer):
                 "face_id": face.id,
             }
             for face in obj.faces.all()
-            if (person := face.person or face.cluster_person)
+            if not face.deleted and (person := face.person or face.cluster_person)
         ]

--- a/apps/backend/api/tests/albums/test_album_auto_title_generation.py
+++ b/apps/backend/api/tests/albums/test_album_auto_title_generation.py
@@ -252,13 +252,20 @@ class GenerateTitleTestCase(TestCase):
             album.title, f"Monday Morning with {Person.UNKNOWN_PERSON_NAME}"
         )
 
-    def test_face_without_person_falls_back_to_exception_title(self):
-        """A face with ``person=None`` raises inside the loop -> fallback title."""
+    def test_face_without_person_is_skipped_instead_of_raising(self):
+        """A face with ``person=None`` is simply not a person to name.
+
+        This replaces a characterization test that pinned the opposite: the
+        loop dereferenced ``face.person.name``, the ``AttributeError`` was
+        swallowed by ``_generate_title``'s ``except Exception``, and the album
+        fell back to "Album from <date>". Since unnamed faces are the normal
+        case, that fallback was hitting most albums that contain any people.
+        """
         album = self.make_album(utc(2022, 1, 3, 8, 0))
         photo = self.add_photo(album, exif_timestamp=utc(2022, 1, 3, 8, 0))
         create_test_face(photo=photo, person=None)
         album._generate_title()
-        self.assertEqual(album.title, "Album from 2022-01-03")
+        self.assertEqual(album.title, "Monday Morning")
 
     # ------------------------------------------------------------------
     # timestamp-span branches

--- a/apps/backend/api/tests/albums/test_album_auto_unnamed_and_deleted_faces.py
+++ b/apps/backend/api/tests/albums/test_album_auto_unnamed_and_deleted_faces.py
@@ -1,0 +1,100 @@
+"""Auto ("event") albums read every face on their photos.
+
+Both places that do so assumed each face has a person and is still live:
+
+* ``AlbumAuto._generate_title`` dereferenced ``face.person.name`` directly. One
+  unnamed face on one photo raised ``AttributeError``, and because the whole
+  title generation is wrapped in ``except Exception``, the album silently fell
+  back to "Album from <date>" - losing the weekday, time of day, people and
+  place it had already worked out.
+* ``AlbumAutoSerializer.get_people`` listed people from soft-deleted faces.
+
+Unnamed faces are the normal case, not an edge case: a library gets one person
+row per *labelled* face, and everything the algorithms have not matched yet has
+``person = None``.
+"""
+
+from datetime import datetime
+
+import pytz
+from django.test import TestCase
+
+from api.models import AlbumAuto
+from api.serializers.album_auto import AlbumAutoSerializer
+from api.tests.utils import (
+    create_test_face,
+    create_test_person,
+    create_test_photo,
+    create_test_user,
+)
+
+
+def utc(*args):
+    return datetime(*args).replace(tzinfo=pytz.utc)
+
+
+class AlbumAutoTitleWithUnnamedFacesTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.timestamp = utc(2022, 1, 2, 15, 0)
+        self.album = AlbumAuto.objects.create(
+            timestamp=self.timestamp, created_on=self.timestamp, owner=self.user
+        )
+        self.photo = create_test_photo(owner=self.user, exif_timestamp=self.timestamp)
+        self.album.photos.add(self.photo)
+
+    def test_an_unnamed_face_does_not_cost_the_album_its_title(self):
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+        create_test_face(photo=self.photo, person=None)
+
+        self.album._generate_title()
+
+        self.assertIn("Alice", self.album.title)
+        self.assertNotIn("Album from", self.album.title)
+
+    def test_only_unnamed_faces_still_yields_the_normal_title(self):
+        create_test_face(photo=self.photo, person=None)
+
+        self.album._generate_title()
+
+        self.assertEqual(self.album.title, "Sunday Afternoon")
+
+    def test_a_deleted_face_is_not_counted_towards_the_title(self):
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+
+        self.album._generate_title()
+
+        self.assertIn("Alice", self.album.title)
+        self.assertNotIn("Ghost", self.album.title)
+
+
+class AlbumAutoPeopleListTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        timestamp = utc(2022, 1, 2, 15, 0)
+        self.album = AlbumAuto.objects.create(
+            timestamp=timestamp, created_on=timestamp, owner=self.user
+        )
+        self.photo = create_test_photo(owner=self.user, exif_timestamp=timestamp)
+        self.album.photos.add(self.photo)
+
+    def _people(self):
+        return AlbumAutoSerializer(self.album).data["people"]
+
+    def test_deleted_faces_are_not_listed(self):
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+
+        self.assertEqual(self._people(), [])
+
+    def test_live_faces_are_still_listed_beside_a_deleted_one(self):
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+
+        self.assertEqual([p["name"] for p in self._people()], ["Alice"])

--- a/apps/backend/api/tests/faces/test_manual_face_tagging.py
+++ b/apps/backend/api/tests/faces/test_manual_face_tagging.py
@@ -1,0 +1,309 @@
+"""Adding a face the detector missed (issue #431).
+
+``POST /api/addface`` takes a box the user drew on a photo, normalized to the
+displayed image, and turns it into a real ``Face`` row: cropped face image,
+person label, and an ArcFace encoding so classification can learn from it.
+
+The box is normalized because that is what a browser can measure. Face rows
+store pixels in big-thumbnail space, and the lightbox displays the big
+thumbnail, so these tests pin the conversion against a thumbnail of a known
+size and check the pixels that come out.
+"""
+
+import shutil
+import tempfile
+from unittest.mock import patch
+
+import numpy as np
+import PIL.Image
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from api.models import Face, Person
+from api.tests.utils import (
+    create_test_face,
+    create_test_person,
+    create_test_photo,
+    create_test_user,
+)
+
+ADD_FACE_URL = "/api/addface"
+THUMB_WIDTH, THUMB_HEIGHT = 800, 600
+
+
+def a_box(top=0.25, right=0.6, bottom=0.75, left=0.4):
+    return {"top": top, "right": right, "bottom": bottom, "left": left}
+
+
+class AddFaceTestBase(TestCase):
+    def setUp(self):
+        self.media = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.media, ignore_errors=True)
+        overridden = override_settings(MEDIA_ROOT=self.media)
+        overridden.enable()
+        self.addCleanup(overridden.disable)
+
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+        self.photo = self._photo_with_thumbnail(self.user)
+
+    def _photo_with_thumbnail(self, owner, name="thumb"):
+        relative = f"thumbnails_big/{name}.jpg"
+        photo = create_test_photo(owner=owner, thumbnail_big=relative)
+        directory = f"{self.media}/thumbnails_big"
+        PIL.Image.new("RGB", (THUMB_WIDTH, THUMB_HEIGHT), "gray").save(
+            self._ensure(directory, f"{name}.jpg")
+        )
+        return photo
+
+    @staticmethod
+    def _ensure(directory, filename):
+        import os
+
+        os.makedirs(directory, exist_ok=True)
+        return f"{directory}/{filename}"
+
+    def _post(self, **overrides):
+        payload = {
+            "photo": self.photo.image_hash,
+            "person_name": "Alice",
+            "box": a_box(),
+        }
+        payload.update(overrides)
+        return self.client.post(ADD_FACE_URL, payload, format="json")
+
+
+@patch(
+    "api.models.face.get_face_encodings",
+    return_value=[np.random.rand(512)],
+)
+class AddFaceTest(AddFaceTestBase):
+    def test_a_drawn_box_becomes_a_labelled_face(self, mock_encodings):
+        response = self._post()
+
+        self.assertEqual(response.status_code, 201)
+        face = Face.objects.get()
+        self.assertEqual(face.photo_id, self.photo.pk)
+        self.assertEqual(face.person.name, "Alice")
+        self.assertEqual(face.person.kind, Person.KIND_USER)
+        self.assertEqual(face.person.cluster_owner, self.user)
+        self.assertEqual(response.data["face"]["face_id"], face.id)
+
+    def test_the_normalized_box_lands_on_the_right_pixels(self, mock_encodings):
+        self._post(box=a_box(top=0.25, right=0.6, bottom=0.75, left=0.4))
+
+        face = Face.objects.get()
+
+        self.assertEqual(face.location_top, int(0.25 * THUMB_HEIGHT))
+        self.assertEqual(face.location_bottom, int(0.75 * THUMB_HEIGHT))
+        self.assertEqual(face.location_left, int(0.4 * THUMB_WIDTH))
+        self.assertEqual(face.location_right, int(0.6 * THUMB_WIDTH))
+
+    def test_the_face_image_is_cropped_to_the_box(self, mock_encodings):
+        self._post(box=a_box(top=0.0, right=0.5, bottom=0.5, left=0.0))
+
+        face = Face.objects.get()
+
+        self.assertTrue(face.image.name.startswith("faces/"))
+        with PIL.Image.open(face.image.path) as cropped:
+            self.assertEqual(cropped.width, THUMB_WIDTH // 2)
+            self.assertEqual(cropped.height, THUMB_HEIGHT // 2)
+
+    def test_the_face_is_encoded_so_classification_can_learn_from_it(
+        self, mock_encodings
+    ):
+        self._post()
+
+        face = Face.objects.get()
+
+        self.assertTrue(face.encoding)
+        mock_encodings.assert_called_once()
+
+    def test_a_manual_face_does_not_seed_a_cluster(self, mock_encodings):
+        """It is a user label, so it trains classification but starts no cluster."""
+        self._post()
+
+        face = Face.objects.get()
+
+        self.assertIsNone(face.cluster)
+        self.assertIsNone(face.cluster_person)
+        self.assertIsNone(face.classification_person)
+
+    def test_the_person_gets_a_face_count_and_a_cover(self, mock_encodings):
+        self._post()
+
+        person = Person.objects.get(name="Alice")
+
+        self.assertEqual(person.face_count, 1)
+        self.assertEqual(person.cover_photo_id, self.photo.pk)
+
+    def test_the_photo_now_lists_the_person(self, mock_encodings):
+        """The end the user actually sees: the sidebar names them on the photo."""
+        self._post()
+
+        detail = self.client.get(f"/api/photos/{self.photo.image_hash}/")
+
+        self.assertEqual(
+            [(p["name"], p["type"]) for p in detail.data["people"]], [("Alice", "user")]
+        )
+
+    def test_the_person_becomes_searchable_on_that_photo(self, mock_encodings):
+        self._post()
+
+        self.photo.refresh_from_db()
+
+        self.assertIn("Alice", self.photo.search_instance.search_captions)
+
+    def test_an_existing_person_is_reused_rather_than_duplicated(self, mock_encodings):
+        create_test_person(name="Alice", kind=Person.KIND_USER, cluster_owner=self.user)
+
+        self._post()
+
+        self.assertEqual(
+            Person.objects.filter(name="Alice", cluster_owner=self.user).count(), 1
+        )
+
+    def test_a_second_face_can_be_added_elsewhere_on_the_photo(self, mock_encodings):
+        self.assertEqual(self._post(box=a_box(0.1, 0.3, 0.4, 0.1)).status_code, 201)
+
+        response = self._post(person_name="Bob", box=a_box(0.5, 0.9, 0.8, 0.7))
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Face.objects.count(), 2)
+
+
+@patch(
+    "api.models.face.get_face_encodings",
+    return_value=[np.random.rand(512)],
+)
+class AddFaceValidationTest(AddFaceTestBase):
+    def test_a_blank_person_name_is_rejected(self, mock_encodings):
+        for name in ("", "   "):
+            with self.subTest(name=name):
+                response = self._post(person_name=name)
+
+                self.assertEqual(response.status_code, 400)
+                self.assertFalse(Face.objects.exists())
+
+    def test_the_placeholder_person_is_rejected(self, mock_encodings):
+        """ "Unknown - Other" is what the algorithms use, not a name for a face."""
+        response = self._post(person_name=Person.UNKNOWN_PERSON_NAME)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(Face.objects.exists())
+
+    def test_surrounding_whitespace_is_trimmed(self, mock_encodings):
+        self._post(person_name="  Alice  ")
+
+        self.assertTrue(Person.objects.filter(name="Alice").exists())
+
+    def test_a_box_outside_the_image_is_rejected(self, mock_encodings):
+        for box in (a_box(top=-0.1), a_box(right=1.4)):
+            with self.subTest(box=box):
+                self.assertEqual(self._post(box=box).status_code, 400)
+
+    def test_an_inverted_box_is_rejected(self, mock_encodings):
+        response = self._post(box=a_box(top=0.8, bottom=0.2))
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_stray_click_is_rejected_as_too_small(self, mock_encodings):
+        response = self._post(box=a_box(top=0.5, bottom=0.501, left=0.5, right=0.501))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(Face.objects.exists())
+
+    def test_a_missing_or_malformed_box_is_rejected(self, mock_encodings):
+        for box in (None, "somewhere", {"top": 0.1}):
+            with self.subTest(box=box):
+                self.assertEqual(self._post(box=box).status_code, 400)
+
+    def test_a_missing_photo_is_rejected(self, mock_encodings):
+        response = self._post(photo="")
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_another_users_photo_is_not_found(self, mock_encodings):
+        stranger = create_test_user()
+        their_photo = self._photo_with_thumbnail(stranger, name="theirs")
+
+        response = self._post(photo=their_photo.image_hash)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(Face.objects.exists())
+
+    def test_a_photo_without_a_big_thumbnail_is_rejected(self, mock_encodings):
+        no_thumbnail = create_test_photo(owner=self.user, thumbnail_big=None)
+
+        response = self._post(photo=no_thumbnail.image_hash)
+
+        self.assertEqual(response.status_code, 400)
+
+
+@patch(
+    "api.models.face.get_face_encodings",
+    return_value=[np.random.rand(512)],
+)
+class AddFaceOverlapTest(AddFaceTestBase):
+    def test_drawing_over_an_existing_face_is_refused(self, mock_encodings):
+        """Relabelling the face that is already there is the right action."""
+        create_test_face(
+            photo=self.photo,
+            person=create_test_person(name="Bob", cluster_owner=self.user),
+            location_top=150,
+            location_bottom=450,
+            location_left=320,
+            location_right=480,
+        )
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(Face.objects.count(), 1)
+
+    def test_a_deleted_face_does_not_block_the_same_region(self, mock_encodings):
+        """A rescan must not resurrect a deleted face, but the user may overrule it.
+
+        Drawing a box there is an explicit statement that there is a face after
+        all, so the deleted row is not treated as an obstacle.
+        """
+        create_test_face(
+            photo=self.photo,
+            person=None,
+            deleted=True,
+            location_top=150,
+            location_bottom=450,
+            location_left=320,
+            location_right=480,
+        )
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Face.objects.filter(deleted=False).count(), 1)
+
+
+class AddFaceWithoutTheFaceServiceTest(AddFaceTestBase):
+    """The label is the user's work; the encoding is a nicety the ML adds."""
+
+    @patch(
+        "api.models.face.get_face_encodings",
+        side_effect=ConnectionError("face service is down"),
+    )
+    def test_the_face_survives_a_face_service_that_is_down(self, mock_encodings):
+        response = self._post()
+
+        self.assertEqual(response.status_code, 201)
+        face = Face.objects.get()
+        self.assertEqual(face.person.name, "Alice")
+        self.assertEqual(face.encoding, "")
+
+    @patch("api.models.face.get_face_encodings", return_value=[])
+    def test_the_face_survives_a_face_service_that_returns_nothing(
+        self, mock_encodings
+    ):
+        response = self._post()
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Face.objects.get().encoding, "")

--- a/apps/backend/api/tests/faces/test_photo_face_list.py
+++ b/apps/backend/api/tests/faces/test_photo_face_list.py
@@ -1,0 +1,301 @@
+"""The face list a photo shows in the lightbox sidebar.
+
+``GET /api/photos/<image_hash>/`` renders ``PhotoSerializer.people``, which is
+what the lightbox sidebar lists next to a photo and what drives the face box
+drawn over the image. Three properties matter to that view and are pinned here:
+
+* a face the owner deleted is gone from it,
+* a face nobody has named yet is still in it (that row is the only place a face
+  the algorithms gave up on can be named), and
+* every entry carries a distinct ``face_id`` for the UI to key and act on.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.models import Person
+from api.tests.utils import (
+    create_test_face,
+    create_test_person,
+    create_test_photo,
+    create_test_user,
+)
+
+LABEL_FACES_URL = "/api/labelfaces"
+
+
+class PhotoPeopleListTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+        self.photo = create_test_photo(owner=self.user)
+
+    def _people(self):
+        response = self.client.get(f"/api/photos/{self.photo.image_hash}/")
+        self.assertEqual(response.status_code, 200)
+        return response.data["people"]
+
+    def test_deleted_face_is_not_listed_on_the_photo(self):
+        """Deleting a face hides it from the dashboard and the person's list.
+
+        The photo's own list used to keep showing it, so a misdetection the user
+        had already dealt with came back on every visit to the photo.
+        """
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+
+        self.assertEqual(self._people(), [])
+
+    def test_deleted_face_does_not_hide_the_live_faces_beside_it(self):
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+        live = create_test_face(
+            photo=self.photo, person=create_test_person(name="Alice")
+        )
+
+        people = self._people()
+
+        self.assertEqual([p["name"] for p in people], ["Alice"])
+        self.assertEqual(people[0]["face_id"], live.id)
+
+    def test_deleted_unnamed_face_is_not_listed_either(self):
+        create_test_face(
+            photo=self.photo,
+            person=None,
+            cluster_person=None,
+            classification_person=None,
+            deleted=True,
+        )
+
+        self.assertEqual(self._people(), [])
+
+    def test_unnamed_face_is_still_listed_with_an_empty_name(self):
+        """The sidebar needs this row: it is where an unnamed face gets named."""
+        face = create_test_face(
+            photo=self.photo,
+            person=None,
+            cluster_person=None,
+            classification_person=None,
+        )
+
+        people = self._people()
+
+        self.assertEqual(len(people), 1)
+        self.assertEqual(people[0]["name"], "")
+        self.assertEqual(people[0]["type"], "")
+        self.assertEqual(people[0]["face_id"], face.id)
+
+    def test_every_entry_has_its_own_face_id(self):
+        """Several unnamed faces share a name, so the id is the only unique key."""
+        faces = [
+            create_test_face(
+                photo=self.photo,
+                person=None,
+                cluster_person=None,
+                classification_person=None,
+            )
+            for _ in range(3)
+        ]
+
+        people = self._people()
+
+        self.assertEqual([p["name"] for p in people], ["", "", ""])
+        self.assertEqual(
+            sorted(p["face_id"] for p in people), sorted(f.id for f in faces)
+        )
+
+    def test_face_location_is_exposed_for_the_overlay(self):
+        create_test_face(
+            photo=self.photo,
+            person=create_test_person(name="Alice"),
+            location_top=10,
+            location_right=90,
+            location_bottom=100,
+            location_left=20,
+        )
+
+        location = self._people()[0]["location"]
+
+        self.assertEqual(location, {"top": 10, "bottom": 100, "left": 20, "right": 90})
+
+
+class LabelFacesPersonNameValidationTest(TestCase):
+    """``POST /api/labelfaces`` must not be talked into a nameless person.
+
+    ``Person.name`` carries a ``MinLengthValidator``, but the endpoint reaches
+    the row through ``get_or_create()``, which does not run field validators.
+    An unnamed face in the sidebar reported ``name: ""``, and the confirm button
+    posted that name straight back - creating a person with no name, and a
+    person album to go with it.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+        self.photo = create_test_photo(owner=self.user)
+        self.face = create_test_face(photo=self.photo, person=None)
+
+    def _post(self, person_name):
+        return self.client.post(
+            LABEL_FACES_URL,
+            {"face_ids": [self.face.id], "person_name": person_name},
+            format="json",
+        )
+
+    def test_empty_person_name_is_rejected(self):
+        response = self._post("")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(Person.objects.filter(name="").exists())
+        self.face.refresh_from_db()
+        self.assertIsNone(self.face.person)
+
+    def test_whitespace_only_person_name_is_rejected(self):
+        response = self._post("   ")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            Person.objects.filter(cluster_owner=self.user, kind=Person.KIND_USER)
+            .exclude(name__regex=r"\S")
+            .exists()
+        )
+        self.face.refresh_from_db()
+        self.assertIsNone(self.face.person)
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        """ " Alice " must not become a second person next to "Alice"."""
+        self.assertEqual(self._post("Alice").status_code, 200)
+
+        other_face = create_test_face(photo=self.photo, person=None)
+        response = self.client.post(
+            LABEL_FACES_URL,
+            {"face_ids": [other_face.id], "person_name": "  Alice  "},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            Person.objects.filter(name="Alice", cluster_owner=self.user).count(), 1
+        )
+        self.assertEqual(
+            Person.objects.filter(
+                name__in=("  Alice  ", " Alice ", "Alice "), cluster_owner=self.user
+            ).count(),
+            0,
+        )
+        other_face.refresh_from_db()
+        self.assertEqual(other_face.person.name, "Alice")
+
+    def test_a_real_name_still_labels_the_face(self):
+        response = self._post("Bob")
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertEqual(self.face.person.name, "Bob")
+        self.assertEqual(self.face.person.kind, Person.KIND_USER)
+
+
+class LabelFacesPseudoPersonNameTest(TestCase):
+    """A cluster's name is not a person's name.
+
+    Clustering names every unnamed cluster ``Unknown NNN`` and backs it with a
+    ``Person`` row of kind ``CLUSTER``; the unclassifiable faces share one of
+    kind ``UNKNOWN`` called "Unknown - Other". Those names reach the lightbox in
+    the same ``name`` field a real person's name arrives in, and the confirm
+    button posts whatever is there straight back here.
+
+    ``get_or_create_person`` looks a row up by ``(name, cluster_owner, kind)``,
+    so asking for ``KIND_USER`` never matches the ``CLUSTER`` row: it mints a
+    *second* person called "Unknown 001", of the kind that gets a person album
+    and trains the classifier, and moves the face onto it. The face dashboard
+    has always hidden confirm for those kinds; the lightbox did not.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = create_test_user()
+        self.client.force_authenticate(user=self.user)
+        self.photo = create_test_photo(owner=self.user)
+        self.cluster_person = create_test_person(
+            name="Unknown 001", kind=Person.KIND_CLUSTER, cluster_owner=self.user
+        )
+        self.face = create_test_face(
+            photo=self.photo, person=None, cluster_person=self.cluster_person
+        )
+
+    def _post(self, person_name, face=None):
+        return self.client.post(
+            LABEL_FACES_URL,
+            {"face_ids": [(face or self.face).id], "person_name": person_name},
+            format="json",
+        )
+
+    def test_a_cluster_name_does_not_become_a_person(self):
+        response = self._post("Unknown 001")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            Person.objects.filter(
+                name="Unknown 001", kind=Person.KIND_USER, cluster_owner=self.user
+            ).exists()
+        )
+        self.assertEqual(Person.objects.filter(name="Unknown 001").count(), 1)
+
+    def test_the_face_keeps_its_cluster_when_the_name_is_refused(self):
+        self._post("Unknown 001")
+
+        self.face.refresh_from_db()
+        self.assertIsNone(self.face.person)
+        self.assertEqual(self.face.cluster_person, self.cluster_person)
+
+    def test_the_unknown_other_pseudo_person_still_unassigns(self):
+        """The one pseudo-person name the endpoint already handled must keep
+        working: posting it clears the face rather than labelling it."""
+        response = self._post(Person.UNKNOWN_PERSON_NAME)
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertIsNone(self.face.person)
+        self.assertIsNone(self.face.cluster_person)
+        self.assertFalse(
+            Person.objects.filter(
+                name=Person.UNKNOWN_PERSON_NAME, kind=Person.KIND_USER
+            ).exists()
+        )
+
+    def test_a_name_no_pseudo_person_holds_is_still_accepted(self):
+        """The guard is about the rows that exist, not about names that look
+        like a cluster's. Someone whose name happens to read that way, or a
+        cluster number that was never created, must still label normally."""
+        response = self._post("Unknown 042")
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertEqual(self.face.person.name, "Unknown 042")
+        self.assertEqual(self.face.person.kind, Person.KIND_USER)
+
+    def test_another_users_cluster_name_does_not_block_this_user(self):
+        """Cluster names are per-owner, and so is the guard."""
+        stranger = create_test_user()
+        create_test_person(
+            name="Unknown 007", kind=Person.KIND_CLUSTER, cluster_owner=stranger
+        )
+
+        response = self._post("Unknown 007")
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertEqual(self.face.person.kind, Person.KIND_USER)
+        self.assertEqual(self.face.person.cluster_owner, self.user)
+
+    def test_a_real_name_still_labels_a_clustered_face(self):
+        response = self._post("Bob")
+
+        self.assertEqual(response.status_code, 200)
+        self.face.refresh_from_db()
+        self.assertEqual(self.face.person.name, "Bob")
+        self.assertEqual(self.face.person.kind, Person.KIND_USER)

--- a/apps/backend/api/tests/sharing_and_public/test_public_photo_people_sharing.py
+++ b/apps/backend/api/tests/sharing_and_public/test_public_photo_people_sharing.py
@@ -133,13 +133,26 @@ class GetPeopleNameResolutionTestCase(TestCase):
 
         self.assertIsNone(entry["face_url"])
 
-    def test_deleted_faces_are_still_returned(self):
-        """QUIRK: ``obj.faces.all()`` is unfiltered - soft-deleted faces leak."""
+    def test_deleted_faces_are_not_returned(self):
+        """A soft-deleted face is hidden everywhere, this list included.
+
+        This replaces a characterization test that pinned the opposite as a
+        known quirk: ``obj.faces.all()`` used to be unfiltered, so a face the
+        owner had deleted came back on every shared copy of the photo.
+        """
         person = create_test_person(name="Ghost")
         create_test_face(photo=self.photo, person=person, deleted=True)
 
+        self.assertEqual(_people(self.photo, self.settings_on), [])
+
+    def test_deleted_face_does_not_hide_the_live_faces_beside_it(self):
+        create_test_face(
+            photo=self.photo, person=create_test_person(name="Ghost"), deleted=True
+        )
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+
         self.assertEqual(
-            [p["name"] for p in _people(self.photo, self.settings_on)], ["Ghost"]
+            [p["name"] for p in _people(self.photo, self.settings_on)], ["Alice"]
         )
 
     def test_photo_without_faces_returns_empty_list(self):

--- a/apps/backend/api/views/faces.py
+++ b/apps/backend/api/views/faces.py
@@ -1,5 +1,6 @@
 import uuid
 
+import PIL
 from django.conf import settings
 from django.db.models import (
     Case,
@@ -22,8 +23,9 @@ from rest_framework.views import APIView
 from api.directory_watcher import generate_face_embeddings, scan_faces
 from api.face_classify import cluster_all_faces
 from api.ml_models import do_all_models_exist, download_models
-from api.models import Face, User
+from api.models import Face, Photo, User
 from api.models.person import Person, get_or_create_person
+from api.models.photo import _overlaps_existing_face
 from api.models.photo_search import PhotoSearch
 from api.serializers.face import (
     FaceListSerializer,
@@ -33,6 +35,7 @@ from api.serializers.face import (
 from api.util import logger
 from api.views.custom_api_view import ListViewSet
 from api.views.pagination import RegularResultsSetPagination
+from api.views.photos import _get_photo_filter_kwargs
 
 
 class ScanFacesView(APIView):
@@ -434,6 +437,212 @@ class SetFacePersonLabel(APIView):
             unique_fields=["photo"],
         )
         PhotoSearch.objects.bulk_update(to_update, ["search_captions", "updated_at"])
+
+
+class AddFaceView(APIView):
+    """Create a face from a box the user drew on a photo.
+
+    Until now every Face row came from the detector or from an XMP region already
+    written into the file, so a face the detector missed could not be recorded at
+    all -- someone turned away from the camera, a child, a face behind a hat. This
+    is the manual way in.
+
+    The box arrives normalized to the displayed image (each side a fraction of the
+    width or height) because fractions are what the browser can measure. Face rows
+    store pixels in big-thumbnail space, and the big thumbnail is the image the
+    lightbox displays, so converting is a multiplication by the thumbnail's own
+    size -- no separate coordinate mapping is involved.
+
+    A manually added face is a user label: it gets ``person`` set with
+    ``KIND_USER`` and no cluster, so classification trains on it like any other
+    face the user named, but it never seeds a cluster of its own.
+    """
+
+    # A box smaller than this in big-thumbnail pixels is a stray drag, not a face.
+    MIN_SIDE_PIXELS = 12
+
+    def post(self, request, format=None):
+        person_name = (request.data.get("person_name") or "").strip()
+        if not person_name:
+            return self._error("person_name must not be empty")
+        if person_name == Person.UNKNOWN_PERSON_NAME:
+            return self._error(
+                "a face drawn by hand has to name someone; "
+                f"'{Person.UNKNOWN_PERSON_NAME}' is what the algorithms use"
+            )
+
+        photo_id = request.data.get("photo")
+        if not photo_id:
+            return self._error("photo is required")
+        photo = (
+            Photo.objects.filter(
+                owner=request.user, **_get_photo_filter_kwargs(str(photo_id))
+            )
+            .select_related(
+                "owner", "thumbnail", "main_file", "metadata", "caption_instance"
+            )
+            .prefetch_related("files", "faces__person")
+            .first()
+        )
+        if photo is None:
+            return Response(
+                {"status": False, "message": "photo not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        thumbnail_path = self._thumbnail_path(photo)
+        if thumbnail_path is None:
+            return self._error(
+                "this photo has no big thumbnail yet, so there is nothing to "
+                "measure the box against"
+            )
+
+        try:
+            big_thumbnail = PIL.Image.open(thumbnail_path)
+        except OSError:
+            logger.exception(f"Cannot open thumbnail for photo {photo.image_hash}")
+            return self._error("this photo's thumbnail cannot be read")
+
+        with big_thumbnail:
+            box, error = self._box_in_pixels(
+                request.data.get("box"), big_thumbnail.width, big_thumbnail.height
+            )
+            if error:
+                return self._error(error)
+            top, right, bottom, left = box
+
+            existing = photo.faces.filter(deleted=False).values_list(
+                "location_top", "location_right", "location_bottom", "location_left"
+            )
+            if _overlaps_existing_face(existing, top, right, bottom, left):
+                return Response(
+                    {
+                        "status": False,
+                        "message": "there is already a face here; label that one "
+                        "instead of adding a second face over it",
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            face_image = big_thumbnail.crop((left, top, right, bottom))
+            person = get_or_create_person(
+                name=person_name, owner=request.user, kind=Person.KIND_USER
+            )
+            face = photo._save_detected_face(
+                face_image,
+                f"{photo.image_hash}_manual_{uuid.uuid4().hex[:8]}.jpg",
+                person,
+                None,
+                (top, right, bottom, left),
+            )
+
+        # Without an encoding the face is still a valid label -- it just cannot be
+        # compared to anything yet. "Train faces" encodes faces that have none, so
+        # a face service that is down or disabled delays recognition rather than
+        # losing the user's work.
+        try:
+            face.generate_encoding()
+        except Exception:
+            logger.exception(
+                f"Could not encode manually added face {face.id}; "
+                "it will be encoded by the next face training run"
+            )
+
+        person._calculate_face_count()
+        person._set_default_cover_photo()
+
+        # The person's name is part of what the photo can be found by.
+        photo.refresh_from_db()
+        SetFacePersonLabel._recreate_search_captions([photo])
+
+        if request.user.save_face_tags_to_disk:
+            use_sidecar = (
+                request.user.save_metadata_to_disk == User.SaveMetadata.SIDECAR_FILE
+            )
+            try:
+                photo._save_metadata(
+                    use_sidecar=use_sidecar, metadata_types=["face_tags"]
+                )
+            except Exception:
+                logger.exception(
+                    f"Failed to write face tags for photo {photo.image_hash}"
+                )
+
+        return Response(
+            {
+                "status": True,
+                "face": {
+                    "face_id": face.id,
+                    "face_url": face.image.url,
+                    "person": person.id,
+                    "person_name": person.name,
+                    "location": {
+                        "top": top,
+                        "right": right,
+                        "bottom": bottom,
+                        "left": left,
+                    },
+                },
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+    @staticmethod
+    def _error(message):
+        return Response(
+            {"status": False, "message": message}, status=status.HTTP_400_BAD_REQUEST
+        )
+
+    @staticmethod
+    def _thumbnail_path(photo):
+        thumbnail = getattr(photo, "thumbnail", None)
+        if thumbnail is None or not thumbnail.thumbnail_big:
+            return None
+        try:
+            return thumbnail.thumbnail_big.path
+        except (ValueError, NotImplementedError):
+            return None
+
+    @classmethod
+    def _box_in_pixels(cls, box, width, height):
+        """Turn a normalized box into big-thumbnail pixels.
+
+        Returns ``((top, right, bottom, left), None)`` or ``(None, message)``.
+        """
+        if not isinstance(box, dict):
+            return None, "box is required, with top, right, bottom and left"
+
+        sides = {}
+        for side in ("top", "right", "bottom", "left"):
+            try:
+                sides[side] = float(box[side])
+            except (KeyError, TypeError, ValueError):
+                return None, f"box.{side} must be a number between 0 and 1"
+            if not 0 <= sides[side] <= 1:
+                return None, f"box.{side} must be between 0 and 1"
+
+        if sides["right"] <= sides["left"] or sides["bottom"] <= sides["top"]:
+            return None, "box must have a positive width and height"
+
+        top = int(round(sides["top"] * height))
+        bottom = int(round(sides["bottom"] * height))
+        left = int(round(sides["left"] * width))
+        right = int(round(sides["right"] * width))
+
+        # Rounding can collapse a thin box, and clamping keeps the crop inside the
+        # thumbnail even when the browser reports a box a fraction past the edge.
+        top = max(0, min(top, height - 1))
+        left = max(0, min(left, width - 1))
+        bottom = max(top + 1, min(bottom, height))
+        right = max(left + 1, min(right, width))
+
+        if right - left < cls.MIN_SIDE_PIXELS or bottom - top < cls.MIN_SIDE_PIXELS:
+            return None, (
+                f"the box is too small; each side has to be at least "
+                f"{cls.MIN_SIDE_PIXELS} pixels of the photo's big thumbnail"
+            )
+
+        return (top, right, bottom, left), None
 
 
 class DeleteFaces(APIView):

--- a/apps/backend/api/views/faces.py
+++ b/apps/backend/api/views/faces.py
@@ -274,9 +274,43 @@ class SetFacePersonLabel(APIView):
         person = None
         cluster_person = None
         classification_person = None
-        if data["person_name"] != Person.UNKNOWN_PERSON_NAME:
+        # Person.name carries a MinLengthValidator, but get_or_create() does not run
+        # field validators, so a blank name would quietly create a nameless person
+        # and an album to go with it. Surrounding whitespace is trimmed for the same
+        # reason: " Bob " would otherwise become a second person next to "Bob".
+        person_name = (data.get("person_name") or "").strip()
+        if not person_name:
+            return Response(
+                {"status": False, "message": "person_name must not be empty"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if person_name != Person.UNKNOWN_PERSON_NAME:
+            # A cluster's label is not a person's name. Clustering backs every
+            # unnamed cluster with a Person of kind CLUSTER called "Unknown NNN",
+            # and that label reaches the client in the same field a real name
+            # arrives in. get_or_create_person() looks a row up by
+            # (name, cluster_owner, kind), so asking for KIND_USER would not find
+            # the cluster: it would mint a *second* person with that name, of the
+            # kind that gets a person album and trains the classifier, and move
+            # the face onto it. The face dashboard has always hidden confirm for
+            # these kinds; the photo's own face list had not.
+            if Person.objects.filter(
+                name=person_name,
+                cluster_owner=self.request.user,
+                kind__in=(Person.KIND_CLUSTER, Person.KIND_UNKNOWN),
+            ).exists():
+                return Response(
+                    {
+                        "status": False,
+                        "message": (
+                            f'"{person_name}" is the label of a face cluster, not a '
+                            "person. Name the face instead of confirming the cluster."
+                        ),
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             person = get_or_create_person(
-                name=data["person_name"], owner=self.request.user, kind=Person.KIND_USER
+                name=person_name, owner=self.request.user, kind=Person.KIND_USER
             )
 
         # Everything the loop below touches is pulled in up front: the ownership

--- a/apps/backend/librephotos/urls.py
+++ b/apps/backend/librephotos/urls.py
@@ -239,6 +239,7 @@ urlpatterns = [
     re_path(r"^api/firsttimesetup", user.IsFirstTimeSetupView.as_view()),
     re_path(r"^api/dirtree", user.RootPathTreeView.as_view()),
     re_path(r"^api/labelfaces", faces.SetFacePersonLabel.as_view()),
+    re_path(r"^api/addface", faces.AddFaceView.as_view()),
     re_path(r"^api/deletefaces", faces.DeleteFaces.as_view()),
     re_path(r"^api/savemetadata", photos.SaveMetadataView.as_view()),
     re_path(r"^api/photosedit/delete", photos.DeletePhotos.as_view()),

--- a/apps/docs/docs/user-guide/face-recognition.md
+++ b/apps/docs/docs/user-guide/face-recognition.md
@@ -25,6 +25,14 @@ Note the second case: turning on **Write face tags to image files** is enough on
 
 To change a face to a new person, click on the green plus button. Search for the person you want it to change to and click on them. Now the face is associated with the new person.
 
+## Name a face from the photo itself
+
+You do not have to go through the face dashboard. Open a photo and look at the **People** section of the sidebar: it lists every face found in that photo, including the ones nothing has named yet. Hovering a row draws a box around that face on the photo, so you can tell which face a row belongs to.
+
+A face the clustering and classification have not matched to anyone is shown as **Who is this?**. Click the row (or the person-question button next to it) to open the same **Label faces** dialog the dashboard uses, and pick or create a person. Rows that carry a name the classification guessed also offer the green check-person button to confirm that guess, the orange person-off button to reject it, and the trashcan to remove a detection that is not a face at all.
+
+A row labelled **Unknown 001** (or a similar number) is a face that clustering grouped together with others like it, without anybody naming the group. That label is the group's name, not a person's, so there is nothing to confirm and no green check-person button — name such a row the same way you name a **Who is this?** one.
+
 ## Train faces
 
 If you click on the blue button (the barbell icon) in the face dashboard, or the **Train** button on the [Library page](./library.md) (avatar menu → **Library**, under **Faces & People**), the system will try to cluster unknown faces and will try to either match them to already known faces or create a new unknown person.

--- a/apps/docs/docs/user-guide/face-recognition.md
+++ b/apps/docs/docs/user-guide/face-recognition.md
@@ -33,6 +33,22 @@ A face the clustering and classification have not matched to anyone is shown as 
 
 A row labelled **Unknown 001** (or a similar number) is a face that clustering grouped together with others like it, without anybody naming the group. That label is the group's name, not a person's, so there is nothing to confirm and no green check-person button — name such a row the same way you name a **Who is this?** one.
 
+## Add a face the scan missed
+
+The detector does not find every face. Someone turned away from the camera, a child, a face behind a hat or sunglasses, a face too small or too blurred — none of those get a face record, so there is nothing to label and the person never appears on the photo.
+
+Open the photo, then click the green person-plus button at the top of the **People** section of the sidebar. The photo dims and the pointer becomes a crosshair: drag a box around the face, and the **Label faces** dialog opens so you can pick an existing person or type a new name. Press **Escape**, or use the **Cancel** button in the sidebar, to leave without adding anything.
+
+A few things worth knowing:
+
+- **The face you add counts as your own labelling.** It is stored exactly like a face you named on the dashboard, and classification trains on it, so adding a few faces the detector missed also helps it recognise that person elsewhere. It never starts a cluster of its own.
+- **It is encoded straight away** by the face recognition service. If that service is unavailable, the face is still saved with its name — the next **Train faces** run gives it an embedding.
+- **You cannot draw a second face on top of one that already exists.** If the box you drag lands on a face that is already recorded, LibrePhotos says so and asks you to label that face instead. A face you _deleted_ does not block you, though: drawing a box there is you overruling the deletion.
+- **Zoom and pan are fine, rotation is not.** You can zoom in to draw a box around a small face. While the photo is turned, the button is disabled — the box could not be lined up with the photo reliably — so turn it back upright first.
+- **The photo needs a thumbnail.** Boxes are measured against the photo's big thumbnail, so a photo that has not been fully processed yet cannot take a face.
+
+If **Settings → Face Options → Write face tags to image files** is enabled, a face you add by hand is written into the photo (or its sidecar) as an XMP region just like any other, so the work is portable to other photo managers.
+
 ## Train faces
 
 If you click on the blue button (the barbell icon) in the face dashboard, or the **Train** button on the [Library page](./library.md) (avatar menu → **Library**, under **Faces & People**), the system will try to cluster unknown faces and will try to either match them to already known faces or create a new unknown person.

--- a/apps/frontend/src/__repro__/issue_431.test.tsx
+++ b/apps/frontend/src/__repro__/issue_431.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Repro for https://github.com/LibrePhotos/librephotos/issues/431
+ * "Manually edit face/person tags in a photo"
+ *
+ * The lightbox sidebar already lists every face on the photo, unnamed ones
+ * included: PhotoSerializer.get_people returns them with `name: ""` and
+ * `type: ""`. That row is the only place in the product where a face the
+ * algorithms gave up on can be named -- but it rendered as a blank button with
+ * no label, and it offered the same buttons a *named* row gets:
+ *
+ *   - the green confirm posted `personName: ""` back to /api/labelfaces, which
+ *     created a person with no name (Person.name has a MinLengthValidator, but
+ *     get_or_create() does not run field validators) and a nameless person
+ *     album to go with it;
+ *   - clicking the row navigated to `/search/` with an empty query;
+ *   - "not this person" moved a face that had no person back to "unknown".
+ *
+ * Every unnamed row also keyed on `person.name`, so all of them collided on the
+ * same empty React key -- see PeopleSection.
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PersonDetail } from "../components/lightbox/PersonDetailComponent";
+import i18n from "../i18n";
+
+const stubs = vi.hoisted(() => ({
+  setFacesPersonLabel: vi.fn(),
+  deleteFaces: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("../api_client/apiClient", () => ({ serverAddress: "" }));
+vi.mock("../service/notifications", () => ({ notification: new Proxy({}, { get: () => () => {} }) }));
+vi.mock("../api_client/faces", () => ({
+  useSetFacesPersonLabelMutation: () => ({ mutate: stubs.setFacesPersonLabel }),
+  useDeleteFacesMutation: () => ({ mutate: stubs.deleteFaces }),
+  FacesTab: { enum: { inferred: "inferred", unknown: "unknown", labeled: "labeled" } },
+}));
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => stubs.navigate,
+  getRouteApi: () => ({ useSearch: () => ({ tab: "inferred" }) }),
+}));
+
+beforeAll(async () => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage("en");
+});
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  stubs.setFacesPersonLabel.mockReset();
+  stubs.deleteFaces.mockReset();
+  stubs.navigate.mockReset();
+});
+
+const unnamedFace = {
+  name: "",
+  type: "",
+  probability: 0,
+  location: { top: 10, bottom: 100, left: 20, right: 90 },
+  face_url: "/faces/1.jpg",
+  face_id: 1,
+};
+
+// Classification guessed a real person: confirming means "yes, that is Alice",
+// and the backend has an Alice to attach the face to.
+const inferredFace = { ...unnamedFace, name: "Alice", type: "classification", probability: 0.8, face_id: 2 };
+
+// Clustering only grouped the face with others like it. The label is the
+// cluster's own name -- every unnamed cluster is called "Unknown NNN" -- and
+// there is no person behind it to confirm the face onto.
+const clusterFace = { ...unnamedFace, name: "Unknown 001", type: "cluster", probability: 0.6, face_id: 3 };
+
+const onPersonEdit = vi.fn();
+
+async function renderRow(person: typeof unnamedFace) {
+  onPersonEdit.mockReset();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <PersonDetail
+          person={person}
+          isPublic={false}
+          setFaceLocation={() => {}}
+          onPersonEdit={onPersonEdit}
+          notThisPerson={() => {}}
+        />
+      </MantineProvider>
+    );
+  });
+  return container;
+}
+
+function buttons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll("button"));
+}
+
+async function clickAll(container: HTMLElement) {
+  for (const button of buttons(container)) {
+    await act(async () => {
+      button.click();
+    });
+  }
+}
+
+describe("an unnamed face in the lightbox sidebar", () => {
+  it("says it needs a name instead of rendering blank", async () => {
+    const container = await renderRow(unnamedFace);
+
+    expect(container.textContent).toContain("Who is this?");
+  });
+
+  it("offers no confirm button - there is no name to confirm", async () => {
+    const container = await renderRow(unnamedFace);
+
+    expect(container.querySelector(".tabler-icon-user-check")).toBeNull();
+    expect(container.querySelector(".tabler-icon-user-off")).toBeNull();
+  });
+
+  it("never posts an empty person name, whichever button is pressed", async () => {
+    const container = await renderRow(unnamedFace);
+
+    await clickAll(container);
+
+    const postedNames = stubs.setFacesPersonLabel.mock.calls.map(([args]) => args.personName);
+    expect(postedNames).not.toContain("");
+    expect(postedNames.every((name: string) => name?.trim())).toBe(true);
+  });
+
+  it("opens the person picker for the face instead of searching for nothing", async () => {
+    const container = await renderRow(unnamedFace);
+
+    await act(async () => {
+      buttons(container)[0].click();
+    });
+
+    expect(onPersonEdit).toHaveBeenCalledWith(unnamedFace.face_id, unnamedFace.face_url);
+    expect(stubs.navigate).not.toHaveBeenCalled();
+  });
+
+  it("can still be deleted, for a detection that is not a face at all", async () => {
+    const container = await renderRow(unnamedFace);
+
+    await clickAll(container);
+
+    expect(stubs.deleteFaces).toHaveBeenCalledWith({ faceIds: [unnamedFace.face_id] });
+  });
+});
+
+describe("a face the algorithms did name", () => {
+  it("shows the name and keeps its confirm button", async () => {
+    const container = await renderRow(inferredFace);
+
+    expect(container.textContent).toContain("Alice");
+    expect(container.querySelector(".tabler-icon-user-check")).not.toBeNull();
+  });
+
+  it("confirms under the inferred name", async () => {
+    const container = await renderRow(inferredFace);
+    const confirm = buttons(container).find(b => b.querySelector(".tabler-icon-user-check"))!;
+
+    await act(async () => {
+      confirm.click();
+    });
+
+    expect(stubs.setFacesPersonLabel).toHaveBeenCalledWith({
+      faceIds: [inferredFace.face_id],
+      personName: "Alice",
+    });
+  });
+
+  it("navigates to its person when the row is clicked", async () => {
+    const container = await renderRow(inferredFace);
+
+    await act(async () => {
+      buttons(container)[0].click();
+    });
+
+    expect(stubs.navigate).toHaveBeenCalledWith({ to: "/search/Alice" });
+  });
+});
+
+describe("a face that carries only a cluster's label", () => {
+  it("offers no confirm button - there is no person by that name to confirm it onto", async () => {
+    const container = await renderRow(clusterFace);
+
+    expect(container.textContent).toContain("Unknown 001");
+    expect(container.querySelector(".tabler-icon-user-check")).toBeNull();
+  });
+
+  it("never posts the cluster's label as a person name, whichever button is pressed", async () => {
+    const container = await renderRow(clusterFace);
+
+    await clickAll(container);
+
+    const postedNames = stubs.setFacesPersonLabel.mock.calls.map(([args]) => args.personName);
+    expect(postedNames).not.toContain("Unknown 001");
+  });
+
+  it("can still be named, through the person picker", async () => {
+    const container = await renderRow(clusterFace);
+    const edit = buttons(container).find(b => b.querySelector(".tabler-icon-edit"))!;
+
+    await act(async () => {
+      edit.click();
+    });
+
+    expect(onPersonEdit).toHaveBeenCalledWith(clusterFace.face_id, clusterFace.face_url);
+  });
+});

--- a/apps/frontend/src/api_client/faces/hooks/index.ts
+++ b/apps/frontend/src/api_client/faces/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./useSetFacesPersonLabelMutation";
+export * from "./useAddFaceMutation";
 export * from "./useTrainFacesMutation";
 export * from "./useDeleteFacesMutation";
 export * from "./useFetchIncompleteFacesQuery";

--- a/apps/frontend/src/api_client/faces/hooks/useAddFaceMutation.ts
+++ b/apps/frontend/src/api_client/faces/hooks/useAddFaceMutation.ts
@@ -1,0 +1,78 @@
+import { useMutation } from "@tanstack/react-query";
+import { z } from "zod";
+import { notification } from "../../../service/notifications";
+import { recordRecentlyTaggedPerson } from "../../../util/recentlyTaggedPeople";
+import { parseWithNotification } from "../../../util/zodUtils";
+import { PeopleAlbumsQueryKeys } from "../../albums/hooks/useFetchPeopleAlbumsQuery";
+import { fetchClient, queryClient } from "../../api";
+import { PhotoDetailsQueryKeys } from "../../photos/hooks/useFetchPhotoDetailsQuery";
+import { CountStatsQueryKeys } from "../../stats/hooks/useFetchCountStatsQuery";
+import { FacesQueryKeys } from "./useFetchFacesQuery";
+import { IncompleteFacesQueryKeys } from "./useFetchIncompleteFacesQuery";
+
+/** A box the user drew, each side a fraction of the displayed image. */
+export type NormalizedFaceBox = z.infer<typeof NormalizedFaceBox>;
+export const NormalizedFaceBox = z.object({
+  top: z.number(),
+  right: z.number(),
+  bottom: z.number(),
+  left: z.number(),
+});
+
+export type AddFaceRequest = z.infer<typeof AddFaceRequest>;
+export const AddFaceRequest = z.object({
+  photo: z.string(),
+  personName: z.string(),
+  box: NormalizedFaceBox,
+});
+
+export type AddFaceResponse = z.infer<typeof AddFaceResponse>;
+export const AddFaceResponse = z.object({
+  status: z.boolean(),
+  face: z.object({
+    face_id: z.number(),
+    face_url: z.string(),
+    person: z.number(),
+    person_name: z.string(),
+    // Pixels in big-thumbnail space, the way every other face reports its box.
+    location: z.object({
+      top: z.number(),
+      right: z.number(),
+      bottom: z.number(),
+      left: z.number(),
+    }),
+  }),
+});
+
+const addFace = (data: AddFaceRequest) =>
+  fetchClient
+    .post<AddFaceResponse>("/addface", {
+      photo: data.photo,
+      person_name: data.personName,
+      box: data.box,
+    })
+    .then(response => {
+      const payload = parseWithNotification(AddFaceResponse, response, "Failed to parse add face response");
+      notification.addFacesToPerson(payload.face.person_name, 1);
+      return payload;
+    });
+
+export const useAddFaceMutation = () =>
+  useMutation({
+    mutationFn: addFace,
+    onSuccess: data => {
+      // Drawing a box by hand is a tagging choice like any other, so it belongs
+      // in the recently-tagged shortcut list too.
+      recordRecentlyTaggedPerson(data.face.person);
+
+      // Same delay the other face mutations use, for the writes that follow the
+      // response (face count, cover photo, search captions).
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: IncompleteFacesQueryKeys });
+        queryClient.invalidateQueries({ queryKey: FacesQueryKeys });
+        queryClient.invalidateQueries({ queryKey: PeopleAlbumsQueryKeys });
+        queryClient.invalidateQueries({ queryKey: CountStatsQueryKeys });
+        queryClient.invalidateQueries({ queryKey: PhotoDetailsQueryKeys });
+      }, 100);
+    },
+  });

--- a/apps/frontend/src/components/lightbox/ContentViewer.tsx
+++ b/apps/frontend/src/components/lightbox/ContentViewer.tsx
@@ -5,9 +5,13 @@ import { useFullscreen, useHotkeys } from "@mantine/hooks";
 import { useGesture } from "@use-gesture/react";
 import { AnimatePresence, motion } from "motion/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAddFaceMutation } from "../../api_client/faces";
+import type { NormalizedFaceBox } from "../../api_client/faces/hooks/useAddFaceMutation";
 import { useFetchPhotoDetailsQuery } from "../../api_client/photos/hooks";
 import { useRotatePhotosMutation } from "../../api_client/photos/hooks/useRotatePhotosMutation";
 import { useCurrentUserSelfDetailsQuery } from "../../api_client/user/hooks";
+import { ModalPersonEdit } from "../modals/ModalPersonEdit";
 import { ImagePreloader } from "./ImagePreloader";
 import {
   NEXT_KEY,
@@ -53,6 +57,10 @@ export function ContentViewer({
   const [imageCacheKey, setImageCacheKey] = useState(0);
   // "Live text": overlay selectable OCR text on the photo
   const [showOcrText, setShowOcrText] = useState(false);
+  // Marking a face the detector missed: first the user drags a box over the
+  // photo, then names whoever is in it.
+  const [isDrawingFace, setIsDrawingFace] = useState(false);
+  const [drawnFaceBox, setDrawnFaceBox] = useState<NormalizedFaceBox | null>(null);
   // Tracks whether we should skip the rotation CSS transition on next render
   // (used to silently reset angle to 0 once the server-rotated image has loaded)
   const [suppressRotationTransition, setSuppressRotationTransition] = useState(false);
@@ -76,6 +84,44 @@ export function ContentViewer({
   // Use image_hash for API calls since backend still uses image_hash for lookup
   // Skip this query on public pages since we don't have authenticated access to photo details
   const { data: photoDetails, isLoading: isPhotoDetailsLoading } = useFetchPhotoDetailsQuery(mainSrcHash, isPublic);
+  const { t } = useTranslation();
+  const { mutate: addFace } = useAddFaceMutation();
+
+  // A drawn box is read against the layer's on-screen rect, which stays right
+  // through zoom and pan but not through rotation: the rect of a rotated
+  // rectangle is its bounding box, so the fractions would not line up.
+  const isRotated = rotationAngle % 360 !== 0;
+  const addFaceBlockedReason = isRotated ? t("lightbox.addface.rotated") : undefined;
+
+  const startDrawingFace = useCallback(() => {
+    setFaceLocation(null);
+    setIsDrawingFace(true);
+  }, []);
+
+  const cancelDrawingFace = useCallback(() => {
+    setIsDrawingFace(false);
+    setDrawnFaceBox(null);
+  }, []);
+
+  const handleFaceDrawn = useCallback((box: NormalizedFaceBox) => {
+    setIsDrawingFace(false);
+    setDrawnFaceBox(box);
+  }, []);
+
+  const handleFacePersonChosen = useCallback(
+    (personName: string) => {
+      if (!drawnFaceBox || !mainSrcHash) return;
+      addFace({ photo: mainSrcHash, personName, box: drawnFaceBox });
+      setDrawnFaceBox(null);
+    },
+    [addFace, drawnFaceBox, mainSrcHash]
+  );
+
+  // Leaving the photo mid-drag would otherwise land the box on the next one.
+  useEffect(() => {
+    setIsDrawingFace(false);
+    setDrawnFaceBox(null);
+  }, [mainSrcHash]);
 
   const rotatePhotos = useRotatePhotosMutation();
 
@@ -451,6 +497,9 @@ export function ContentViewer({
                         onImageLoad={handleImageLoad}
                         ocrBlocks={ocrBlocks ?? undefined}
                         showOcrText={showOcrText}
+                        drawingFace={isDrawingFace}
+                        onFaceDrawn={handleFaceDrawn}
+                        onCancelDrawFace={cancelDrawingFace}
                         {...(photoDetails ? { photoDetails } : {})}
                       />
                     </motion.div>
@@ -497,8 +546,19 @@ export function ContentViewer({
               publicAlbumSlug={publicAlbumSlug}
               setFaceLocation={setFaceLocation}
               onPhotoSelect={onPhotoSelect}
+              onAddFaceRequest={type === "photo" ? startDrawingFace : undefined}
+              onCancelAddFace={cancelDrawingFace}
+              isDrawingFace={isDrawingFace}
+              addFaceBlockedReason={addFaceBlockedReason}
             />
           )}
+          <ModalPersonEdit
+            isOpen={!!drawnFaceBox}
+            onRequestClose={cancelDrawingFace}
+            selectedFaces={[]}
+            prompt={t("lightbox.addface.whoisit")}
+            onPersonChosen={handleFacePersonChosen}
+          />
         </Modal.Body>
       </Modal.Content>
     </Modal.Root>

--- a/apps/frontend/src/components/lightbox/FaceDrawLayer.test.tsx
+++ b/apps/frontend/src/components/lightbox/FaceDrawLayer.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * The geometry behind marking a face the detector missed (issue #431).
+ *
+ * The layer reports a box as fractions of the image, which is the only thing
+ * the browser can measure and exactly what the backend needs: Face rows store
+ * pixels in big-thumbnail space, and multiplying a fraction by the thumbnail's
+ * own size gets there without a coordinate mapping.
+ */
+import { describe, expect, it } from "vitest";
+import { boxFromPoints, isBoxBigEnough } from "./FaceDrawLayer";
+
+describe("boxFromPoints", () => {
+  it("orders the sides however the drag went", () => {
+    const downRight = boxFromPoints({ x: 0.2, y: 0.3 }, { x: 0.6, y: 0.8 });
+    const upLeft = boxFromPoints({ x: 0.6, y: 0.8 }, { x: 0.2, y: 0.3 });
+
+    expect(downRight).toEqual({ top: 0.3, bottom: 0.8, left: 0.2, right: 0.6 });
+    expect(upLeft).toEqual(downRight);
+  });
+
+  it("keeps a drag that leaves the photo inside it", () => {
+    const box = boxFromPoints({ x: -0.4, y: -0.2 }, { x: 1.5, y: 1.9 });
+
+    expect(box).toEqual({ top: 0, bottom: 1, left: 0, right: 1 });
+  });
+});
+
+describe("isBoxBigEnough", () => {
+  it("rejects a click that did not really drag", () => {
+    expect(isBoxBigEnough(boxFromPoints({ x: 0.5, y: 0.5 }, { x: 0.5, y: 0.5 }))).toBe(false);
+    expect(isBoxBigEnough(boxFromPoints({ x: 0.5, y: 0.5 }, { x: 0.505, y: 0.505 }))).toBe(false);
+  });
+
+  it("rejects a drag that is wide but flat, or tall but thin", () => {
+    expect(isBoxBigEnough({ top: 0.5, bottom: 0.505, left: 0.1, right: 0.9 })).toBe(false);
+    expect(isBoxBigEnough({ top: 0.1, bottom: 0.9, left: 0.5, right: 0.505 })).toBe(false);
+  });
+
+  it("accepts a box that plausibly holds a face", () => {
+    expect(isBoxBigEnough({ top: 0.3, bottom: 0.6, left: 0.4, right: 0.55 })).toBe(true);
+  });
+});

--- a/apps/frontend/src/components/lightbox/FaceDrawLayer.tsx
+++ b/apps/frontend/src/components/lightbox/FaceDrawLayer.tsx
@@ -1,0 +1,147 @@
+import { Box } from "@mantine/core";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import type { NormalizedFaceBox } from "../../api_client/faces/hooks/useAddFaceMutation";
+
+type Props = {
+  /** Receives the drawn box with each side as a fraction of the image. */
+  onCommit: (box: NormalizedFaceBox) => void;
+  onCancel: () => void;
+};
+
+type Point = { x: number; y: number };
+
+/**
+ * A drag smaller than this fraction of the image is a stray click, not a face.
+ * The backend rejects boxes under a pixel floor as well; this only avoids
+ * bothering it (and the user) with an obvious miss.
+ */
+const MIN_SIDE_FRACTION = 0.02;
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+export function boxFromPoints(start: Point, end: Point): NormalizedFaceBox {
+  return {
+    top: clamp01(Math.min(start.y, end.y)),
+    bottom: clamp01(Math.max(start.y, end.y)),
+    left: clamp01(Math.min(start.x, end.x)),
+    right: clamp01(Math.max(start.x, end.x)),
+  };
+}
+
+export function isBoxBigEnough(box: NormalizedFaceBox): boolean {
+  return box.right - box.left >= MIN_SIDE_FRACTION && box.bottom - box.top >= MIN_SIDE_FRACTION;
+}
+
+/**
+ * Lets the user drag a rectangle over the photo to mark a face the detector
+ * missed.
+ *
+ * The layer is a sibling of the image inside the wrapper that matches the image
+ * exactly, and it carries the same transform, so a fraction of the layer is the
+ * same fraction of the image. Reading the pointer against the layer's own
+ * bounding rect therefore stays correct while the photo is zoomed or panned --
+ * the rect is the box as it ends up on screen. Rotation is the exception (the
+ * rect becomes the bounding box of a rotated rectangle), which is why the
+ * caller only mounts this while the photo is unrotated.
+ */
+export function FaceDrawLayer({ onCommit, onCancel }: Props) {
+  const layerRef = useRef<HTMLDivElement>(null);
+  const [start, setStart] = useState<Point | null>(null);
+  const [current, setCurrent] = useState<Point | null>(null);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onCancel]);
+
+  const pointOf = useCallback((event: React.PointerEvent): Point | null => {
+    const rect = layerRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0 || rect.height === 0) return null;
+    return {
+      x: (event.clientX - rect.left) / rect.width,
+      y: (event.clientY - rect.top) / rect.height,
+    };
+  }, []);
+
+  // The photo sits inside a carousel and a drag-to-pan handler, both of which
+  // would rather treat this drag as a swipe.
+  const swallow = (event: React.PointerEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+  };
+
+  const handlePointerDown = (event: React.PointerEvent) => {
+    if (event.button !== 0 && event.pointerType === "mouse") return;
+    swallow(event);
+    const point = pointOf(event);
+    if (!point) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setStart(point);
+    setCurrent(point);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent) => {
+    if (!start) return;
+    swallow(event);
+    const point = pointOf(event);
+    if (point) setCurrent(point);
+  };
+
+  const handlePointerUp = (event: React.PointerEvent) => {
+    if (!start) return;
+    swallow(event);
+    const end = pointOf(event) ?? current;
+    setStart(null);
+    setCurrent(null);
+    if (!end) return;
+    const box = boxFromPoints(start, end);
+    if (isBoxBigEnough(box)) {
+      onCommit(box);
+    }
+  };
+
+  const rubberBand = start && current ? boxFromPoints(start, current) : null;
+
+  return (
+    <Box
+      ref={layerRef}
+      data-testid="face-draw-layer"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      style={{
+        position: "absolute",
+        inset: 0,
+        cursor: "crosshair",
+        touchAction: "none",
+        borderRadius: 8,
+        // Dim the photo a little so it is obvious the click does something else
+        // than usual right now.
+        backgroundColor: "rgba(0, 0, 0, 0.25)",
+      }}
+    >
+      {rubberBand && (
+        <Box
+          style={theme => ({
+            position: "absolute",
+            top: `${rubberBand.top * 100}%`,
+            left: `${rubberBand.left * 100}%`,
+            width: `${(rubberBand.right - rubberBand.left) * 100}%`,
+            height: `${(rubberBand.bottom - rubberBand.top) * 100}%`,
+            border: `2px solid ${theme.colors.blue[4]}`,
+            borderRadius: theme.radius.sm,
+            backgroundColor: "rgba(255, 255, 255, 0.12)",
+            pointerEvents: "none",
+          })}
+        />
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/lightbox/MediaDisplay.tsx
+++ b/apps/frontend/src/components/lightbox/MediaDisplay.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { serverAddress } from "../../api_client/apiClient";
+import type { NormalizedFaceBox } from "../../api_client/faces/hooks/useAddFaceMutation";
 import type { PhotoOcrBlock } from "../../api_client/photos/types";
+import { FaceDrawLayer } from "./FaceDrawLayer";
 import { FaceOverlay } from "./FaceOverlay";
 import type { FaceLocationType } from "./lightbox.types";
 import { OcrTextOverlay } from "./OcrTextOverlay";
@@ -27,6 +29,10 @@ export type MediaDisplayProps = {
   onImageLoad?: () => void;
   ocrBlocks?: PhotoOcrBlock[];
   showOcrText?: boolean;
+  /** Marking a face the detector missed: the photo becomes a drawing surface. */
+  drawingFace?: boolean;
+  onFaceDrawn?: (box: NormalizedFaceBox) => void;
+  onCancelDrawFace?: () => void;
 };
 
 export function MediaDisplay({
@@ -50,6 +56,9 @@ export function MediaDisplay({
   onImageLoad,
   ocrBlocks,
   showOcrText = false,
+  drawingFace = false,
+  onFaceDrawn,
+  onCancelDrawFace,
 }: MediaDisplayProps) {
   const imgRef = useRef<HTMLImageElement | null>(null);
   // Natural pixel size of the loaded image; drives the OCR overlay's aspect
@@ -176,7 +185,22 @@ export function MediaDisplay({
             <OcrTextOverlay blocks={ocrBlocks} aspectRatio={naturalSize.height / naturalSize.width} />
           </div>
         )}
-        {isMainContent && faceLocation && <FaceOverlay faceLocation={faceLocation} imageDimensions={imageDimensions} />}
+        {isMainContent && faceLocation && !drawingFace && (
+          <FaceOverlay faceLocation={faceLocation} imageDimensions={imageDimensions} />
+        )}
+        {isMainContent && drawingFace && onFaceDrawn && onCancelDrawFace && (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              transition: mainTransition,
+              transform: mainTransform,
+              willChange: "transform",
+            }}
+          >
+            <FaceDrawLayer onCommit={onFaceDrawn} onCancel={onCancelDrawFace} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/lightbox/PeopleSection.test.tsx
+++ b/apps/frontend/src/components/lightbox/PeopleSection.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The way into manual face tagging (issue #431).
+ *
+ * The People section is where a face gets named, so it is also where a face the
+ * detector never found has to be addable -- which is exactly the case where the
+ * section used to render nothing at all, because it bailed out on an empty list.
+ */
+import "@mantine/core/styles.css";
+import { MantineProvider } from "@mantine/core";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../i18n";
+import { PeopleSection } from "./PeopleSection";
+
+vi.mock("../../api_client/apiClient", () => ({ serverAddress: "" }));
+vi.mock("../../service/notifications", () => ({ notification: new Proxy({}, { get: () => () => {} }) }));
+vi.mock("../../api_client/faces", () => ({
+  useSetFacesPersonLabelMutation: () => ({ mutate: vi.fn() }),
+  useDeleteFacesMutation: () => ({ mutate: vi.fn() }),
+  FacesTab: { enum: { inferred: "inferred", unknown: "unknown", labeled: "labeled" } },
+}));
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+  getRouteApi: () => ({ useSearch: () => ({ tab: "inferred" }) }),
+}));
+
+const onAddFaceRequest = vi.fn();
+const onCancelAddFace = vi.fn();
+
+beforeAll(async () => {
+  // @ts-ignore - jsdom has no matchMedia, MantineProvider needs it
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+  // @ts-ignore
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  await i18n.changeLanguage("en");
+});
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  onAddFaceRequest.mockReset();
+  onCancelAddFace.mockReset();
+});
+
+async function renderSection(overrides: Record<string, unknown> = {}, people: unknown[] = []) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MantineProvider>
+        <PeopleSection
+          photoDetail={{ people } as any}
+          isPublic={false}
+          setFaceLocation={() => {}}
+          onPersonEdit={() => {}}
+          notThisPerson={() => {}}
+          onAddFaceRequest={onAddFaceRequest}
+          onCancelAddFace={onCancelAddFace}
+          {...overrides}
+        />
+      </MantineProvider>
+    );
+  });
+  return container;
+}
+
+function addButton(container: HTMLElement): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(button =>
+    button.querySelector(".tabler-icon-user-plus")
+  ) as HTMLButtonElement | undefined;
+}
+
+describe("adding a face the scan missed", () => {
+  it("offers the add button on a photo with no faces at all", async () => {
+    const container = await renderSection();
+
+    expect(addButton(container)).toBeDefined();
+    expect(container.textContent).toContain("No faces were found in this photo");
+  });
+
+  it("asks for the box when the button is pressed", async () => {
+    const container = await renderSection();
+
+    await act(async () => {
+      addButton(container)!.click();
+    });
+
+    expect(onAddFaceRequest).toHaveBeenCalledOnce();
+  });
+
+  it("explains the drag and offers a way out while drawing", async () => {
+    const container = await renderSection({ isDrawingFace: true });
+
+    expect(container.textContent).toContain("Drag a box around the face");
+    expect(addButton(container)).toBeUndefined();
+
+    const cancel = Array.from(container.querySelectorAll("button")).find(b => b.textContent === "Cancel")!;
+    await act(async () => {
+      cancel.click();
+    });
+
+    expect(onCancelAddFace).toHaveBeenCalledOnce();
+  });
+
+  it("disables the button when the photo is turned, where a drawn box would not line up", async () => {
+    const container = await renderSection({ addFaceBlockedReason: "Turn the photo back upright to add a face" });
+
+    expect(addButton(container)!.disabled).toBe(true);
+  });
+
+  it("does not offer it on someone else's shared photo", async () => {
+    const container = await renderSection({ isPublic: true });
+
+    expect(addButton(container)).toBeUndefined();
+  });
+
+  it("renders nothing at all when there is neither a face nor a way to add one", async () => {
+    const container = await renderSection({ onAddFaceRequest: undefined });
+
+    // MantineProvider drops a responsive style block in here, so look for the
+    // section's own content rather than an empty container.
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector("h4")).toBeNull();
+    expect(container.textContent).not.toContain("No faces were found");
+  });
+});

--- a/apps/frontend/src/components/lightbox/PeopleSection.tsx
+++ b/apps/frontend/src/components/lightbox/PeopleSection.tsx
@@ -1,5 +1,5 @@
-import { Group, Title } from "@mantine/core";
-import { IconUsers } from "@tabler/icons-react";
+import { ActionIcon, Alert, Button, Group, Text, Title, Tooltip } from "@mantine/core";
+import { IconUserPlus, IconUsers } from "@tabler/icons-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Photo as PhotoType } from "../../api_client/photos/types";
@@ -12,6 +12,12 @@ interface PeopleSectionProps {
   setFaceLocation: (face: { face_id: number; face_url: string }) => void;
   onPersonEdit: (faceId: string, faceUrl: string) => void;
   notThisPerson: (faceId: number) => void;
+  /** Absent when adding a face is not available, e.g. on a shared photo. */
+  onAddFaceRequest?: () => void;
+  onCancelAddFace?: () => void;
+  isDrawingFace?: boolean;
+  /** Why the photo cannot be drawn on right now, if it cannot. */
+  addFaceBlockedReason?: string;
 }
 
 export function PeopleSection({
@@ -21,21 +27,59 @@ export function PeopleSection({
   setFaceLocation,
   onPersonEdit,
   notThisPerson,
+  onAddFaceRequest,
+  onCancelAddFace,
+  isDrawingFace = false,
+  addFaceBlockedReason,
 }: PeopleSectionProps) {
   const { t } = useTranslation();
 
-  if (!photoDetail.people || photoDetail.people.length === 0) return null;
+  const people = photoDetail.people ?? [];
+  const canAddFace = !isPublic && !!onAddFaceRequest;
+
+  // Without the add button there is nothing to show for a photo with no faces,
+  // but with it this section is the way to record a face the detector missed --
+  // which is exactly the case where the list is empty.
+  if (people.length === 0 && !canAddFace) return null;
 
   return (
     <div>
       {showTitle && (
-        <Group>
-          <IconUsers />
-          <Title order={4}>{t("lightbox.sidebar.people", "People")}</Title>
+        <Group justify="space-between">
+          <Group>
+            <IconUsers />
+            <Title order={4}>{t("lightbox.sidebar.people", "People")}</Title>
+          </Group>
+          {canAddFace && !isDrawingFace && (
+            <Tooltip label={addFaceBlockedReason ?? t("lightbox.addface.tooltip")}>
+              <ActionIcon
+                variant="light"
+                color="green"
+                aria-label={t("lightbox.addface.tooltip")}
+                disabled={!!addFaceBlockedReason}
+                onClick={onAddFaceRequest}
+              >
+                <IconUserPlus />
+              </ActionIcon>
+            </Tooltip>
+          )}
         </Group>
       )}
+      {isDrawingFace && (
+        <Alert mt="xs" color="blue" title={t("lightbox.addface.drawtitle")}>
+          <Text size="sm">{t("lightbox.addface.drawhint")}</Text>
+          <Button mt="xs" size="xs" variant="light" onClick={onCancelAddFace}>
+            {t("cancel")}
+          </Button>
+        </Alert>
+      )}
+      {people.length === 0 && !isDrawingFace && (
+        <Text mt="xs" size="sm" c="dimmed">
+          {t("lightbox.addface.nofaces")}
+        </Text>
+      )}
       <Group mt="xs">
-        {photoDetail.people.map(person => (
+        {people.map(person => (
           <PersonDetail
             key={person.face_id}
             person={person}

--- a/apps/frontend/src/components/lightbox/PeopleSection.tsx
+++ b/apps/frontend/src/components/lightbox/PeopleSection.tsx
@@ -37,7 +37,7 @@ export function PeopleSection({
       <Group mt="xs">
         {photoDetail.people.map(person => (
           <PersonDetail
-            key={person.name}
+            key={person.face_id}
             person={person}
             isPublic={isPublic}
             setFaceLocation={setFaceLocation}

--- a/apps/frontend/src/components/lightbox/PersonDetailComponent.tsx
+++ b/apps/frontend/src/components/lightbox/PersonDetailComponent.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Avatar, Button, Group, Indicator, Text, Tooltip } from "@mantine/core";
-import { IconEdit, IconTrash, IconUserCheck, IconUserOff } from "@tabler/icons-react";
+import { IconEdit, IconTrash, IconUserCheck, IconUserOff, IconUserQuestion } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -24,11 +24,25 @@ export function PersonDetail({ person, isPublic, setFaceLocation, onPersonEdit, 
   const { mutate: deleteFaces } = useDeleteFacesMutation();
   const navigate = useNavigate();
 
+  // A face nobody has named yet, and that neither clustering nor classification
+  // guessed a name for. It still belongs in this list -- it is the only place
+  // where a face the algorithms gave up on can be named -- but it has no name to
+  // show, no confidence to explain, and nothing to confirm or reject.
+  const isUnnamed = !person.name;
+
+  // A cluster row's label is the cluster's own name -- clustering calls every
+  // unnamed cluster "Unknown 001" and so on -- not the name of whoever is in the
+  // photo. Confirming it asks the backend for a *person* by that name, which is
+  // not a person anyone has. The face dashboard has always hidden confirm for
+  // CLUSTER and UNKNOWN kinds; this is the same row seen from the photo.
+  const isClusterLabel = person.type === "cluster";
+
+  const openPersonPicker = () => onPersonEdit(person.face_id, person.face_url);
+
   return (
     <Group
       align="center"
       gap="xs"
-      key={person.name}
       onMouseEnter={() => setFaceLocation(person.location)}
       onMouseLeave={() => setFaceLocation(null)}
     >
@@ -40,8 +54,8 @@ export function PersonDetail({ person, isPublic, setFaceLocation, onPersonEdit, 
           <FaceTooltip tooltipOpened={tooltipOpened} probability={person.probability}>
             <Indicator
               color={calculateProbabiltyColor(person.probability)}
-              disabled={person.type === "user"}
-              onMouseEnter={() => person.type !== "user" && setTooltipOpened(true)}
+              disabled={person.type === "user" || isUnnamed}
+              onMouseEnter={() => person.type !== "user" && !isUnnamed && setTooltipOpened(true)}
               onMouseLeave={() => setTooltipOpened(false)}
               size={12}
               offset={4}
@@ -50,11 +64,22 @@ export function PersonDetail({ person, isPublic, setFaceLocation, onPersonEdit, 
             </Indicator>
           </FaceTooltip>
         }
-        onClick={() => !isPublic && navigate({ to: `/search/${person.name}` })}
+        // An unnamed face has no person album and no search term to navigate to,
+        // so the whole row is the affordance for naming it instead.
+        onClick={() => {
+          if (isPublic) return;
+          if (isUnnamed) {
+            openPersonPicker();
+          } else {
+            navigate({ to: `/search/${person.name}` });
+          }
+        }}
       >
-        <Text size="sm">{person.name}</Text>
+        <Text size="sm" c={isUnnamed ? "dimmed" : undefined} fs={isUnnamed ? "italic" : undefined}>
+          {isUnnamed ? t("lightbox.sidebar.unnamedface") : person.name}
+        </Text>
       </Button>
-      {!isPublic && person.type !== "user" && (
+      {!isPublic && !isUnnamed && !isClusterLabel && person.type !== "user" && (
         <Tooltip label={t("facesdashboard.explanationadding")}>
           <ActionIcon
             onClick={() => setFacesPersonLabel({ faceIds: [person.face_id], personName: person.name })}
@@ -66,13 +91,13 @@ export function PersonDetail({ person, isPublic, setFaceLocation, onPersonEdit, 
         </Tooltip>
       )}
       {!isPublic && (
-        <Tooltip label={t("facesdashboard.explanationadding")}>
-          <ActionIcon onClick={() => onPersonEdit(person.face_id, person.face_url)} variant="light">
-            <IconEdit />
+        <Tooltip label={isUnnamed ? t("lightbox.sidebar.nameface") : t("facesdashboard.explanationadding")}>
+          <ActionIcon onClick={openPersonPicker} variant={isUnnamed ? "filled" : "light"}>
+            {isUnnamed ? <IconUserQuestion /> : <IconEdit />}
           </ActionIcon>
         </Tooltip>
       )}
-      {!isPublic && (
+      {!isPublic && !isUnnamed && (
         <Tooltip label={t("facesdashboard.notthisperson")}>
           <ActionIcon variant="light" color="orange" onClick={() => notThisPerson(person.face_id)}>
             <IconUserOff />

--- a/apps/frontend/src/components/lightbox/Sidebar.tsx
+++ b/apps/frontend/src/components/lightbox/Sidebar.tsx
@@ -34,6 +34,11 @@ interface SidebarProps {
   closeSidepanel: () => void;
   setFaceLocation: (face: { face_id: number; face_url: string }) => void;
   onPhotoSelect?: (photoId: string) => void;
+  /** Marking a face the detector missed happens on the photo, which the viewer owns. */
+  onAddFaceRequest?: () => void;
+  onCancelAddFace?: () => void;
+  isDrawingFace?: boolean;
+  addFaceBlockedReason?: string;
 }
 
 interface SelectedFace {
@@ -73,6 +78,10 @@ export function Sidebar({
   setFaceLocation,
   id,
   onPhotoSelect,
+  onAddFaceRequest,
+  onCancelAddFace,
+  isDrawingFace,
+  addFaceBlockedReason,
 }: SidebarProps) {
   const [personEditOpen, setPersonEditOpen] = useState(false);
   const [selectedFaces, setSelectedFaces] = useState<SelectedFace[]>([]);
@@ -261,6 +270,10 @@ export function Sidebar({
           setFaceLocation={setFaceLocation}
           onPersonEdit={handlePersonEdit}
           notThisPerson={notThisPerson}
+          onAddFaceRequest={onAddFaceRequest}
+          onCancelAddFace={onCancelAddFace}
+          isDrawingFace={isDrawingFace}
+          addFaceBlockedReason={addFaceBlockedReason}
         />
         <Description photoDetail={photoDetail} isPublic={isPublic} />
         {/* Tags and keywords stay owner-only: public shares have no flag for them. */}

--- a/apps/frontend/src/components/modals/ModalPersonEdit.tsx
+++ b/apps/frontend/src/components/modals/ModalPersonEdit.tsx
@@ -28,6 +28,14 @@ type Props = Readonly<{
   onRequestClose: () => void;
   resetGroups?: () => void;
   selectedFaces: any[];
+  /**
+   * Takes over what picking a person does. The dialog is also used for a face
+   * that does not exist yet -- a box the user just drew -- where there is no
+   * face id to label and the caller creates the face instead.
+   */
+  onPersonChosen?: (personName: string) => void;
+  /** Replaces the "n selected" line when the dialog is not acting on a selection. */
+  prompt?: string;
 }>;
 
 type PersonRowProps = Readonly<{
@@ -69,7 +77,14 @@ function PersonRow({ person, onSelect }: PersonRowProps) {
   );
 }
 
-export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGroups = () => {} }: Props) {
+export function ModalPersonEdit({
+  isOpen,
+  onRequestClose,
+  selectedFaces,
+  resetGroups = () => {},
+  onPersonChosen,
+  prompt,
+}: Props) {
   const [newPersonName, setNewPersonName] = useState("");
   const matches = useMediaQuery("(min-width: 700px)");
   const { data: people } = useFetchPeopleAlbumsQuery();
@@ -94,10 +109,18 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
     return people?.map(person => person.name.toLowerCase().trim()).includes(name.toLowerCase().trim());
   }
 
-  function labelSelectedFacesAs(person: Person) {
-    setFacesPersonLabel({ faceIds: selectedFaceIDs, personName: person.name });
+  function applyPersonName(personName: string) {
+    if (onPersonChosen) {
+      onPersonChosen(personName);
+    } else {
+      setFacesPersonLabel({ faceIds: selectedFaceIDs, personName });
+    }
     onRequestClose();
     setNewPersonName("");
+  }
+
+  function labelSelectedFacesAs(person: Person) {
+    applyPersonName(person.name);
   }
 
   return (
@@ -112,17 +135,20 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
     >
       <Stack>
         <Text c="dimmed">
-          {t("personedit.numberselected", {
-            number: selectedFaces.length,
-          })}
+          {prompt ??
+            t("personedit.numberselected", {
+              number: selectedFaces.length,
+            })}
         </Text>
-        <ScrollArea style={{ height: 50 }}>
-          <Group>
-            {selectedImageIDs.map(image => (
-              <Avatar key={`selected_image${image}`} size={40} src={`${serverAddress}${image}`} radius="xl" />
-            ))}
-          </Group>
-        </ScrollArea>
+        {selectedImageIDs.length > 0 && (
+          <ScrollArea style={{ height: 50 }}>
+            <Group>
+              {selectedImageIDs.map(image => (
+                <Avatar key={`selected_image${image}`} size={40} src={`${serverAddress}${image}`} radius="xl" />
+              ))}
+            </Group>
+          </ScrollArea>
+        )}
 
         <Divider />
         <Title order={5}>{t("personedit.newperson")}</Title>
@@ -139,12 +165,10 @@ export function ModalPersonEdit({ isOpen, onRequestClose, selectedFaces, resetGr
           />
           <Button
             onClick={() => {
-              setFacesPersonLabel({ faceIds: selectedFaceIDs, personName: newPersonName });
+              applyPersonName(newPersonName.trim());
               if (resetGroups) {
                 resetGroups();
               }
-              onRequestClose();
-              setNewPersonName("");
             }}
             disabled={personExist(newPersonName) || newPersonName.trim().length === 0}
             type="submit"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -533,6 +533,14 @@
       "tagsSaveFailed": "The tags could not be saved. Please try again.",
       "save": "Save"
     },
+    "addface": {
+      "tooltip": "Add a face the scan missed",
+      "drawtitle": "Drag a box around the face",
+      "drawhint": "Drag across the photo to draw a box around the face, then say who it is. Press Escape to stop.",
+      "whoisit": "Who is in the box you drew?",
+      "nofaces": "No faces were found in this photo. If there is one, you can add it yourself.",
+      "rotated": "Turn the photo back upright to add a face"
+    },
     "controls": {
       "fullscreen": "Fullscreen (G)",
       "exitfullscreen": "Exit Fullscreen (G)",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -497,6 +497,8 @@
       "location": "Location",
       "caption": "Caption",
       "people": "People",
+      "unnamedface": "Who is this?",
+      "nameface": "Name this face",
       "submit": "Submit",
       "generate": "Generate",
       "cancel": "Cancel",


### PR DESCRIPTION
Depends on #2004 — this branch is stacked on it, so the diff here includes that commit until it merges. Review #2004 first.

Until now every face record came from the detector or from an XMP region already written into the file, so a face the detector missed could not be recorded at all — someone turned away from the camera, a child, a face behind a hat, a face too small or too blurred. There was nothing to label, so that person simply did not exist on the photo, and the only recourse was a full re-scan that would miss the face again.

The green person-plus button at the top of the People section turns the photo into a drawing surface: drag a box around the face, and the same Label faces dialog the rest of the app uses opens to name whoever is in it. It reuses the dialog's recently-tagged shortcuts, its fuzzy search and its create-a-person field, so the picking half of the flow behaves exactly as it does everywhere else. Escape or the sidebar's Cancel button leaves without adding anything.

The box travels as fractions of the displayed image, which is what a browser can measure. Face rows store pixels in big-thumbnail space, and the lightbox displays the big thumbnail, so the backend converts by multiplying by the thumbnail's own size — there is no separate coordinate mapping to keep in step. The drawing layer sits inside the wrapper that matches the image exactly and carries the same transform as the OCR text overlay, so drawing keeps working while the photo is zoomed or panned. Rotation is the one case it cannot serve — the bounding rect of a rotated rectangle is not the rectangle — so the button is disabled with an explanation while the photo is turned.

A hand-drawn face is the user's own label: it gets a person with kind `USER` and no cluster, so classification trains on it like any other named face but it never seeds a cluster. It is encoded through the existing face service, and a service that is down or disabled costs the encoding rather than the label — the next Train faces run gives it an embedding, which is the same path a face with no embedding already takes. Writing face tags to disk, the person's face count and cover photo, and the photo's search captions are all updated the way labelling an existing face updates them, so a name added this way is immediately searchable.

Drawing over a face that already exists is refused with a message pointing at it, since relabelling that face is the thing the user actually wants. A face that was *deleted* does not block the region: a re-scan must not resurrect it, but a box drawn by hand is the user overruling that, which is the other half of what #431 asked for.

The People section previously rendered nothing when a photo had no faces, which is exactly the case where adding one matters, so it now shows the empty state and the button. It stays hidden on shared photos and for videos.

Large and small libraries are unaffected either way: this adds one face row per deliberate user action, and the endpoint touches only the photo it was given.

Verified with the backend and frontend suites, `tsc` at its baseline count, and a docs build, plus a run against the real face service to confirm a hand-drawn box comes back with a 512-dimension ArcFace embedding. Also driven in a browser on a real library: two faces the detector had missed were drawn and named, including one with a non-Latin name, and both came back encoded and searchable.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
