### PR TITLE
fix: count inferred faces, not person number one's faces

### DIFF
--- a/apps/backend/api/stats.py
+++ b/apps/backend/api/stats.py
@@ -241,8 +241,13 @@ def get_count_stats(user):
     num_labeled_faces = Face.objects.filter(
         Q(person__isnull=False) & Q(photo__owner=user) & Q(photo__hidden=False)
     ).count()
+    # The faces the user has not labelled -- the complement of
+    # num_labeled_faces above, and what the face dashboard shows under its
+    # Inferred tab, where every branch pairs its cluster or classification
+    # guess with person=None. This read Q(person=True), which Django resolves
+    # as a primary key: it counted the faces of person number 1.
     num_inferred_faces = Face.objects.filter(
-        Q(person=True) & Q(photo__owner=user) & Q(photo__hidden=False)
+        Q(person__isnull=True) & Q(photo__owner=user) & Q(photo__hidden=False)
     ).count()
     num_people = (
         Person.objects.filter(

--- a/apps/backend/api/tests/stats/test_count_stats_inferred_faces.py
+++ b/apps/backend/api/tests/stats/test_count_stats_inferred_faces.py
@@ -1,0 +1,106 @@
+"""Tests for the ``num_inferred_faces`` count in ``api.stats.get_count_stats``.
+
+The filter read ``Q(person=True)``. Django resolves a boolean given to a
+ForeignKey lookup as a primary key, so ``person=True`` becomes ``person_id=1``:
+the statistic reported "faces belonging to person number 1" rather than faces
+whose person was inferred. Sitting one line below ``num_labeled_faces``, which
+counts ``person__isnull=False``, the intended meaning is that count's
+complement - the faces the user has not labelled, the ones the face dashboard
+offers under its Inferred tab, where every branch pairs the cluster or
+classification guess with ``person=None``.
+
+The figure is shown to the user in the hover card on the people/faces card,
+next to Labeled and Unknown.
+"""
+
+from django.test import TestCase
+
+from api.models import Person
+from api.stats import get_count_stats
+from api.tests.utils import (
+    create_test_face,
+    create_test_person,
+    create_test_photo,
+    create_test_user,
+)
+
+
+class CountStatsInferredFacesTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.photo = create_test_photo(owner=self.user)
+
+    def test_an_unlabelled_face_is_inferred(self):
+        create_test_face(photo=self.photo, person=None)
+
+        self.assertEqual(get_count_stats(self.user)["num_inferred_faces"], 1)
+
+    def test_a_labelled_face_is_not_inferred(self):
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+
+        self.assertEqual(get_count_stats(self.user)["num_inferred_faces"], 0)
+
+    def test_the_count_is_not_person_number_ones_face_count(self):
+        """The bug in its own right.
+
+        ``person=True`` resolves to ``person_id=1``, so the faces of whichever
+        person happens to hold primary key 1 were reported as inferred - and the
+        genuinely unlabelled faces were not counted at all. Person 1 is created
+        explicitly here so the arrangement does not depend on insertion order.
+        """
+        person_one = create_test_person(name="Alice", id=1)
+        self.assertEqual(person_one.pk, 1, "this test needs to own primary key 1")
+        create_test_face(photo=self.photo, person=person_one)
+        create_test_face(photo=self.photo, person=None)
+        create_test_face(photo=self.photo, person=None)
+
+        stats = get_count_stats(self.user)
+
+        self.assertEqual(stats["num_inferred_faces"], 2)
+        self.assertEqual(stats["num_labeled_faces"], 1)
+
+    def test_inferred_and_labelled_account_for_every_visible_face(self):
+        """The hover card shows these two side by side, so they must partition
+        the faces on the owner's visible photos rather than overlap or leave a
+        gap."""
+        create_test_face(photo=self.photo, person=create_test_person(name="Alice"))
+        create_test_face(photo=self.photo, person=None)
+        create_test_face(
+            photo=self.photo,
+            person=None,
+            cluster_person=create_test_person(
+                name="Unknown 001", kind=Person.KIND_CLUSTER, cluster_owner=self.user
+            ),
+        )
+
+        stats = get_count_stats(self.user)
+
+        self.assertEqual(
+            stats["num_inferred_faces"] + stats["num_labeled_faces"],
+            stats["num_faces"],
+        )
+
+    def test_a_face_on_a_hidden_photo_is_not_counted(self):
+        """``num_labeled_faces`` excludes hidden photos; this must match."""
+        hidden = create_test_photo(owner=self.user, hidden=True)
+        create_test_face(photo=hidden, person=None)
+
+        self.assertEqual(get_count_stats(self.user)["num_inferred_faces"], 0)
+
+    def test_another_users_unlabelled_face_is_not_counted(self):
+        stranger = create_test_user()
+        create_test_face(photo=create_test_photo(owner=stranger), person=None)
+
+        self.assertEqual(get_count_stats(self.user)["num_inferred_faces"], 0)
+
+    def test_a_deleted_face_the_user_never_labelled_still_counts_once(self):
+        """Pins current behaviour rather than asking for a change: none of the
+        face counts in this dict filter on ``deleted``, so a deleted face is
+        still part of ``num_faces`` and stays part of this count too. Changing
+        that belongs with a change to the whole group."""
+        create_test_face(photo=self.photo, person=None, deleted=True)
+
+        stats = get_count_stats(self.user)
+
+        self.assertEqual(stats["num_inferred_faces"], 1)
+        self.assertEqual(stats["num_faces"], 1)


### PR DESCRIPTION
The Inferred figure in the hover card on the Library page's people/faces card came from a filter reading `Q(person=True)`. Django resolves a boolean given to a ForeignKey lookup as a primary key, so that became `person_id = 1`: the statistic reported how many faces belong to whichever person happens to hold primary key 1, and the faces it was meant to count were not counted at all.

On the library this was found on, no person holds primary key 1 any more — it was labelled and later removed, as any person can be — so Inferred had been showing `0` while 2,557 of the 2,613 faces were waiting to be named. A library whose person 1 still exists gets that person's face count instead, which is just as wrong but harder to notice.

It now counts the faces with no person, which is the complement of `num_labeled_faces` on the line above and matches what the face dashboard already means by inferred: every branch of its face list pairs the cluster or classification guess with `person = None`. The two figures then add up to the number of faces on the owner's visible photos, which is what the card presents them as doing — 2,557 + 56 = 2,613 on the library above, where the card's own face total is 2,613.

Deleted faces stay inside this count, as they already are inside `num_faces` and every other face figure in the same dict. That is pinned by a test rather than changed here, so the group can be changed together if it should be.

Seven tests, five of which fail without the one-line fix; one of them owns primary key 1 explicitly so it pins the coercion itself rather than depending on insertion order. The full backend suite has a failure set identical to a clean `dev` run in the same environment, and the whole `api.tests.stats` module (118 tests) passes in an environment that has `cpuinfo` installed, since much of that module cannot run without it. Also confirmed in the browser: the card now reads 2557 / 56 / 0 where it previously read 0 / 56 / 0.

This is independent of #2004 and #2005 and touches no file they touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
